### PR TITLE
Add keyless ignition and diesel runaway protection systems

### DIFF
--- a/docs/jeep_lj/01-power-systems/01-power-generation/05-wire-distance-reference.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/05-wire-distance-reference.md
@@ -71,7 +71,7 @@ Distances required for voltage drop calculations and wire purchases. Measure act
 | CT4 (steering column)   | Passenger tail light     | 14 AWG | 16 ft ✓  | Turn signal rear                    |
 | PMU (engine bay)        | Rear tail lights         | 16 AWG | 13 ft ✓  | Brake/reverse/marker (Out 21/22/23) |
 | SwitchPros (wheel well) | Roll bar dome lights     | 16 AWG | ~8 ft    | Low current, estimated              |
-| Ignition switch         | PMU In 6                 | 18 AWG | 3 ft ✓   | Same as steering column → PMU       |
+| Dash push-button        | PMU In 5                 | 18 AWG | 3 ft ✓   | Keyless ignition (via firewall Pin 15) |
 | CT4 SW3 output          | PMU In 7                 | 18 AWG | 3 ft ✓   | Same as steering column → PMU       |
 
 ### Offroad Lighting (Priority: Medium)

--- a/docs/jeep_lj/01-power-systems/04-pmu/02-pmu-inputs.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/02-pmu-inputs.md
@@ -27,7 +27,7 @@ See [Ignition Signal Distribution](#ignition-signal-distribution) for complete w
 | :------- | :------------------- | :--------------------------- | :---------------------- | :--------------------------------------- |
 | **In 1** | Horn Button          | Steering wheel button        | Out 18 (Horn)           | Normally open, closes when pressed       |
 | **In 2** | Brake Switch         | Brake pedal switch           | Out 21 (Brake Lights)   | Normally open, closes when pedal pressed |
-| **In 3** | Reverse Switch       | AX15 trans switch            | Out 22 (Reverse Lights) | Normally open, closes in reverse gear    |
+| **In 3** | Reverse Signal       | Turbolamik aux output (Reverse) | Out 22 (Reverse Lights) | 12V from TCU when 8HP70 in Reverse       |
 | **In 4** | **[Available]**      | -                            | -                       | Available for future expansion           |
 | **In 5** | **[Available]**      | -                            | -                       | Available for future expansion           |
 | **In 6** | **[Available]**      | -                            | -                       | Available for future expansion           |
@@ -35,7 +35,7 @@ See [Ignition Signal Distribution](#ignition-signal-distribution) for complete w
 | **In 8** | **[Available]**      | -                            | -                       | Available for future expansion           |
 | **In 9** | A/C Request          | Factory TJ A/C button signal | Out 17 (A/C Clutch)     | 12V when factory dash A/C button pressed |
 
-**Note:** Starter system uses traditional direct control (keyswitch → clutch switch → relay) independent of PMU. See [Starter System][starter].
+**Note:** Starter system uses traditional direct control (ignition RUN → start button → brake switch → P/N interlock → relay) independent of PMU. See [Starter System][starter].
 
 [starter]: ../../02-engine-systems/01-starter.md
 

--- a/docs/jeep_lj/01-power-systems/04-pmu/02-pmu-inputs.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/02-pmu-inputs.md
@@ -9,7 +9,7 @@ PMU input configuration including digital inputs, analog inputs, CAN bus integra
 
 ## 12V Switched Input (Pin 7)
 
-**Source:** Dedicated 18 AWG wire from ignition switch RUN terminal
+**Source:** Dedicated 18 AWG wire from ECM Ignition Relay output (relay driven by PMU OUT24 when state machine is in RUN or CRANK — see [Keyless Ignition][keyless-ignition])
 
 **Function:** Provides switched power reference for PMU logic
 
@@ -28,16 +28,17 @@ See [Ignition Signal Distribution](#ignition-signal-distribution) for complete w
 | **In 1** | Horn Button          | Steering wheel button        | Out 18 (Horn)           | Normally open, closes when pressed       |
 | **In 2** | Brake Switch         | Brake pedal switch           | Out 21 (Brake Lights)   | Normally open, closes when pedal pressed |
 | **In 3** | Reverse Signal       | Turbolamik aux output (Reverse) | Out 22 (Reverse Lights) | 12V from TCU when 8HP70 in Reverse       |
-| **In 4** | **[Available]**      | -                            | -                       | Available for future expansion           |
-| **In 5** | **[Available]**      | -                            | -                       | Available for future expansion           |
-| **In 6** | **[Available]**      | -                            | -                       | Available for future expansion           |
+| **In 4** | Boomerang Fob Present | Bullet 230 transistor output | OUT24 logic (ignition)  | 12V active when RFID fob in range        |
+| **In 5** | Push Button (Start/Stop) | Dash momentary button     | OUT24 logic (state machine) | 12V on press; toggles ignition state  |
+| **In 6** | Turbolamik P/N        | Turbolamik P/N aux output    | OUT24 logic + crank gate | 12V when 8HP70 shifter in P or N        |
 | **In 7** | CT4 SW3 (Headlights) | CT4 lever pull               | Out 14 (DRL) logic      | 12V when headlights active, disables DRL |
 | **In 8** | **[Available]**      | -                            | -                       | Available for future expansion           |
 | **In 9** | A/C Request          | Factory TJ A/C button signal | Out 17 (A/C Clutch)     | 12V when factory dash A/C button pressed |
 
-**Note:** Starter system uses traditional direct control (ignition RUN → start button → brake switch → P/N interlock → relay) independent of PMU. See [Starter System][starter].
+**Note:** Keyless ignition state machine runs on PMU. OUT24 drives the ECM ignition relay coil and supplies the hardware crank chain (push button → brake → P/N relay → engine-running lockout → Cole Hersee 24213). See [Keyless Ignition][keyless-ignition] and [Starter System][starter].
 
 [starter]: ../../02-engine-systems/01-starter.md
+[keyless-ignition]: ../../05-control-interfaces/06-keyless-ignition.md
 
 ## Analog Inputs
 
@@ -91,9 +92,9 @@ See [PMU Programming][pmu-programming] for CAN-based logic examples.
 
 ## Ignition Signal Distribution
 
-**PMU Pin 7:** Dedicated 18 AWG wire directly from keyswitch RUN terminal (NOT from ignition signal bus bar)
+**PMU Pin 7:** Dedicated 18 AWG wire directly from ECM Ignition Relay output (NOT from ignition signal bus bar)
 
-**Routing:** Through firewall (Grommet 2) to PMU Pin 7
+**Routing:** Engine bay (relay → PMU Pin 7), no firewall crossing required
 
 **Purpose:** Critical PMU functions have guaranteed power independent of other devices
 

--- a/docs/jeep_lj/01-power-systems/04-pmu/03-pmu-outputs.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/03-pmu-outputs.md
@@ -48,7 +48,7 @@ Complete configuration of all 24 PMU outputs, load allocations, and combined out
 | **Out 21** | Brake Lights             | ~3A  | [SwitchPros Ground Bus][switchpros-ground]            | External input      | Shared tail light ground       |
 | **Out 22** | Reverse Lights           | ~5A  | [SwitchPros Ground Bus][switchpros-ground]            | External input      | Maxbilt + Squadron Sport       |
 | **Out 23** | DRL/Parking Lights       | ~2A  | [SwitchPros Ground Bus][switchpros-ground]            | Auto (ignition)     | See [DRL & Parking][drl-parking-lights] |
-| **Out 24** | **[Available]**          | -    | -                                                     | -                   | Future expansion (7A)          |
+| **Out 24** | Ignition Authorize       | ~5A  | Via downstream loads                                  | PMU state machine   | Drives ECM ignition relay + supplies hardware crank chain (push button → brake → P/N → ER lockout → Cole Hersee). See [Keyless Ignition][keyless-ignition] |
 
 ## Combined Outputs
 
@@ -121,3 +121,4 @@ Complete configuration of all 24 PMU outputs, load allocations, and combined out
 [windshield-wiper-control-system]: ../../02-engine-systems/04-wipers.md
 [drl-parking-lights]: ../../03-lighting-systems/05-drl-parking.md
 [adu7-display]: ../../02-engine-systems/10-adu7-display/index.md
+[keyless-ignition]: ../../05-control-interfaces/06-keyless-ignition.md

--- a/docs/jeep_lj/01-power-systems/04-pmu/index.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/index.md
@@ -15,7 +15,7 @@ Engine bay power distribution handled by ECUMaster PMU24, a programmable power m
 | :----------------- | :---------------- | :--------------------- | :--------- | :--------------------------------------------------------------------------------------------------------------- |
 | **Main Power**     | START battery+    | 2/0 AWG                | 250A CB    | Optimized for 220A max load with proper protection coordination - See [Circuit Breakers][front-circuit-breakers] |
 | **Ground**         | START battery-    | 2/0 AWG                | N/A        | Matches power wire gauge for 220A max load - See [Grounding Architecture][grounding]                             |
-| **Ignition Sense** | Keyswitch RUN     | 18 AWG                 | N/A        | Dedicated wire - see [PMU Inputs][pmu-inputs]                                                                    |
+| **Ignition Sense** | ECM Ignition Relay output | 18 AWG         | N/A        | Dedicated wire; relay driven by PMU OUT24 - see [PMU Inputs][pmu-inputs] and [Keyless Ignition][keyless-ignition] |
 | **CAN Bus**        | Cummins ECM J1939 | 18-20 AWG twisted pair | N/A        | Stub tap - see [PMU Inputs][pmu-inputs]                                                                          |
 
 ## System Components
@@ -39,3 +39,4 @@ Engine bay power distribution handled by ECUMaster PMU24, a programmable power m
 [grounding]: ../05-grounding/index.md
 [starter-battery-distribution]: ../02-starter-battery-distribution/index.md
 [firewall-ingress]: ../07-wire-routing/02-firewall-ingress.md
+[keyless-ignition]: ../../05-control-interfaces/06-keyless-ignition.md

--- a/docs/jeep_lj/01-power-systems/06-ignition-signal/index.md
+++ b/docs/jeep_lj/01-power-systems/06-ignition-signal/index.md
@@ -34,7 +34,7 @@ Distributes low-current 12V ignition sense signal from keyswitch RUN terminal to
 Critical engine and power management systems use dedicated wires directly from the keyswitch, NOT this bus bar, for maximum reliability. This includes:
 
     - **PMU 12V Switched Input (Physical Pin 7):** Direct wire for ignition sense and power reference - see [PMU Inputs][pmu-inputs]
-    - **Starter Control:** Direct keyswitch → clutch switch → relay path - see [Starter System][starter-system]
+    - **Starter Control:** Direct keyswitch RUN → START push-button → brake switch → P/N interlock → relay path - see [Starter System][starter-system]
 
     **Note:** PMU "Pin 7" (physical connector pin for 12V switched power) is different from PMU "In 7" (digital input channel #7 used for CT4 headlight status).
 

--- a/docs/jeep_lj/01-power-systems/06-ignition-signal/index.md
+++ b/docs/jeep_lj/01-power-systems/06-ignition-signal/index.md
@@ -24,17 +24,17 @@ tags:
 
 ## Overview
 
-Distributes low-current 12V ignition sense signal from keyswitch RUN terminal to non-critical convenience devices.
+Distributes low-current 12V ignition sense signal to non-critical convenience devices. With the keyswitch removed (see [Keyless Ignition][keyless-ignition]), the bus bar input is now sourced from the **ECM Ignition Relay** — a switched relay driven by PMU OUT24 whenever the state machine is in RUN or CRANK.
 
 **Location:** Cabin side of firewall
 
 **Function:** Signal distribution only (not a power bus)
 
 !!! info "Critical Systems Use Dedicated Wires"
-Critical engine and power management systems use dedicated wires directly from the keyswitch, NOT this bus bar, for maximum reliability. This includes:
+Critical engine and power management systems take their own switched supply directly from the ECM Ignition Relay (or PMU OUT24 tap), NOT through this bus bar, for maximum reliability. This includes:
 
-    - **PMU 12V Switched Input (Physical Pin 7):** Direct wire for ignition sense and power reference - see [PMU Inputs][pmu-inputs]
-    - **Starter Control:** Direct keyswitch RUN → START push-button → brake switch → P/N interlock → relay path - see [Starter System][starter-system]
+    - **PMU 12V Switched Input (Physical Pin 7):** Direct wire from ECM Ignition Relay output - see [PMU Inputs][pmu-inputs]
+    - **Starter Control:** Hardware crank chain (push button → brake → P/N relay → engine-running lockout → Cole Hersee) supplied by PMU OUT24 - see [Starter System][starter-system] and [Keyless Ignition][keyless-ignition]
 
     **Note:** PMU "Pin 7" (physical connector pin for 12V switched power) is different from PMU "In 7" (digital input channel #7 used for CT4 headlight status).
 
@@ -50,7 +50,7 @@ Critical engine and power management systems use dedicated wires directly from t
 
 | Stud/Terminal           | Connection                | Wire Gauge   | Distance              | Max Current     | Notes                                              |
 | :---------------------- | :------------------------ | :----------- | :-------------------- | :-------------- | :------------------------------------------------- |
-| **Stud 1 (5/16")**      | **Keyswitch RUN (INPUT)** | **18 AWG ✓** | **Through Grommet 2** | **~80mA total** | **Already fused at keyswitch**                     |
+| **Stud 1 (5/16")**      | **ECM Ignition Relay output (INPUT)** | **18 AWG ✓** | **Through firewall (engine bay → cabin)** | **~80mA total** | **5A inline fuse at relay**                     |
 | Stud 2 (5/16")          | **[Available]**           | -            | -                     | -               | Future high-current signal                         |
 | Terminal 1 (#10-24)     | Command Touch CT4         | 18 AWG ✓     | ~3 ft                 | ~20mA           | Ignition sense for turn signal auto-cancel         |
 | Terminal 2 (#10-24)     | SwitchPros SP-1200        | 18 AWG ✓     | ~4 ft                 | ~20mA           | Pin 3 (Lt Blue) - ignition sense                   |
@@ -63,9 +63,9 @@ Critical engine and power management systems use dedicated wires directly from t
 
 ## Mounting
 
-**Location:** Cabin side of firewall near keyswitch
+**Location:** Cabin side of firewall, behind dash (former keyswitch location now repurposed)
 
-**Benefits:** Single firewall penetration (input only), all outputs routed within cabin
+**Benefits:** Single firewall penetration (input only — from ECM Ignition Relay in engine bay), all outputs routed within cabin
 
 ## Related Documentation
 
@@ -79,3 +79,5 @@ Critical engine and power management systems use dedicated wires directly from t
 [pmu-inputs]: ../04-pmu/02-pmu-inputs.md
 [firewall-ingress]: ../07-wire-routing/02-firewall-ingress.md
 [bcdc]: ../01-power-generation/03-bcdc.md
+[keyless-ignition]: ../../05-control-interfaces/06-keyless-ignition.md
+[starter-system]: ../../02-engine-systems/01-starter.md

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/02-firewall-ingress.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/02-firewall-ingress.md
@@ -69,7 +69,7 @@ RF interference analysis determined that with ferrite chokes on radio power lead
 | 12 | Ignition sense | 18 AWG | Ignition switch RUN | PMU Pin 7 | #16 |
 | 13 | Brake switch | 18 AWG | Brake pedal switch | PMU In 2 | #16 |
 | 14 | A/C request | 18 AWG | HVAC controls | PMU In 9 | #16 |
-| 15 | Clutch switch | 18 AWG | Clutch pedal switch | Starter circuit | #16 |
+| 15 | P/N interlock (gated start) | 18 AWG | Brake switch (start tap, after START button) | P/N interlock relay → Cole Hersee coil | #16 |
 | 16 | Winch control IN | 18 AWG | Dash rocker switch | Winch contactor | #16 |
 | 17 | Winch control OUT | 18 AWG | Dash rocker switch | Winch contactor | #16 |
 

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/02-firewall-ingress.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/02-firewall-ingress.md
@@ -46,7 +46,7 @@ RF interference analysis determined that with ferrite chokes on radio power lead
 
 ## Pin Assignment
 
-### Engine Bay → Cabin (6 wires)
+### Engine Bay → Cabin (7 wires)
 
 | Pin | Circuit | Gauge | Source | Destination | Contact |
 |:---:|:--------|:-----:|:-------|:------------|:-------:|
@@ -56,8 +56,11 @@ RF interference analysis determined that with ferrite chokes on radio power lead
 | 4 | Brake lights | 16 AWG | PMU OUT21 | Rear tail lights | #16 |
 | 5 | Reverse lights | 16 AWG | PMU OUT22 | Rear tail lights | #16 |
 | 6 | DRL/Parking | 16 AWG | PMU OUT23 | Rear tail lights | #16 |
+| 12 | Ignition signal bus feed + dash button supply | 18 AWG | ECM Ignition Relay output (EB) | Ignition signal bus bar (cabin); also taps to dash push-button supply | #16 |
 
-### Cabin → Engine Bay (11 wires)
+### Cabin → Engine Bay (10 wires)
+
+Pin 12 was reassigned from "Ignition sense" (cabin→EB) to "Ignition signal bus feed" (EB→cabin) when the keyswitch was removed.
 
 | Pin | Circuit | Gauge | Source | Destination | Contact |
 |:---:|:--------|:-----:|:-------|:------------|:-------:|
@@ -66,10 +69,9 @@ RF interference analysis determined that with ferrite chokes on radio power lead
 | 9 | Low beam headlights | 14 AWG | CT4 SW3 | LP6 Pin 1 (both) | #16 |
 | 10 | High beam headlights | 14 AWG | CT4 SW4 | LP6 Pin 4 (both) | #16 |
 | 11 | Horn button trigger | 18 AWG | Steering wheel button | PMU In 1 | #16 |
-| 12 | Ignition sense | 18 AWG | Ignition switch RUN | PMU Pin 7 | #16 |
 | 13 | Brake switch | 18 AWG | Brake pedal switch | PMU In 2 | #16 |
 | 14 | A/C request | 18 AWG | HVAC controls | PMU In 9 | #16 |
-| 15 | P/N interlock (gated start) | 18 AWG | Brake switch (start tap, after START button) | P/N interlock relay → Cole Hersee coil | #16 |
+| 15 | Push button → PMU + crank chain | 18 AWG | Dash push-button (NO) | PMU In 5 + brake switch start tap | #16 |
 | 16 | Winch control IN | 18 AWG | Dash rocker switch | Winch contactor | #16 |
 | 17 | Winch control OUT | 18 AWG | Dash rocker switch | Winch contactor | #16 |
 
@@ -77,7 +79,14 @@ RF interference analysis determined that with ferrite chokes on radio power lead
 
 | Pin | Contact | Notes |
 |:---:|:-------:|:------|
-| A-D | #12 | Size 12 cavities reserved for future 10-12 AWG circuits |
+| A-D | #12 | Size 12 cavities — candidate slots for outstanding keyless system signals (fob present, gated start return); will need size 16→12 reducer crimps or size 12 contacts on 18 AWG wires |
+
+**Keyless Ignition Outstanding Pins:** Two additional pins still need allocation:
+
+1. **Boomerang fob present** (cabin → EB): Bullet 230 output to PMU In 4
+2. **Gated start return** (cabin → EB): brake switch start tap → engine bay P/N relay
+
+Current 17 size-16 contacts are fully assigned. Options under consideration in [Keyless Ignition][keyless-ignition]: use two of the size-12 reserved cavities, or add a small secondary connector for keyless signals.
 
 ---
 
@@ -158,6 +167,7 @@ PMU In 7 receives the headlight status signal from this tap, enabling DRL auto-o
 - [Intercom][intercom] - STX power routing
 
 [wire-routing]: index.md
+[keyless-ignition]: ../../05-control-interfaces/06-keyless-ignition.md
 [pmu-outputs]: ../04-pmu/03-pmu-outputs.md
 [pmu-inputs]: ../04-pmu/02-pmu-inputs.md
 [ct4]: ../../05-control-interfaces/03-command-touch-ct4.md

--- a/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
+++ b/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
@@ -186,9 +186,9 @@ It is intentional adherence to:
    - Thermal time constant >> cranking duration
    - No fire hazard during normal cranking
 
-2. **Clutch Safety Interlock**
-   - Prevents starter engagement unless clutch depressed
-   - Reduces accidental cranking scenarios
+2. **Brake + START Button + P/N Interlock**
+   - Prevents starter engagement unless brake pressed, START button held, and shifter in P or N
+   - Triple gate eliminates accidental cranking and in-gear cranking
 
 3. **Two-Stage Relay Control**
    - Cole Hersee 24213 solenoid controls high current

--- a/docs/jeep_lj/02-engine-systems/01-starter.md
+++ b/docs/jeep_lj/02-engine-systems/01-starter.md
@@ -52,34 +52,40 @@ tags:
 
 **Control Solenoid:** Cole Hersee 24213 (85A continuous-duty)
 
-**Safety Interlock:** Clutch pedal switch (normally open)
+**Safety Interlock:** Series chain — brake pedal switch + dash START push-button + Turbolamik P/N output (all three required to crank the 8HP70 auto)
 
 **Battery Requirement:** 800 CCA minimum (Odyssey PC1500 provides 850 CCA)
 
 ## Wiring
 
-| Circuit              | Source                   | Destination                   | Wire Gauge | Current  | Notes                                                            |
-| :------------------- | :----------------------- | :---------------------------- | :--------- | :------- | :--------------------------------------------------------------- |
-| Main Power           | START battery+           | Starter solenoid battery post | 2/0 AWG    | 400-600A | See [START Battery Distribution][starter-battery] for wire specs |
-| Solenoid Power Tap   | START battery post       | Cole Hersee 24213 input       | 10 AWG     | 30-75A   | ~2 ft                                                            |
-| Ignition Control     | Ignition switch START    | Clutch safety switch          | 16 AWG     | ~1A      | ~10 ft                                                           |
-| Clutch Switch Output | Clutch switch            | Cole Hersee 24213 coil+       | 16 AWG     | ~1.6A    | ~3 ft                                                            |
-| Solenoid Coil Ground | Cole Hersee 24213 coil-  | Engine bay ground bus         | 16 AWG     | ~1.6A    | ~3 ft                                                            |
-| Solenoid Output      | Cole Hersee 24213 output | Starter solenoid switch post  | 10 AWG     | 30-75A   | ~2 ft                                                            |
-| Ground Return        | Starter case             | Engine block → START battery- | 2/0 AWG    | 400-600A | Via engine bay ground bus                                        |
+| Circuit               | Source                   | Destination                       | Wire Gauge | Current  | Notes                                                            |
+| :-------------------- | :----------------------- | :-------------------------------- | :--------- | :------- | :--------------------------------------------------------------- |
+| Main Power            | START battery+           | Starter solenoid battery post     | 2/0 AWG    | 400-600A | See [START Battery Distribution][starter-battery] for wire specs |
+| Solenoid Power Tap    | START battery post       | Cole Hersee 24213 input           | 10 AWG     | 30-75A   | ~2 ft                                                            |
+| Start Button Power    | Ignition switch RUN      | Dash START push-button (input)    | 16 AWG     | ~1.6A    | ~2 ft (cabin)                                                    |
+| Brake Interlock       | START button (output)    | Brake pedal switch (start tap)    | 18 AWG     | ~1.6A    | ~2 ft (cabin); requires brake pressed                            |
+| Cabin → Engine Bay    | Brake switch (start tap) | Firewall Pin 15 → P/N interlock relay | 18 AWG | ~1.6A    | Via Deutsch HDP24-24-21 Pin 15                                   |
+| P/N Interlock         | Turbolamik P/N aux output| Interlock relay coil              | 18 AWG     | ~0.1A    | 12V when 8HP70 shifter in P or N                                 |
+| Gated Coil Drive      | Interlock relay output   | Cole Hersee 24213 coil+           | 16 AWG     | ~1.6A    | ~1 ft (engine bay)                                               |
+| Solenoid Coil Ground  | Cole Hersee 24213 coil-  | Engine bay ground bus             | 16 AWG     | ~1.6A    | ~3 ft                                                            |
+| Solenoid Output       | Cole Hersee 24213 output | Starter solenoid switch post      | 10 AWG     | 30-75A   | ~2 ft                                                            |
+| Ground Return         | Starter case             | Engine block → START battery-     | 2/0 AWG    | 400-600A | Via engine bay ground bus                                        |
 
 ## Control Flow
 
 ```text
-Ignition START → Clutch Switch → Cole Hersee 24213 Coil → Ground
-                                         ↓
-                              Solenoid Closes (when clutch depressed)
-                                         ↓
-                    START battery Post → Cole Hersee Output → Starter Switch Post
-                                         ↓
-                              Main Solenoid Engages
-                                         ↓
-                                   Starter Cranks
+Ignition RUN → START Button → Brake Switch → Pin 15 (firewall) →
+                                              P/N Interlock Relay (gated by Turbolamik P/N output)
+                                                         ↓
+                                              Cole Hersee 24213 Coil → Ground
+                                                         ↓
+                                              Solenoid Closes (button + brake + P or N all asserted)
+                                                         ↓
+                              START battery Post → Cole Hersee Output → Starter Switch Post
+                                                         ↓
+                                              Main Solenoid Engages
+                                                         ↓
+                                                   Starter Cranks
 ```
 
 ## Starter Motor Terminals
@@ -110,12 +116,16 @@ Ignition START → Clutch Switch → Cole Hersee 24213 Coil → Ground
 
 - Large Stud 1 (Input): From START battery post (M8 terminal, 10 AWG)
 - Large Stud 2 (Output): To starter switch post (6.3mm female push-on, 10 AWG)
-- Small Terminal 1 (Coil+): From clutch switch (16-18 AWG)
+- Small Terminal 1 (Coil+): From P/N interlock relay output (16-18 AWG)
 - Small Terminal 2 (Coil-): To engine bay ground bus (16-18 AWG)
 
 ## Outstanding Items
 
-None - design complete. See [installation checklist][install-checklist] for build tasks.
+- [ ] Select dash START push-button (momentary, normally open, illuminated preferred)
+- [ ] Select P/N interlock relay (low-current automotive relay, ~30A SPST)
+- [ ] Confirm Turbolamik aux output configured for P/N (12V when in P or N)
+
+See [installation checklist][install-checklist] for build tasks.
 
 [install-checklist]: ../09-installation/02-engine-systems-checklist.md
 

--- a/docs/jeep_lj/02-engine-systems/01-starter.md
+++ b/docs/jeep_lj/02-engine-systems/01-starter.md
@@ -52,7 +52,7 @@ tags:
 
 **Control Solenoid:** Cole Hersee 24213 (85A continuous-duty)
 
-**Safety Interlock:** Series chain — brake pedal switch + dash START push-button + Turbolamik P/N output (all three required to crank the 8HP70 auto)
+**Safety Interlock:** PMU24 state machine (OUT24) supplies a hardware crank chain — push button + brake pedal switch + Turbolamik P/N relay + engine-running lockout (all four gates required). See [Keyless Ignition][keyless-ignition] for the full architecture.
 
 **Battery Requirement:** 800 CCA minimum (Odyssey PC1500 provides 850 CCA)
 
@@ -62,11 +62,13 @@ tags:
 | :-------------------- | :----------------------- | :-------------------------------- | :--------- | :------- | :--------------------------------------------------------------- |
 | Main Power            | START battery+           | Starter solenoid battery post     | 2/0 AWG    | 400-600A | See [START Battery Distribution][starter-battery] for wire specs |
 | Solenoid Power Tap    | START battery post       | Cole Hersee 24213 input           | 10 AWG     | 30-75A   | ~2 ft                                                            |
-| Start Button Power    | Ignition switch RUN      | Dash START push-button (input)    | 16 AWG     | ~1.6A    | ~2 ft (cabin)                                                    |
-| Brake Interlock       | START button (output)    | Brake pedal switch (start tap)    | 18 AWG     | ~1.6A    | ~2 ft (cabin); requires brake pressed                            |
-| Cabin → Engine Bay    | Brake switch (start tap) | Firewall Pin 15 → P/N interlock relay | 18 AWG | ~1.6A    | Via Deutsch HDP24-24-21 Pin 15                                   |
-| P/N Interlock         | Turbolamik P/N aux output| Interlock relay coil              | 18 AWG     | ~0.1A    | 12V when 8HP70 shifter in P or N                                 |
-| Gated Coil Drive      | Interlock relay output   | Cole Hersee 24213 coil+           | 16 AWG     | ~1.6A    | ~1 ft (engine bay)                                               |
+| Crank Chain Supply    | PMU OUT24                | Dash push-button supply (cabin)   | 18 AWG     | ~1.6A    | Asserted by PMU state machine; routed through firewall to cabin  |
+| Push Button Output    | Dash push-button         | Brake switch (start tap)          | 18 AWG     | ~1.6A    | Cabin                                                            |
+| Brake-gated Start     | Brake switch (start tap) | Firewall Pin 15 → P/N relay contact | 18 AWG   | ~1.6A    | Via Deutsch HDP24-24-21 Pin 15                                   |
+| P/N Relay Coil        | Turbolamik P/N aux output| P/N interlock relay coil          | 18 AWG     | ~0.1A    | Engine bay; energized when shifter in P or N                     |
+| P/N Relay Output      | P/N interlock relay (NO) | Engine-running lockout relay      | 18 AWG     | ~1.6A    | Engine bay                                                       |
+| Engine-Run Relay Coil | Alternator B+ (filtered) | Engine-running relay coil         | 18 AWG     | ~0.1A    | Diode + zener filter; >13V threshold = engine running            |
+| Lockout-gated Drive   | Engine-running relay NC  | Cole Hersee 24213 coil+           | 16 AWG     | ~1.6A    | NC contacts: closed when engine off, opens once running          |
 | Solenoid Coil Ground  | Cole Hersee 24213 coil-  | Engine bay ground bus             | 16 AWG     | ~1.6A    | ~3 ft                                                            |
 | Solenoid Output       | Cole Hersee 24213 output | Starter solenoid switch post      | 10 AWG     | 30-75A   | ~2 ft                                                            |
 | Ground Return         | Starter case             | Engine block → START battery-     | 2/0 AWG    | 400-600A | Via engine bay ground bus                                        |
@@ -74,18 +76,22 @@ tags:
 ## Control Flow
 
 ```text
-Ignition RUN → START Button → Brake Switch → Pin 15 (firewall) →
-                                              P/N Interlock Relay (gated by Turbolamik P/N output)
-                                                         ↓
-                                              Cole Hersee 24213 Coil → Ground
-                                                         ↓
-                                              Solenoid Closes (button + brake + P or N all asserted)
-                                                         ↓
+PMU OUT24 (Ignition Authorize) → Push Button (cabin) → Brake Switch → Pin 15 (firewall) →
+                                                          P/N Relay (coil = Turbolamik P/N) →
+                                                          Engine-Running Lockout Relay (NC, coil = alternator) →
+                                                              ↓
+                                                          Cole Hersee 24213 Coil → Ground
+                                                              ↓
+                                                          Solenoid Closes (all four gates asserted)
+                                                              ↓
                               START battery Post → Cole Hersee Output → Starter Switch Post
-                                                         ↓
-                                              Main Solenoid Engages
-                                                         ↓
-                                                   Starter Cranks
+                                                              ↓
+                                                          Main Solenoid Engages
+                                                              ↓
+                                                              Starter Cranks
+                                                              ↓
+                                                  Engine starts → alternator output rises →
+                                                  Engine-Running Relay opens → Cole Hersee de-energized
 ```
 
 ## Starter Motor Terminals
@@ -116,14 +122,12 @@ Ignition RUN → START Button → Brake Switch → Pin 15 (firewall) →
 
 - Large Stud 1 (Input): From START battery post (M8 terminal, 10 AWG)
 - Large Stud 2 (Output): To starter switch post (6.3mm female push-on, 10 AWG)
-- Small Terminal 1 (Coil+): From P/N interlock relay output (16-18 AWG)
+- Small Terminal 1 (Coil+): From engine-running lockout relay NC output (16-18 AWG)
 - Small Terminal 2 (Coil-): To engine bay ground bus (16-18 AWG)
 
 ## Outstanding Items
 
-- [ ] Select dash START push-button (momentary, normally open, illuminated preferred)
-- [ ] Select P/N interlock relay (low-current automotive relay, ~30A SPST)
-- [ ] Confirm Turbolamik aux output configured for P/N (12V when in P or N)
+Starter-circuit-specific items are tracked in the [Keyless Ignition][keyless-ignition] doc and the [TBD Tracker][tbd-tracker], since the new crank chain is part of the keyless ignition design.
 
 See [installation checklist][install-checklist] for build tasks.
 
@@ -136,6 +140,7 @@ See [installation checklist][install-checklist] for build tasks.
 - [Engine Bay Ground Bus][engine-bay-ground-bus] - Ground connections
 - [Power Generation][power-generation] - Battery specifications
 - [Wire Distance Reference][wire-distance] - Starter to battery routing distances
+- [Keyless Ignition][keyless-ignition] - State machine driving OUT24 and the crank chain
 
 [db-starter]: https://www.dbelectrical.com/products/starter-for-2-8-cummins-isf2-8-qsb3-9-30-qsb4-5-4996706-428000-7090.html
 [starter-battery-distribution]: ../01-power-systems/02-starter-battery-distribution/index.md
@@ -144,3 +149,5 @@ See [installation checklist][install-checklist] for build tasks.
 [engine-bay-ground-bus]: ../01-power-systems/05-grounding/01-engine-bay-ground-bus.md
 [power-generation]: ../01-power-systems/01-power-generation/index.md
 [wire-distance]: ../01-power-systems/01-power-generation/05-wire-distance-reference.md
+[keyless-ignition]: ../05-control-interfaces/06-keyless-ignition.md
+[tbd-tracker]: ../09-installation/00-tbd-tracker.md

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/01-hdx-control.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/01-hdx-control.md
@@ -101,7 +101,7 @@ Main control box for HDX instrument system. Processes sensor inputs, BIM module 
 | **LEFT**                 | 18 AWG ✓    | CT4 left turn output         | HDX LEFT input          | Left turn indicator                              |
 | **RIGHT**                | 18 AWG ✓    | CT4 right turn output        | HDX RIGHT input         | Right turn indicator                             |
 | **4x4/EX**               | 18 AWG ✓    | Transfer case switch         | HDX 4x4/EX input        | 4WD/4LO indicators                               |
-| GEAR                     | -           | -                            | -                       | Not used (manual transmission)                   |
+| GEAR                     | -           | BIM-01-2 J1939               | -                       | Gear position read from Turbolamik J1939 broadcast (no discrete input wiring) |
 | **WAIT/EX**              | 18 AWG ✓    | ECM harness                  | HDX WAIT/EX input       | Wait-to-start indicator (active high)            |
 | EX                       | -           | -                            | -                       | Reserved                                         |
 | EX                       | -           | -                            | -                       | Reserved                                         |

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/03-bim-j1939.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/03-bim-j1939.md
@@ -57,11 +57,15 @@ Interfaces Cummins R2.8 ECM J1939 CAN bus data with HDX instrument system. Provi
 - Engine hours
 - Diagnostic trouble codes (DTCs)
 
+**Turbolamik TCU 2.0 (8HP70) Broadcast:**
+
+- Gear position (PGN 61445 / SPN 524) → drives HDX GEAR display
+- Transmission oil temperature
+- Selected gear (Drive / Sport / Manual)
+
 **Potentially Available:**
 
 - Intake air temperature
-- Transmission temperature
-- Gear position
 - Fuel pressure
 - Boost/MAP
 - Air/fuel ratio
@@ -83,6 +87,7 @@ Specific J1939 parameters vary by ECM configuration and vehicle application. Cum
 - Cummins R2.8 body harness passes through firewall from engine bay to cabin
 - CAN High/Low wires spliced on cabin side (non-invasive tap connectors)
 - Short wire run from splice to BIM-01-2 on HDPE panel
+- Turbolamik TCU 2.0 shares the same J1939 bus (tapped in engine bay) — both ECM and TCU broadcast to the BIM-01-2
 
 ## Integration with Cummins R2.8
 

--- a/docs/jeep_lj/02-engine-systems/11-runaway-protection.md
+++ b/docs/jeep_lj/02-engine-systems/11-runaway-protection.md
@@ -1,0 +1,175 @@
+---
+hide:
+  - toc
+tags:
+  - product-details
+  - engine-systems
+  - safety
+---
+
+# 2.11 Diesel Runaway Protection {#runaway-protection}
+
+## Overview
+
+Layered, fully mechanical defense against diesel runaway on the Cummins R2.8. The strategy has two independent layers:
+
+1. **Prevention** - Mishimoto baffled catch can in the crankcase ventilation path blocks the most common runaway initiator (oil ingestion via PCV).
+2. **Termination** - AMOT 4261M intake air shutoff valve in the pre-turbo intake tract, manually actuated by a dash-mounted push-pull cable with locking T-handle.
+
+This is a deliberate departure from Cummins' Repower default (no air shutoff) because the R2.8 PMU/ECM kill path documented in [Keyless Ignition][keyless] cannot stop a runaway that is sustained by oil or hydrocarbon vapor — the ECM can be cutting injector commands and the engine will still run. The AMOT cable is the only kill path that works under all failure modes, including total ECM/PMU failure.
+
+## Components
+
+| Component                              | Part Number             | Manufacturer    | Notes                                              |
+| :------------------------------------- | :---------------------- | :-------------- | :------------------------------------------------- |
+| Baffled oil catch can                  | MMOCC-CBT               | Mishimoto       | Compact, 13 oz capacity, petcock drain             |
+| Catch can mounting bracket             | MMOCC-UB                | Mishimoto       | Universal aluminum bracket                         |
+| Intake air shutoff valve (2.8")        | 4261M02A027-AA          | AMOT            | Manual/pneumatic cylinder, NPT, manual trip        |
+| Push-pull cable + locking T-handle     | 30-144-TTL-BH-3         | Midwest Control | 144" cable, turn-to-lock T-handle, 3" travel, bulkhead mount |
+| Catch can hose                         | 5/8" oil-resistant      | User-supplied   | 2 ft typical; worm clamps both ends                |
+| AMOT-to-intake adapters                | NPT-to-hose, 2.8"       | User-supplied   | Match turbo inlet tube size (verify on R2.8)       |
+
+## Catch Can: Crankcase Ventilation
+
+### Plumbing
+
+```text
+R2.8 valve cover breather
+    ↓
+5/8" oil-resistant hose (engine-side)
+    ↓
+Catch can INLET (top)
+    │  Baffled separation
+    ▼
+Catch can OUTLET (top)
+    ↓
+5/8" hose to turbo inlet
+    ↓
+Turbo inlet (pre-compressor)
+```
+
+### Mounting
+
+- Engine bay, intake side, away from exhaust manifold heat
+- Vertical orientation; petcock at bottom for draining
+- Within easy reach for visual inspection at every oil change
+
+### Function
+
+The R2.8 routes crankcase blow-by vapor back to the pre-turbo intake (factory closed PCV). The baffled can sits in this line. Oil mist condenses on the internal baffles and collects in the reservoir; clean vapor continues to the intake. This blocks the most common runaway initiator on small modern diesels: oil carryover from a worn turbo shaft seal or overfilled crankcase being burned as supplemental fuel.
+
+## AMOT 4261M: Manual Air Shutoff
+
+### Valve Specifications
+
+| Parameter                | Value                          |
+| :----------------------- | :----------------------------- |
+| Valve body size          | 2.8" (71 mm) - smallest 4261M  |
+| Bore size                | 2.4" (61 mm)                   |
+| Weight                   | 3.1–4.0 lb                     |
+| Body material            | Anodized aluminum              |
+| Shaft material           | Stainless steel                |
+| Seals                    | Nitrile (200°F max intake temp)|
+| Mechanical pull-to-release | 67 N (15 lb)                 |
+| Operating mode           | Manually cocked open; spring-loaded; trips closed on cable pull or air-pressure loss |
+
+### Cable + Handle Specifications
+
+| Parameter                | Value                          |
+| :----------------------- | :----------------------------- |
+| Part                     | Midwest Control 30-144-TTL-BH-3 |
+| Length                   | 144" (12 ft) - more than adequate for dash-to-engine-bay |
+| Travel                   | 3" working stroke              |
+| Handle                   | Turn-to-lock T-handle, bulkhead mount |
+| Conduit                  | Steel-armored Bowden           |
+
+### Mounting
+
+- **Valve location:** Pre-turbo intake tract, between air filter outlet and turbo inlet. **Must be pre-turbo** — post-turbo placement does not work because the line is pressurized during normal operation and the turbo itself stores enough air to sustain runaway briefly.
+- **Handle location:** Dash, driver-accessible without leaving belted position. Label: `EMERGENCY ENGINE SHUTOFF — PULL TO STOP`.
+- **Cable routing:** Through firewall via a dedicated grommet (not shared with other cables), secured every 12" with adel clamps to prevent chafing or sag. Avoid sharp bends (≥6" radius).
+
+### Function
+
+In normal operation the valve is cocked open and held by an internal latch. The cable handle sits flush against the dash bezel. When the driver pulls the T-handle:
+
+1. Cable pulls the AMOT trip lever ≥15 lb of force
+2. Internal latch releases
+3. Return spring snaps butterfly closed within ~100 ms
+4. Engine starves of intake air and stops within 1–2 seconds
+
+The handle's turn-to-lock feature prevents accidental actuation (turn quarter-turn to unlock before pulling) and holds the cable in the tripped position after pulling (turn to lock-pulled).
+
+### Reset Procedure
+
+The 4261M does **not** auto-reset. After actuation:
+
+1. Determine and resolve the cause (oil ingestion, fuel leak, etc.)
+2. Open the hood
+3. Manually re-cock the AMOT butterfly using the lever on the valve body
+4. Push the dash T-handle back to flush, turn to lock-closed
+5. Restart engine via normal keyless sequence
+
+This is intentional — it forces a diagnosis step and prevents an unattended restart into the same fault.
+
+## Failure Modes Covered
+
+| Scenario                                  | Covered By               |
+| :---------------------------------------- | :----------------------- |
+| Oil ingestion via crankcase blow-by       | Catch can (prevention)   |
+| Worn turbo shaft seal feeding oil to intake | Catch can (prevention) |
+| External fuel/oil/propane vapor inhaled by intake | AMOT cable          |
+| ECM stuck commanding injector duty cycle  | AMOT cable               |
+| PMU fault preventing OUT24 deassertion    | AMOT cable               |
+| Total electrical failure                  | AMOT cable (mechanical)  |
+| Driver incapacitated                      | Not covered (no auto-trip in this design) |
+
+The last row is the conscious limitation of the manual-only design. Adding speed-sensed auto-trip would require AMOT 4261M with electric solenoid actuator (`4261M02A071-AA`) plus an 8210K speed switch — see [Future Enhancements](#future-enhancements).
+
+## Maintenance
+
+| Interval        | Task                                                   |
+| :-------------- | :----------------------------------------------------- |
+| Every oil change | Drain catch can via petcock; visually inspect hose condition |
+| Every oil change | Verify AMOT lever returns freely (do NOT trip — verify by inspection only) |
+| Annually        | Function-test AMOT: engine off, pull T-handle, verify butterfly closes positively. Reset and confirm engine restarts. |
+| Annually        | Inspect cable conduit for chafing at firewall grommet and adel clamp points |
+
+## Standards Context
+
+| Reference          | Position                                                  |
+| :----------------- | :-------------------------------------------------------- |
+| Cummins R2.8 Repower Installation Guide (5504137) | Does not require an air shutoff valve for the consumer crate program |
+| Cummins commercial/industrial R2.8 application sheets | Air shutoff standard on oil-field, marine, hazardous-area deployments |
+| AMOT 4261M datasheet | "An air intake shut-off valve is recommended for diesel engines which have a possibility of encountering hydrocarbon vapors" |
+
+The off-road LJ build sits between consumer and industrial use cases. Fuel handling during recovery, dust/oil exposure, and modified intake plumbing all push the risk profile toward the industrial side, justifying the additional protection.
+
+## Future Enhancements
+
+Two upgrade paths from this baseline, neither required:
+
+1. **Add electric solenoid auto-trip** — replace AMOT actuator option `27` with option `71` (electric solenoid, 12 VDC) and feed it from a speed switch driven by the alternator W terminal or a magnetic crank pickup. Auto-closes on overspeed condition.
+2. **Add overspeed sensing** — AMOT 8210K electronic speed switch + magnetic pickup wired to drive the solenoid above. Provides automatic protection independent of driver action.
+
+Both upgrades preserve the manual cable as the always-available backup.
+
+## Outstanding Items
+
+- [ ] Verify R2.8 turbo inlet tube outside diameter (2.5" suspected; 2.8" AMOT body is closest available)
+- [ ] Source NPT-to-hose adapter fittings sized to match turbo inlet
+- [ ] Select dash T-handle mounting location (within reach belted, away from accidental contact)
+- [ ] Assign firewall grommet for AMOT cable pass-through (dedicated grommet required)
+- [ ] Determine catch can mounting bracket attachment point on engine bracketry
+
+## Related Documentation
+
+- [Keyless Ignition][keyless] - Why ECM-only kill is insufficient; this doc supersedes the prior "no protection" note
+- [Engine Systems Checklist][checklist] - Phase 11 install steps
+- [TBD Tracker][tbd] - Open items for parts selection
+- [Purchase Tracker][purchase] - BOM line items
+
+[keyless]: ../05-control-interfaces/06-keyless-ignition.md
+[checklist]: ../09-installation/02-engine-systems-checklist.md
+[tbd]: ../09-installation/00-tbd-tracker.md
+[purchase]: ../09-installation/03-purchase-tracker.md

--- a/docs/jeep_lj/02-engine-systems/index.md
+++ b/docs/jeep_lj/02-engine-systems/index.md
@@ -19,6 +19,7 @@ Engine bay systems and critical vehicle subsystems required for safe vehicle ope
 - **[2.6 Radiator Fan][radiator-fan]** - Electric radiator cooling fan system
 - **[2.7 Grid Heater][grid-heater]** - Cummins R2.8 cold-start grid heater relay and control
 - **[2.8 Fuel System][fuel-system]** - Lift pump control circuit (replaces factory PDC/PCM logic)
+- **[2.11 Runaway Protection][runaway-protection]** - Mishimoto catch can + AMOT 4261M manual air shutoff
 
 ## System Overview
 
@@ -40,6 +41,7 @@ Critical safety systems (brake booster, starter) have direct battery connections
 [radiator-fan]: 06-radiator-fan.md
 [grid-heater]: 07-grid-heater.md
 [fuel-system]: 08-fuel-system.md
+[runaway-protection]: 11-runaway-protection.md
 [pmu-power-distribution]: ../01-power-systems/04-pmu/index.md
 [body-pdu]: ../01-power-systems/03-aux-battery-distribution/03-body-pdu.md
 [safetyhub]: ../01-power-systems/03-aux-battery-distribution/04-safetyhub.md

--- a/docs/jeep_lj/05-control-interfaces/01-overview.md
+++ b/docs/jeep_lj/05-control-interfaces/01-overview.md
@@ -27,6 +27,12 @@ This section documents all control interfaces in the Jeep LJ build - the switche
   - Winch control switch
   - Other dash-mounted controls
 
+- **[Keyless Ignition][keyless-ignition]** - RFID + push-button start/stop replacing the factory keyswitch
+  - Boomerang Bullet 230 RFID fob anti-theft
+  - Single dash push-button (start/stop)
+  - PMU24 runs the ignition state machine
+  - Hidden hardwired bypass for emergencies
+
 ## System Integration
 
 All control interfaces integrate with the dual-battery electrical system:
@@ -46,6 +52,7 @@ All control interfaces integrate with the dual-battery electrical system:
 [switchpros-sp-1200-rcr-force-12]: 02-switchpros-sp1200.md
 [command-touch-ct4]: 03-command-touch-ct4.md
 [dashboard-physical-controls]: 05-dashboard-controls.md
+[keyless-ignition]: 06-keyless-ignition.md
 [vehicle-lighting-overview]: ../03-lighting-systems/01-lighting-overview.md
 [offroad-auxiliary-lighting]: ../04-offroad-lighting/index.md
 [pmu-power-distribution]: ../01-power-systems/04-pmu/index.md

--- a/docs/jeep_lj/05-control-interfaces/06-keyless-ignition.md
+++ b/docs/jeep_lj/05-control-interfaces/06-keyless-ignition.md
@@ -156,7 +156,9 @@ A hidden hardwired toggle (under dash, location TBD) bypasses the PMU and direct
 
 ## Diesel Runaway Note
 
-The Cummins R2.8 is a modern electronic common-rail diesel. Engine shutdown is achieved by cutting power to the ECM, which stops commanding the injectors. There is no mechanical fuel shutoff in this build (no intake air shutoff valve — see [Standards Exceptions][standards-exceptions]). If the ECM fails in a way that maintains injector commands, the runaway cannot be killed by the keyless system or the bypass toggle.
+The Cummins R2.8 is a modern electronic common-rail diesel. Normal engine shutdown is achieved by cutting power to the ECM, which stops commanding the injectors. However, ECM-only kill does not stop a true runaway — if the engine is being fed oil, fuel, or hydrocarbon vapor from an external source, cutting ECM power does nothing.
+
+This build provides independent mechanical protection: a Mishimoto catch can in the crankcase ventilation path (prevention) plus an AMOT 4261M air shutoff valve with dash-mounted manual cable (termination). See [Diesel Runaway Protection][runaway-protection] for the full specification.
 
 ## Outstanding Items
 
@@ -191,3 +193,4 @@ The Cummins R2.8 is a modern electronic common-rail diesel. Engine shutdown is a
 [ignition-signal]: ../01-power-systems/06-ignition-signal/index.md
 [firewall-ingress]: ../01-power-systems/07-wire-routing/02-firewall-ingress.md
 [standards-exceptions]: ../01-power-systems/STANDARDS-EXCEPTIONS.md
+[runaway-protection]: ../02-engine-systems/11-runaway-protection.md

--- a/docs/jeep_lj/05-control-interfaces/06-keyless-ignition.md
+++ b/docs/jeep_lj/05-control-interfaces/06-keyless-ignition.md
@@ -1,0 +1,193 @@
+---
+hide:
+  - toc
+tags:
+  - product-details
+  - control-interfaces
+  - ignition
+  - keyless
+  - boomerang
+---
+
+# 5.6 Keyless Ignition System {#keyless-ignition}
+
+Modern push-button ignition for the Cummins R2.8 + 8HP70 build. Replaces the factory keyswitch entirely. Single dash button starts and stops the engine. Boomerang Bullet 230 RFID provides theft deterrence. State machine runs on the PMU24.
+
+## Architecture
+
+/// html | div.product-info
+
+**Type:** RFID-enabled push-button start/stop with diesel-specific interlocks
+
+**Anti-theft:** Boomerang Bullet 230 (RFID fob required to enable)
+
+**State Machine:** PMU24 firmware (logic in `04-pmu-programming.md`)
+
+**Crank Interlocks:** Brake pedal + Turbolamik P/N + engine-running lockout
+
+**Emergency Bypass:** Hidden hardwired toggle (get-home mode)
+
+///
+
+## Components
+
+### Boomerang Bullet 230 (RFID Immobilizer)
+
+| Specification     | Value                                            |
+| :---------------- | :----------------------------------------------- |
+| Type              | RFID transponder + fob                           |
+| Detection Range   | 3-6 ft                                           |
+| Output            | Single transistor output (12V when fob in range) |
+| Power             | 12V CONSTANT (so fob can be detected key-off)    |
+| Mounting          | Under dash, near driver position                 |
+| Product Page      | [Boomerang Bullet 230][boomerang]                |
+
+### Dash Push-Button
+
+| Specification     | Value                                            |
+| :---------------- | :----------------------------------------------- |
+| Type              | Momentary, normally open, illuminated            |
+| Diameter          | 19mm or 22mm panel mount                         |
+| Illumination      | LED, driven by PMU (state feedback)              |
+| Mounting          | Dash, within easy reach from driver seat         |
+| Part              | TBD (Otto P9-113121 or equivalent)               |
+
+### ECM Ignition Relay
+
+| Specification     | Value                                            |
+| :---------------- | :----------------------------------------------- |
+| Type              | Automotive SPST, 30/40A                          |
+| Coil              | 12V DC, ~150 mA draw                             |
+| Contacts          | Switches Cummins ECM 12V supply                  |
+| Mounting          | Engine bay, near ECM                             |
+| Part              | TBD (Hella H41730011 or Bosch 0332019150)        |
+
+### P/N Interlock Relay
+
+| Specification     | Value                                            |
+| :---------------- | :----------------------------------------------- |
+| Type              | Automotive SPST, 30A                             |
+| Coil              | 12V DC, driven by Turbolamik P/N aux output      |
+| Contacts          | NO; in series with crank circuit                 |
+| Mounting          | Engine bay, near Cole Hersee 24213               |
+| Part              | TBD                                              |
+
+### Engine-Running Lockout Relay
+
+Prevents Cole Hersee from energizing while the engine is running, even if the start button is pressed with brake + P/N held. Protects the starter from Bendix engagement against a spinning flywheel.
+
+| Specification     | Value                                            |
+| :---------------- | :----------------------------------------------- |
+| Type              | Automotive SPST, 30A                             |
+| Coil              | 12V DC, driven by alternator output (~14V when running) |
+| Coil Trigger      | Simple diode + zener filter on alternator B+ tap (>13V threshold) |
+| Contacts          | NC; opens when engine running                    |
+| Mounting          | Engine bay, near Cole Hersee 24213               |
+| Part              | TBD                                              |
+
+## State Machine
+
+| Current State | Trigger                                              | Action                                       | New State |
+| :------------ | :--------------------------------------------------- | :------------------------------------------- | :-------- |
+| OFF           | Fob detected + button press                          | Assert OUT24 (ECM powered)                   | RUN       |
+| OFF           | Fob detected + button + brake + P/N                  | Assert OUT24 → hardware crank chain closes   | CRANK     |
+| CRANK         | J1939 RPM > 500 (engine running)                     | Engine-running relay opens, crank disengages | RUN       |
+| RUN           | Button press (with or without brake)                 | De-assert OUT24, ECM loses power, engine off | OFF       |
+| Any           | Hold button > 3 sec                                  | Force OFF (emergency)                        | OFF       |
+| Any           | Fob lost while moving (RPM > 0)                      | Stay in current state, log alarm             | unchanged |
+| OFF           | Button press, fob NOT detected                       | No action, optional alarm chirp              | OFF       |
+
+**Fob-lost behavior:** If the fob leaves range while driving, the PMU does not kill the engine — only blocks re-start at the next OFF cycle. Modern-car convention; prevents stranding on dead fob battery.
+
+## Wiring
+
+### PMU24 I/O (new)
+
+| PMU Channel | Function                                | Source                       | Destination               | Notes                          |
+| :---------- | :-------------------------------------- | :--------------------------- | :------------------------ | :----------------------------- |
+| **In 4**    | Boomerang fob present                   | Bullet 230 transistor output | PMU In 4                  | 12V active when fob in range   |
+| **In 5**    | Push button                             | Dash button (NO contact)     | PMU In 5                  | Pulled up; goes high on press  |
+| **In 6**    | Turbolamik P/N                          | Turbolamik P/N aux output    | PMU In 6                  | 12V active when in P or N      |
+| **Out 24**  | Ignition Authorize                      | PMU OUT24                    | ECM ignition relay + start circuit supply | ~5A, switched by PMU logic |
+
+J1939 RPM is read via the existing CAN bus connection ([PMU Inputs - CAN][pmu-inputs]). No new wire needed for the engine-running input to the state machine.
+
+### Power & Control Wiring
+
+| Connection                 | Wire Gauge | Source                       | Destination                          | Notes                                |
+| :------------------------- | :--------- | :--------------------------- | :----------------------------------- | :----------------------------------- |
+| Boomerang power            | 18 AWG     | Critical Cabin PDU (CONSTANT)| Bullet 230 +12V input                | ~50 mA standby; CONSTANT required    |
+| Boomerang ground           | 18 AWG     | Cabin ground bus             | Bullet 230 ground                    |                                      |
+| Boomerang → PMU In 4       | 18 AWG     | Bullet 230 transistor output | Firewall Pin (TBD) → PMU In 4        | Cabin → Engine Bay                   |
+| Push button signal         | 18 AWG     | Dash button NO contact       | Firewall Pin 15 → PMU In 5           | Cabin → Engine Bay                   |
+| Push button LED supply     | 22 AWG     | PMU OUT24 (or dedicated tap) | Button LED+                          | Illuminates when ignition authorized |
+| Button LED ground          | 22 AWG     | Button LED-                  | Cabin ground bus                     |                                      |
+| OUT24 → ECM relay coil     | 18 AWG     | PMU OUT24                    | ECM ignition relay coil+             | Engine bay                           |
+| OUT24 → crank supply       | 18 AWG     | PMU OUT24                    | Push button supply (cabin)           | Engine Bay → Cabin (firewall)        |
+| Start chain (cabin)        | 18 AWG     | Push button output (gated)   | Brake switch start tap               | Cabin                                |
+| Start chain (firewall)     | 18 AWG     | Brake switch start tap       | Firewall Pin (TBD) → P/N relay       | Cabin → Engine Bay                   |
+| P/N relay coil             | 18 AWG     | Turbolamik P/N aux output    | P/N interlock relay coil             | Engine bay                           |
+| ER lockout coil            | 18 AWG     | Alternator B+ (via filter)   | Engine-running relay coil            | Engine bay; opens contacts when RPM up |
+| Cole Hersee drive          | 16 AWG     | ER lockout relay NC output   | Cole Hersee 24213 coil+              | Engine bay                           |
+| Hidden bypass toggle       | 18 AWG     | Battery+ (via fuse)          | ECM ignition relay coil+ (parallel)  | Get-home mode, hidden under dash     |
+
+### Firewall Pin Assignments
+
+Three pins are used by the keyless system. Pin 15 was reassigned from the prior P/N interlock placeholder (the P/N signal now stays in the engine bay since PMU and Turbolamik are co-located).
+
+| Pin | Direction       | Signal                          | Source                | Destination          |
+| :-- | :-------------- | :------------------------------ | :-------------------- | :------------------- |
+| 15  | Cabin → EB      | Push button signal              | Dash button NO        | PMU In 5             |
+| TBD | Cabin → EB      | Boomerang fob present           | Bullet 230 output     | PMU In 4             |
+| TBD | EB → Cabin      | OUT24 ignition supply           | PMU OUT24             | Dash button supply   |
+| TBD | Cabin → EB      | Gated start (post-brake)        | Brake switch output   | P/N relay contact    |
+
+See [Firewall Ingress][firewall-ingress] for the full pin map.
+
+## Emergency Bypass
+
+A hidden hardwired toggle (under dash, location TBD) bypasses the PMU and directly powers the ECM ignition relay coil from CONSTANT 12V via a 5A inline fuse. This provides a get-home mode if:
+
+- PMU24 firmware locks up or fails
+- Boomerang Bullet 230 fails or fob battery dies and PMU programming has no fallback
+- A CAN bus fault prevents the state machine from running
+
+**Bypass does NOT enable cranking** — only ignition. Cranking still requires the full hardware interlock chain (brake + P/N + engine-running lockout). In bypass mode you can still start by holding the dash button if all hardware interlocks are intact.
+
+## Diesel Runaway Note
+
+The Cummins R2.8 is a modern electronic common-rail diesel. Engine shutdown is achieved by cutting power to the ECM, which stops commanding the injectors. There is no mechanical fuel shutoff in this build (no intake air shutoff valve — see [Standards Exceptions][standards-exceptions]). If the ECM fails in a way that maintains injector commands, the runaway cannot be killed by the keyless system or the bypass toggle.
+
+## Outstanding Items
+
+- [ ] Select Boomerang Bullet 230 mounting location (under dash, near driver)
+- [ ] Select dash push-button part (Otto, Apem, Carling, etc.) - 19mm/22mm, illuminated, momentary NO
+- [ ] Select ECM ignition relay part (Hella/Bosch SPST 30-40A automotive)
+- [ ] Select P/N interlock relay part (SPST 30A automotive)
+- [ ] Select engine-running lockout relay part (SPST 30A, NC contacts)
+- [ ] Design alternator B+ voltage filter for engine-running relay coil drive (diode + zener + resistor)
+- [ ] Assign 3 new firewall HDP24 pin numbers (currently TBD): fob signal, OUT24 supply to cabin, gated start return
+- [ ] Determine hidden bypass toggle location and part
+- [ ] Confirm Turbolamik aux output channel can be configured for P/N (12V when in P or N)
+- [ ] Decide PMU output strategy: OUT24-only with engine-running lockout (current plan) vs. freeing OUT15 winch trigger for dedicated crank output
+- [ ] Write PMU24 state-machine logic in ECUMaster Light Client (see [PMU Programming][pmu-programming])
+
+## Related Documentation
+
+- [PMU Inputs][pmu-inputs] - In 4, In 5, In 6 assignments
+- [PMU Outputs][pmu-outputs] - OUT24 assignment
+- [PMU Programming][pmu-programming] - State machine logic
+- [Starter System][starter] - Cole Hersee 24213 and crank chain
+- [Transmission][transmission] - Turbolamik aux outputs (P/N source)
+- [Ignition Signal Distribution][ignition-signal] - Why the keyswitch is gone
+- [Firewall Ingress][firewall-ingress] - Pin assignments
+
+[boomerang]: https://boomerangtag.com/products/bullet-230
+[pmu-inputs]: ../01-power-systems/04-pmu/02-pmu-inputs.md
+[pmu-outputs]: ../01-power-systems/04-pmu/03-pmu-outputs.md
+[pmu-programming]: ../01-power-systems/04-pmu/04-pmu-programming.md
+[starter]: ../02-engine-systems/01-starter.md
+[transmission]: ../10-drivetrain/01-transmission.md
+[ignition-signal]: ../01-power-systems/06-ignition-signal/index.md
+[firewall-ingress]: ../01-power-systems/07-wire-routing/02-firewall-ingress.md
+[standards-exceptions]: ../01-power-systems/STANDARDS-EXCEPTIONS.md

--- a/docs/jeep_lj/09-installation/00-tbd-tracker.md
+++ b/docs/jeep_lj/09-installation/00-tbd-tracker.md
@@ -7,9 +7,9 @@ hide:
 
 **Purpose:** Central tracking for all To-Be-Determined items across the Jeep LJ electrical system documentation.
 
-**Last Updated:** 2025-11-28
+**Last Updated:** 2026-05-20
 
-**Total Open Items:** 22
+**Total Open Items:** 25
 
 ---
 
@@ -30,6 +30,10 @@ Items needed before installation begins but not system-critical.
 | Item                              | Description                                                     | File                           | Priority |
 | :-------------------------------- | :-------------------------------------------------------------- | :----------------------------- | :------- |
 | Dakota Digital Panel Mounting     | HDPE sheet dimensions and location                              | [Wire Routing][wire-routing]   | High     |
+| Turbolamik Aux: Reverse           | Confirm aux output channel + pinout configured for Reverse signal → PMU In 3 | [Transmission][transmission]   | High     |
+| Turbolamik Aux: P/N               | Confirm aux output channel + pinout configured for P/N (start interlock) | [Transmission][transmission]   | High     |
+| Dash START Push-Button            | Select momentary push-button (illuminated, dash-mountable) for keyless start | [Starter][starter-doc]         | High     |
+| P/N Interlock Relay               | Select SPST automotive relay for P/N gate in engine bay         | [Starter][starter-doc]         | High     |
 
 ---
 
@@ -155,11 +159,11 @@ Items completed since last update.
 | Priority    | Count  |
 | :---------- | :----- |
 | 🔴 Critical | 0      |
-| High        | 1      |
+| High        | 5      |
 | 📋 Medium   | 17     |
 | 📝 Low      | 4      |
 | 🔍 Verify   | 1      |
-| **TOTAL**   | **23** |
+| **TOTAL**   | **27** |
 
 ## Related Documentation
 
@@ -190,3 +194,4 @@ Items completed since last update.
 [footwell-lights]: ../04-offroad-lighting/09-footwell-lights.md
 [rock-lights]: ../04-offroad-lighting/06-rock-lights.md
 [transmission]: ../10-drivetrain/01-transmission.md
+[starter-doc]: ../02-engine-systems/01-starter.md

--- a/docs/jeep_lj/09-installation/00-tbd-tracker.md
+++ b/docs/jeep_lj/09-installation/00-tbd-tracker.md
@@ -9,7 +9,7 @@ hide:
 
 **Last Updated:** 2026-05-20
 
-**Total Open Items:** 25
+**Total Open Items:** 36
 
 ---
 
@@ -32,8 +32,17 @@ Items needed before installation begins but not system-critical.
 | Dakota Digital Panel Mounting     | HDPE sheet dimensions and location                              | [Wire Routing][wire-routing]   | High     |
 | Turbolamik Aux: Reverse           | Confirm aux output channel + pinout configured for Reverse signal → PMU In 3 | [Transmission][transmission]   | High     |
 | Turbolamik Aux: P/N               | Confirm aux output channel + pinout configured for P/N (start interlock) | [Transmission][transmission]   | High     |
-| Dash START Push-Button            | Select momentary push-button (illuminated, dash-mountable) for keyless start | [Starter][starter-doc]         | High     |
-| P/N Interlock Relay               | Select SPST automotive relay for P/N gate in engine bay         | [Starter][starter-doc]         | High     |
+| Dash Push-Button (Keyless)        | Select 19/22mm illuminated momentary NO push-button for keyless start/stop | [Keyless Ignition][keyless]   | High     |
+| Boomerang Bullet 230              | Order RFID receiver + fob; mounting location under dash         | [Keyless Ignition][keyless]   | High     |
+| Boomerang Mounting Location       | Under-dash position near driver (3-6 ft range to driver seat)   | [Keyless Ignition][keyless]   | High     |
+| ECM Ignition Relay                | Select Hella/Bosch SPST 30-40A automotive relay                 | [Keyless Ignition][keyless]   | High     |
+| P/N Interlock Relay               | Select SPST 30A automotive relay (Turbolamik P/N → coil)        | [Keyless Ignition][keyless]   | High     |
+| Engine-Running Lockout Relay      | Select SPST 30A automotive relay with NC contacts               | [Keyless Ignition][keyless]   | High     |
+| Engine-Running Voltage Filter     | Design diode + zener + resistor filter on alternator B+ tap for lockout coil drive | [Keyless Ignition][keyless]   | High     |
+| Keyless Firewall Pin Assignments  | Assign 3 new HDP24 pins (fob, OUT24 supply, gated start return); current connector is full | [Firewall Ingress][firewall-ingress] | High     |
+| Hidden Bypass Toggle              | Select part + mounting location for emergency get-home bypass   | [Keyless Ignition][keyless]   | High     |
+| PMU Output Strategy (Keyless)     | Decide: OUT24-only + engine-running lockout (current plan) vs. free OUT15 winch trigger for dedicated crank output | [Keyless Ignition][keyless]   | High     |
+| PMU24 Keyless State Machine       | Program ECUMaster Light Client logic for OFF/RUN/CRANK transitions, fob detection, kill behavior | [PMU Programming][pmu-programming]   | High     |
 
 ---
 
@@ -159,11 +168,11 @@ Items completed since last update.
 | Priority    | Count  |
 | :---------- | :----- |
 | 🔴 Critical | 0      |
-| High        | 5      |
+| High        | 14     |
 | 📋 Medium   | 17     |
 | 📝 Low      | 4      |
 | 🔍 Verify   | 1      |
-| **TOTAL**   | **27** |
+| **TOTAL**   | **36** |
 
 ## Related Documentation
 
@@ -195,3 +204,6 @@ Items completed since last update.
 [rock-lights]: ../04-offroad-lighting/06-rock-lights.md
 [transmission]: ../10-drivetrain/01-transmission.md
 [starter-doc]: ../02-engine-systems/01-starter.md
+[keyless]: ../05-control-interfaces/06-keyless-ignition.md
+[pmu-programming]: ../01-power-systems/04-pmu/04-pmu-programming.md
+[firewall-ingress]: ../01-power-systems/07-wire-routing/02-firewall-ingress.md

--- a/docs/jeep_lj/09-installation/00-tbd-tracker.md
+++ b/docs/jeep_lj/09-installation/00-tbd-tracker.md
@@ -9,7 +9,7 @@ hide:
 
 **Last Updated:** 2026-05-20
 
-**Total Open Items:** 36
+**Total Open Items:** 41
 
 ---
 
@@ -43,6 +43,11 @@ Items needed before installation begins but not system-critical.
 | Hidden Bypass Toggle              | Select part + mounting location for emergency get-home bypass   | [Keyless Ignition][keyless]   | High     |
 | PMU Output Strategy (Keyless)     | Decide: OUT24-only + engine-running lockout (current plan) vs. free OUT15 winch trigger for dedicated crank output | [Keyless Ignition][keyless]   | High     |
 | PMU24 Keyless State Machine       | Program ECUMaster Light Client logic for OFF/RUN/CRANK transitions, fob detection, kill behavior | [PMU Programming][pmu-programming]   | High     |
+| R2.8 Turbo Inlet OD               | Measure turbo inlet tube outside diameter to confirm AMOT 4261M-02 (2.8" body) fitment and select intake-side adapter | [Runaway Protection][runaway-protection] | High     |
+| AMOT-to-Intake Adapters           | Source NPT-to-hose fittings sized to match measured turbo inlet OD                                | [Runaway Protection][runaway-protection] | High     |
+| AMOT T-Handle Mounting Location   | Select dash mounting position for Midwest Control 30-144-TTL-BH-3 (reachable belted, away from accidental contact) | [Runaway Protection][runaway-protection] | High     |
+| AMOT Cable Firewall Grommet       | Assign dedicated firewall grommet for AMOT push-pull cable pass-through (must not share with other cables) | [Runaway Protection][runaway-protection] | High     |
+| Catch Can Mounting Bracket Point  | Select engine bracketry attachment point for Mishimoto MMOCC-UB universal bracket                  | [Runaway Protection][runaway-protection] | High     |
 
 ---
 
@@ -168,11 +173,11 @@ Items completed since last update.
 | Priority    | Count  |
 | :---------- | :----- |
 | 🔴 Critical | 0      |
-| High        | 14     |
+| High        | 19     |
 | 📋 Medium   | 17     |
 | 📝 Low      | 4      |
 | 🔍 Verify   | 1      |
-| **TOTAL**   | **36** |
+| **TOTAL**   | **41** |
 
 ## Related Documentation
 
@@ -207,3 +212,4 @@ Items completed since last update.
 [keyless]: ../05-control-interfaces/06-keyless-ignition.md
 [pmu-programming]: ../01-power-systems/04-pmu/04-pmu-programming.md
 [firewall-ingress]: ../01-power-systems/07-wire-routing/02-firewall-ingress.md
+[runaway-protection]: ../02-engine-systems/11-runaway-protection.md

--- a/docs/jeep_lj/09-installation/01-power-systems-checklist.md
+++ b/docs/jeep_lj/09-installation/01-power-systems-checklist.md
@@ -208,7 +208,7 @@ Create 12 custom 2-pin Delphi harnesses at SwitchPros:
 - [ ] Confirm 18 AWG: Ignition RUN → PMU Pin 7 (dedicated wire, not from bus bar)
 - [ ] Confirm horn button → PMU In 1 (via Deutsch connector Pin 11)
 - [ ] Confirm brake pedal switch → PMU In 2 (via Deutsch connector Pin 13)
-- [ ] Confirm reverse switch → PMU In 3 (AX15 trans switch)
+- [ ] Confirm reverse signal → PMU In 3 (Turbolamik aux output, Reverse gear)
 - [ ] Confirm A/C request → PMU In 9 (via Deutsch connector Pin 14)
 - [ ] Confirm CT4 SW3 (headlight status) → PMU In 7 (tap on engine bay side of connector)
 

--- a/docs/jeep_lj/09-installation/01-power-systems-checklist.md
+++ b/docs/jeep_lj/09-installation/01-power-systems-checklist.md
@@ -209,6 +209,9 @@ Create 12 custom 2-pin Delphi harnesses at SwitchPros:
 - [ ] Confirm horn button → PMU In 1 (via Deutsch connector Pin 11)
 - [ ] Confirm brake pedal switch → PMU In 2 (via Deutsch connector Pin 13)
 - [ ] Confirm reverse signal → PMU In 3 (Turbolamik aux output, Reverse gear)
+- [ ] Confirm Boomerang fob present → PMU In 4 (via firewall pin TBD)
+- [ ] Confirm push-button → PMU In 5 (via Deutsch connector Pin 15)
+- [ ] Confirm Turbolamik P/N → PMU In 6 (engine bay, direct from TCU)
 - [ ] Confirm A/C request → PMU In 9 (via Deutsch connector Pin 14)
 - [ ] Confirm CT4 SW3 (headlight status) → PMU In 7 (tap on engine bay side of connector)
 
@@ -244,6 +247,7 @@ Create 12 custom 2-pin Delphi harnesses at SwitchPros:
 - [ ] Confirm brake lights → OUT21 (3A) - ground: SwitchPros Ground Bus T4
 - [ ] Confirm reverse lights → OUT22 (5A) - ground: SwitchPros Ground Bus T4
 - [ ] Confirm DRL/parking → OUT23 (2A) - ground: SwitchPros Ground Bus T5
+- [ ] Confirm Ignition Authorize → OUT24 (5A) - drives ECM ignition relay + keyless crank chain
 
 ### PMU CAN Bus Integration
 

--- a/docs/jeep_lj/09-installation/02-engine-systems-checklist.md
+++ b/docs/jeep_lj/09-installation/02-engine-systems-checklist.md
@@ -24,6 +24,14 @@ Organized by installation order for efficient build workflow.
 
 - [ ] Order Ron Francis WS-51C wiper controller module
 
+### Runaway Protection
+
+- [ ] Order Mishimoto MMOCC-CBT catch can + MMOCC-UB bracket
+- [ ] Order AMOT 4261M02A027-AA air shutoff valve (2.8", manual/pneumatic, NPT)
+- [ ] Order Midwest Control 30-144-TTL-BH-3 push-pull cable + T-handle
+- [ ] Measure R2.8 turbo inlet OD and order matching NPT-to-hose adapters
+- [ ] Source 2 ft of 5/8" oil-resistant hose + worm clamps for catch can plumbing
+
 ---
 
 ## Phase 1: Starter System
@@ -110,7 +118,37 @@ Organized by installation order for efficient build workflow.
 
 ---
 
-## Phase 8: Testing
+## Phase 8: Runaway Protection
+
+### Catch Can Installation
+
+- [ ] Confirm Mishimoto MMOCC-UB bracket mounted to selected engine bay location (TBD - intake side, away from exhaust)
+- [ ] Confirm MMOCC-CBT catch can installed vertically with petcock at bottom
+- [ ] Confirm 5/8" hose from R2.8 valve cover breather to catch can INLET (worm clamps both ends)
+- [ ] Confirm 5/8" hose from catch can OUTLET to turbo inlet (worm clamps both ends)
+- [ ] Verify catch can petcock closed before first engine start
+- [ ] Verify no hose chafing against engine, exhaust, or moving parts
+
+### AMOT Air Shutoff Installation
+
+- [ ] Confirm AMOT 4261M02A027-AA installed in pre-turbo intake tract (between air filter outlet and turbo inlet)
+- [ ] Confirm NPT-to-hose adapters secure on both AMOT ports
+- [ ] Confirm AMOT butterfly cocks fully open and latches; verify lever orientation matches cable pull direction
+- [ ] Confirm intake clamps torqued on both sides of AMOT (no boost or vacuum leaks)
+- [ ] Confirm AMOT body oriented so the trip lever clears engine bay obstructions through full motion
+
+### Cable and T-Handle Installation
+
+- [ ] Confirm Midwest 30-144-TTL-BH-3 T-handle mounted at selected dash location (TBD)
+- [ ] Confirm cable conduit passes through dedicated firewall grommet (TBD - must not share with other cables)
+- [ ] Confirm cable secured every 12" with adel clamps; no sharp bends (≥6" radius)
+- [ ] Confirm cable end attaches to AMOT trip lever; pull stroke ≥0.5" past trip point
+- [ ] Confirm T-handle sits flush against dash bezel when AMOT is cocked open
+- [ ] Confirm T-handle is labeled `EMERGENCY ENGINE SHUTOFF — PULL TO STOP`
+
+---
+
+## Phase 9: Testing
 
 ### iBooster Testing
 
@@ -167,6 +205,15 @@ Organized by installation order for efficient build workflow.
 - [ ] Verify inverted duty cycle behavior (high duty = low speed)
 - [ ] Tune temperature setpoints for R2.8 under real-world conditions
 
+### Runaway Protection Testing
+
+- [ ] Static test: engine OFF, pull T-handle, verify AMOT butterfly snaps fully closed (visual through air filter housing)
+- [ ] Reset test: re-cock AMOT manually, push T-handle to flush, verify butterfly returns fully open
+- [ ] Cable freedom: pull T-handle through full 3" stroke, verify no binding in conduit
+- [ ] Functional test (with engine running at idle, away from people/objects): pull T-handle, verify engine stalls within 2 seconds
+- [ ] Catch can drain check: after first 100 miles, drain petcock and inspect for oil collection (confirms PCV flow)
+- [ ] Visual inspection: verify catch can hoses, AMOT cable, and conduit show no chafing or heat damage
+
 ---
 
 ## Reference Documentation
@@ -178,6 +225,7 @@ Organized by installation order for efficient build workflow.
 - **Wipers:** [Wiper System][wipers]
 - **Horn:** [Horn System][horn]
 - **Radiator Fan:** [Radiator Fan System][radiator-fan]
+- **Runaway Protection:** [Diesel Runaway Protection][runaway-protection]
 
 [tulays-harness]: https://tulayswirewerks.com/product/bosch-ibooster-gen-2-universal-wire-harness/
 [starter]: ../02-engine-systems/01-starter.md
@@ -187,3 +235,4 @@ Organized by installation order for efficient build workflow.
 [wipers]: ../02-engine-systems/04-wipers.md
 [horn]: ../02-engine-systems/05-horn.md
 [radiator-fan]: ../02-engine-systems/06-radiator-fan.md
+[runaway-protection]: ../02-engine-systems/11-runaway-protection.md

--- a/docs/jeep_lj/09-installation/02-engine-systems-checklist.md
+++ b/docs/jeep_lj/09-installation/02-engine-systems-checklist.md
@@ -33,12 +33,16 @@ Organized by installation order for efficient build workflow.
 - [ ] Confirm Cole Hersee 24213 solenoid mounted on firewall (engine bay side)
 - [ ] Confirm 10 AWG from starter battery post to Cole Hersee input
 - [ ] Confirm 10 AWG from Cole Hersee output to starter switch post
-- [ ] Confirm 16 AWG ignition RUN feed to dash START push-button (cabin)
-- [ ] Confirm START push-button output series with brake pedal switch (start tap)
-- [ ] Confirm gated start signal routed through firewall Pin 15 to engine bay
-- [ ] Confirm P/N interlock relay gated by Turbolamik P/N aux output
-- [ ] Confirm interlock relay output wired to Cole Hersee coil+
+- [ ] Confirm PMU OUT24 (Ignition Authorize) routed through firewall to dash push-button supply
+- [ ] Confirm push-button output (cabin) wired in series with brake pedal switch start tap
+- [ ] Confirm gated start signal routed through firewall Pin 15 → P/N relay contact in engine bay
+- [ ] Confirm P/N interlock relay coil driven by Turbolamik P/N aux output
+- [ ] Confirm engine-running lockout relay coil sensed from alternator B+ via filter circuit
+- [ ] Confirm engine-running lockout relay NC contacts in series with Cole Hersee coil+
 - [ ] Confirm Cole Hersee coil- grounded to engine bay ground bus
+- [ ] Confirm ECM ignition relay coil driven by PMU OUT24 (parallel to crank chain supply)
+- [ ] Confirm Boomerang Bullet 230 mounted, powered (CONSTANT), and output to PMU In 4
+- [ ] Confirm hidden bypass toggle installed (battery+ via 5A fuse → ECM relay coil)
 
 ---
 
@@ -136,11 +140,15 @@ Organized by installation order for efficient build workflow.
 
 ### Starter Testing
 
-- [ ] Verify starter does NOT crank with shifter in R, D, or manual gates (P/N interlock open)
+- [ ] Verify starter does NOT crank with shifter in R, D, or manual gates (P/N interlock relay open)
 - [ ] Verify starter does NOT crank when brake pedal is released (brake interlock open)
-- [ ] Verify starter does NOT crank when START button is not pressed
-- [ ] Verify starter cranks when ignition RUN + brake pressed + START button held + shifter in P or N
-- [ ] Verify starter disengages cleanly when START button is released
+- [ ] Verify starter does NOT crank when push-button is not pressed
+- [ ] Verify starter does NOT crank without Boomerang fob present (PMU blocks OUT24 assertion)
+- [ ] Verify starter cranks when fob + push-button + brake + P/N all asserted (engine off)
+- [ ] Verify engine-running lockout opens once alternator output > 13V (no Bendix re-engagement)
+- [ ] Verify push-button press while engine running kills the engine (OUT24 de-asserts, ECM off)
+- [ ] Verify hidden bypass toggle powers ECM ignition relay independent of PMU
+- [ ] Verify Boomerang fob lost while running does NOT kill the engine (PMU stay-on logic)
 
 ### Grid Heater Testing
 

--- a/docs/jeep_lj/09-installation/02-engine-systems-checklist.md
+++ b/docs/jeep_lj/09-installation/02-engine-systems-checklist.md
@@ -33,8 +33,11 @@ Organized by installation order for efficient build workflow.
 - [ ] Confirm Cole Hersee 24213 solenoid mounted on firewall (engine bay side)
 - [ ] Confirm 10 AWG from starter battery post to Cole Hersee input
 - [ ] Confirm 10 AWG from Cole Hersee output to starter switch post
-- [ ] Confirm 16 AWG ignition START wire routed through firewall to clutch switch
-- [ ] Confirm clutch safety switch wired to Cole Hersee coil+
+- [ ] Confirm 16 AWG ignition RUN feed to dash START push-button (cabin)
+- [ ] Confirm START push-button output series with brake pedal switch (start tap)
+- [ ] Confirm gated start signal routed through firewall Pin 15 to engine bay
+- [ ] Confirm P/N interlock relay gated by Turbolamik P/N aux output
+- [ ] Confirm interlock relay output wired to Cole Hersee coil+
 - [ ] Confirm Cole Hersee coil- grounded to engine bay ground bus
 
 ---
@@ -133,9 +136,11 @@ Organized by installation order for efficient build workflow.
 
 ### Starter Testing
 
-- [ ] Verify clutch pedal switch prevents starting when clutch released
-- [ ] Verify starter engages when clutch depressed and key in START
-- [ ] Verify starter disengages cleanly when key released
+- [ ] Verify starter does NOT crank with shifter in R, D, or manual gates (P/N interlock open)
+- [ ] Verify starter does NOT crank when brake pedal is released (brake interlock open)
+- [ ] Verify starter does NOT crank when START button is not pressed
+- [ ] Verify starter cranks when ignition RUN + brake pressed + START button held + shifter in P or N
+- [ ] Verify starter disengages cleanly when START button is released
 
 ### Grid Heater Testing
 

--- a/docs/jeep_lj/09-installation/03-purchase-tracker.md
+++ b/docs/jeep_lj/09-installation/03-purchase-tracker.md
@@ -72,6 +72,7 @@ Major components - watch for sales, consider financing options.
 | ARB Air Tank (171601) | ARB | ~$200 | Medium | [Air Compressor][air-compressor] |
 | WolfBox G900 TriPro Dash Camera | WolfBox | ~$200 | Low | [Dash Camera][dash-camera] |
 | DB Electrical 410-52442 Starter | DB Electrical | ~$200 | High | [Starter][starter] |
+| AMOT 4261M02A027-AA Air Shutoff Valve | AMOT | ~$400-500 | High | 2.8" manual/pneumatic, NPT - [Runaway Protection][runaway-protection] |
 
 ---
 
@@ -133,6 +134,11 @@ _(Most electrical distribution components already purchased - see Purchased Item
 | 0-200 PSI Pressure Gauge | Generic | ~$20 | Medium | [Air Compressor][air-compressor] |
 | Air Chuck Plate and Fittings | Generic | ~$30 | Low | [Rear Air Chuck][rear-air-chuck] |
 | Center-Off Momentary Rocker Switch | Generic | ~$15 | Medium | Winch control - [Dashboard][dashboard] |
+| Mishimoto MMOCC-CBT Compact Baffled Catch Can | Mishimoto | ~$150 | High | 13 oz, petcock drain - [Runaway Protection][runaway-protection] |
+| Mishimoto MMOCC-UB Universal Mounting Bracket | Mishimoto | ~$40 | High | [Runaway Protection][runaway-protection] |
+| Midwest Control 30-144-TTL-BH-3 Push-Pull Cable | Midwest Control | ~$60-80 | High | 144" turn-to-lock T-handle, 3" travel - [Runaway Protection][runaway-protection] |
+| 5/8" Oil-Resistant Hose (2 ft) + Worm Clamps | Generic | ~$15 | High | Catch can plumbing - [Runaway Protection][runaway-protection] |
+| NPT-to-Hose Adapter Fittings (AMOT to intake) | Generic | ~$25 | High | Size per measured turbo inlet - [Runaway Protection][runaway-protection] |
 
 ---
 
@@ -231,6 +237,7 @@ _(Most electrical distribution components already purchased - see Purchased Item
 [dashboard]: ../05-control-interfaces/05-dashboard-controls.md
 [power-checklist]: 01-power-systems-checklist.md
 [engine-checklist]: 02-engine-systems-checklist.md
+[runaway-protection]: ../02-engine-systems/11-runaway-protection.md
 [tbd-tracker]: 00-tbd-tracker.md
 [bd-site]: https://www.bajadesigns.com/
 [4wp-site]: https://www.4wheelparts.com/

--- a/docs/jeep_lj/10-drivetrain/01-transmission.md
+++ b/docs/jeep_lj/10-drivetrain/01-transmission.md
@@ -120,8 +120,16 @@ The Turbolamik communicates with the Cummins R2.8 ECM via J1939 CAN for:
 | Output Speed Sensor   | Internal to trans     | Hall effect                   |
 | Transmission Temp     | Internal to trans     | NTC thermistor                |
 | Range Sensor (BTSI)   | Internal to trans     | Gear position                 |
-| Shifter Input         | Electronic shifter    | TBD - depends on shifter type |
+| Shifter Input         | Electronic shifter    | Kilduff (factory 8HP70 connector) |
 | Brake Switch          | Digital input         | Unlock from Park              |
+
+### Aux Outputs (TCU → Vehicle)
+
+| Output            | Function                          | Destination                              | Notes                                              |
+| :---------------- | :-------------------------------- | :--------------------------------------- | :------------------------------------------------- |
+| Aux Out (Reverse) | 12V when shifter in R             | [PMU In 3][pmu-inputs]                   | Drives PMU OUT22 (Reverse Lights)                  |
+| Aux Out (P/N)     | 12V when shifter in P or N        | [Starter P/N interlock relay][starter]   | Required gate for cranking the engine              |
+| J1939 broadcast   | Gear position, trans temp, mode   | [BIM-01-2 J1939][bim-j1939] → HDX GEAR   | Shares Cummins J1939 bus                           |
 
 ### Shifter
 
@@ -202,6 +210,8 @@ The Turbolamik communicates with the Cummins R2.8 ECM via J1939 CAN for:
 [pmu-inputs]: ../01-power-systems/04-pmu/02-pmu-inputs.md
 [pmu-outputs]: ../01-power-systems/04-pmu/03-pmu-outputs.md
 [engine]: ../02-engine-systems/index.md
+[starter]: ../02-engine-systems/01-starter.md
+[bim-j1939]: ../02-engine-systems/09-gauge-cluster/03-bim-j1939.md
 [kilduff-shifter]: https://www.kilduffmachine.com/store/p168/Kilduff_8PH70_%2F_8_speed_ZF_Shifter_for_swaps_%23KIL8HP70.html
 [turbolamik]: https://www.turbolamik.us/tcu-2-0-turbolamik/
 [turbolamik-manual]: https://manual.turbolamik.eu/

--- a/docs/jeep_lj/10-drivetrain/index.md
+++ b/docs/jeep_lj/10-drivetrain/index.md
@@ -45,7 +45,6 @@ Complete drivetrain system documentation for the Jeep LJ build.
 
 ## Outstanding Items
 
-- [ ] Select 8HP70 transmission controller (Compushift vs US Shift Quick 8)
 - [ ] Document driveshaft specifications
 
 ## Related Documentation

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -159,6 +159,7 @@ nav:
         - 2.9.5 - BIM TPMS: jeep_lj/02-engine-systems/09-gauge-cluster/05-bim-tpms.md
         - 2.9.6 - BIM Compass: jeep_lj/02-engine-systems/09-gauge-cluster/06-bim-compass.md
       - 2.10 - ADU7 Display: jeep_lj/02-engine-systems/10-adu7-display/index.md
+      - 2.11 - Runaway Protection: jeep_lj/02-engine-systems/11-runaway-protection.md
     - Vehicle Lighting:
       - jeep_lj/03-lighting-systems/index.md
       - 3.1 - Lighting Overview: jeep_lj/03-lighting-systems/01-lighting-overview.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -184,6 +184,7 @@ nav:
       - 5.2 - SwitchPros SP-1200: jeep_lj/05-control-interfaces/02-switchpros-sp1200.md
       - 5.3 - Command Touch CT4: jeep_lj/05-control-interfaces/03-command-touch-ct4.md
       - 5.4 - Dashboard Switches: jeep_lj/05-control-interfaces/05-dashboard-controls.md
+      - 5.6 - Keyless Ignition: jeep_lj/05-control-interfaces/06-keyless-ignition.md
     - Stereo Systems:
       - jeep_lj/06-audio-systems/index.md
       - 6.1 - Head Unit: jeep_lj/06-audio-systems/01-head-unit.md


### PR DESCRIPTION
## Summary

This PR adds comprehensive documentation and integration details for two critical safety systems in the Jeep LJ build:

1. **Keyless Ignition System** - RFID-enabled push-button start/stop replacing the factory keyswitch, with PMU24-based state machine and multiple hardware interlocks
2. **Diesel Runaway Protection** - Layered mechanical defense against diesel runaway using a Mishimoto catch can (prevention) and AMOT 4261M air shutoff valve (termination)

## Key Changes

### New Documentation
- **`05-control-interfaces/06-keyless-ignition.md`** - Complete keyless ignition architecture including:
  - Boomerang Bullet 230 RFID immobilizer specifications
  - Dash push-button and relay component details
  - PMU24 state machine logic (OFF → RUN → CRANK transitions)
  - Comprehensive wiring diagrams and firewall pin assignments
  - Emergency bypass hardwired toggle for get-home mode
  - 10 outstanding items for parts selection and integration

- **`02-engine-systems/11-runaway-protection.md`** - Diesel runaway protection strategy:
  - Mishimoto baffled catch can in crankcase ventilation path
  - AMOT 4261M manual air shutoff valve with push-pull cable
  - Failure mode coverage matrix
  - Maintenance intervals and reset procedures
  - Future enhancement paths (electric solenoid auto-trip)

### Modified Documentation
- **`02-engine-systems/01-starter.md`** - Updated wiring table to reflect new keyless architecture:
  - Replaced clutch interlock with PMU OUT24 state machine
  - Added P/N interlock relay, engine-running lockout relay, and brake-gated start chain
  - Clarified hardware crank chain requirements (4 gates: button + brake + P/N + engine-running)

- **`01-power-systems/04-pmu/02-pmu-inputs.md`** - Updated PMU input descriptions:
  - In 4: Boomerang fob present signal
  - In 5: Push-button input
  - In 6: Turbolamik P/N signal
  - Pin 7: Now sourced from ECM Ignition Relay (driven by OUT24) instead of keyswitch

- **`01-power-systems/06-ignition-signal/index.md`** - Updated ignition bus architecture:
  - Bus bar now fed from ECM Ignition Relay (PMU OUT24-driven) instead of keyswitch
  - Clarified that critical systems use dedicated wires, not the bus bar

- **`01-power-systems/07-wire-routing/02-firewall-ingress.md`** - Updated firewall pin assignments:
  - Pin 12 reassigned from "Ignition sense" (C→EB) to "Ignition signal bus feed" (EB→C)
  - Added 3 new pins for keyless system (fob signal, OUT24 supply, gated start)
  - Adjusted pin count from 11 to 10 cabin→EB wires

- **`09-installation/02-engine-systems-checklist.md`** - Added comprehensive checklists:
  - Pre-install runaway protection BOM items
  - Phase 1 starter system updates (PMU OUT24, P/N relay, engine-running lockout)
  - Phase 8 runaway protection installation (catch can, AMOT valve, cable routing)
  - Phase 9 testing procedures for keyless and runaway systems

- **`09-installation/00-tbd-tracker.md`** - Added 15 new TBD items:
  - Turbolamik aux output configuration (Reverse, P/N)
  - Dash push-button and Boomerang Bullet 230 selection
  - Relay part selection (ECM ignition, P/N interlock, engine-running lockout)
  - Firewall pin assignments and hidden bypass toggle location

- **`09-installation/03-purchase-tracker.md`** - Added AMOT

https://claude.ai/code/session_01S5R1pyvdrB2GxHGZ7iyJr5