### PR TITLE
docs(lj): triage TBD tracker - resolve answered/duplicate items

### DIFF
--- a/docs/jeep_lj/01-power-systems/04-pmu/03-pmu-outputs.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/03-pmu-outputs.md
@@ -20,7 +20,7 @@ Complete configuration of all 24 PMU outputs, load allocations, and combined out
 | **Out 5**  | HVAC Blower Motor            | ~20A     | Factory HVAC ground                                   | Auto (ignition ON) | See [HVAC System][hvac-system] |
 | **Out 6**  | GMRS Radio (Midland G1)      | 15A      | [Direct START battery-][starter-battery-distribution] | CONSTANT           | RF noise isolation             |
 | **Out 7**  | Oil Cooler Fan               | ~15A     | [Engine Bay Bus][engine-ground] Stud 8                | Auto (CAN temp)    | SPN 175 oil temp trigger       |
-| **Out 8**  | PS Cooler Fan                | ~15A     | [Engine Bay Bus][engine-ground] Stud 8                | Auto (CAN temp)    | SPN 110 coolant temp trigger   |
+| **Out 8**  | PS Cooler Fan                | ~15A     | [Engine Bay Bus][engine-ground] Stud 8                | 180°F inline thermostat | Mishimoto PS cooler fan; thermostat-switched on PS fluid temp (not engine coolant) |
 | **Out 9**  | Dakota Digital System        | ~25A     | [Firewall Stud Bus][firewall-ground] T4-5             | CONSTANT           | Cluster + 4 BIM modules        |
 | **Out 10** | **iBooster Main (combined)** | Combined | [Engine Bay Bus][engine-ground] Stud 7                | CONSTANT           | Combined with OUT1             |
 

--- a/docs/jeep_lj/05-control-interfaces/06-keyless-ignition.md
+++ b/docs/jeep_lj/05-control-interfaces/06-keyless-ignition.md
@@ -171,7 +171,6 @@ Normal engine shutdown (press brake + 2 sec button hold) drops PBS-I's PINK IGN 
 - [ ] Select PBS-I module mounting location (cabin under-dash, away from heat and water)
 - [ ] Select Start Button dash mounting position (within easy reach of driver)
 - [ ] Select Programming Button storage location (hidden but accessible)
-- [ ] Assign firewall pins for PBS-I PINK IGN (cabin → EB) and WAIT-gated PURPLE START (cabin → EB)
 - [ ] Verify PBS-I quiescent current draw to add to START battery parasitic budget
 - [ ] Set DIP switches / jumpers per install manual (PBS-I has no DIP/Jumper menu; check Feature Programming defaults are acceptable)
 

--- a/docs/jeep_lj/09-installation/00-tbd-tracker.md
+++ b/docs/jeep_lj/09-installation/00-tbd-tracker.md
@@ -9,7 +9,7 @@ hide:
 
 **Last Updated:** 2026-05-31
 
-**Total Open Items:** 49
+**Total Open Items:** 47
 
 > Count reflects the priority sections below. The Critical-Spec Verification Audit is a separate validation log (its open on-arrival/on-vehicle checks are tracked via GitHub issue [#29][i29]); items already marked ✅ Resolved are not counted.
 
@@ -35,8 +35,6 @@ Items needed before installation begins but not system-critical.
 | Turbolamik Aux: Reverse           | Confirm aux output channel + pinout configured for Reverse signal → PMU In 3 | [Transmission][transmission]   | High     |
 | Turbolamik Aux: P/N               | Confirm aux output channel + pinout configured for P/N (start interlock) | [Transmission][transmission]   | High     |
 | Dash Push-Button (Keyless)        | Select 19/22mm illuminated momentary NO push-button for keyless start/stop | [Keyless Ignition][keyless]   | High     |
-| Boomerang Bullet 230              | Order RFID receiver + fob; mounting location under dash         | [Keyless Ignition][keyless]   | High     |
-| Boomerang Mounting Location       | Under-dash position near driver (3-6 ft range to driver seat)   | [Keyless Ignition][keyless]   | High     |
 | ECM Ignition Relay                | Select Hella/Bosch SPST 30-40A automotive relay                 | [Keyless Ignition][keyless]   | High     |
 | P/N Interlock Relay               | Select SPST 30A automotive relay (Turbolamik P/N → coil)        | [Keyless Ignition][keyless]   | High     |
 | Engine-Running Lockout Relay      | Select SPST 30A automotive relay with NC contacts               | [Keyless Ignition][keyless]   | High     |
@@ -232,12 +230,12 @@ Items completed since last update.
 | Priority         | Count  |
 | :--------------- | :----- |
 | 🔴 Critical      | 0      |
-| High             | 19     |
+| High             | 17     |
 | 📋 Medium        | 15     |
 | 📝 Low           | 2      |
 | 🔍 Verify        | 1      |
 | 🚙 Drivetrain    | 12     |
-| **TOTAL**        | **49** |
+| **TOTAL**        | **47** |
 
 ## Related Documentation
 

--- a/docs/jeep_lj/09-installation/00-tbd-tracker.md
+++ b/docs/jeep_lj/09-installation/00-tbd-tracker.md
@@ -120,11 +120,11 @@ Mechanical drivetrain specifications, tracked separately from the electrical bui
 | Rear Axle Gearing & Locker        | Ratio, manufacturer, and locker type                                                         | [Rear Axle][rear-axle]            | Medium   |
 | Front Suspension Components       | Coil rate, bypass valving, control arms, track bar, sway bar                                 | [Suspension][suspension]          | Medium   |
 | Rear Suspension Components        | Coil rate, bypass valving, control arms, track bar, sway bar                                 | [Suspension][suspension]          | Medium   |
-| Steering Pump Specs               | PSC pump (decided) — model, flow rate, pressure, drive type (belt vs Cummins gear-drive) TBD | [Steering][steering]              | Medium   |
-| Steering Ram Specs                | PSC double-ended ram on Artec D60 mount (cut to D44) + Busted Knuckle stops to D44 stroke (decided); model/bore TBD | [Steering][steering]              | Medium   |
+| Steering Pump Specs               | Kit pump PK40JP2-FH is Jeep 4.0L-only — source Cummins R2.8 PSC pump/bracket; flow/pressure/drive TBD | [Steering][steering]              | Medium   |
+| Steering Ram Specs                | PSC SC2227K1 (2.75×8 double-ended, FHK400TJ) on Artec D60 mount cut to D44 + Busted Knuckle stops; confirm tire-size bore variant | [Steering][steering]              | Medium   |
 | Steering Cooler Fan (electrical)  | Mishimoto cooler + fan w/ 180°F inline thermostat (decided); fan current draw + power source/control TBD | [Steering][steering]              | Medium   |
 | Suspension Geometry               | Departure and breakover angles (calculated from chosen suspension)                           | [Suspension][suspension]          | Low      |
-| Steering Reservoir & Fluid        | Reservoir type/capacity/location and fluid type/capacity                                     | [Steering][steering]              | Low      |
+| Steering Reservoir & Fluid        | Fluid = PSC/SWEPCO 715; remote reservoir (in pump kit) model/location + system fill qty TBD  | [Steering][steering]              | Low      |
 
 ---
 

--- a/docs/jeep_lj/09-installation/00-tbd-tracker.md
+++ b/docs/jeep_lj/09-installation/00-tbd-tracker.md
@@ -9,7 +9,7 @@ hide:
 
 **Last Updated:** 2026-05-31
 
-**Total Open Items:** 38
+**Total Open Items:** 46
 
 > Count reflects the priority sections below. The Critical-Spec Verification Audit is a separate validation log (its open on-arrival/on-vehicle checks are tracked via GitHub issue [#29][i29]); items already marked ✅ Resolved are not counted.
 
@@ -34,6 +34,11 @@ Items needed before installation begins but not system-critical.
 | Dakota Digital Panel Mounting     | HDPE sheet dimensions and location                              | [Wire Routing][wire-routing]   | High     |
 | Turbolamik Aux: Reverse           | Confirm aux output channel + pinout configured for Reverse signal → PMU In 3 | [Transmission][transmission]   | High     |
 | Turbolamik Aux: P/N               | Confirm aux output channel + pinout configured for P/N (start interlock) | [Transmission][transmission]   | High     |
+| PBS-I Kit Order                   | Order Digital Guard Dawg PBS-I kit (ICM, 2 iTag fobs, Start Button + 36" harness, Programming Button, Bypass Card) | [Keyless Ignition][keyless]   | High     |
+| WAIT-Gate Relay Part              | Select SPST 30A automotive relay, NC contacts in start path (e.g. Bosch 0332019150 or Hella 4RA 003 510-04) | [Keyless Ignition][keyless]   | High     |
+| ECM Pin 41 Inline Fuse            | Add 5A inline fuse on ignition outbound wire to ECM Pin 41 per Cummins R2.8 install manual (doc 0042728) | [Keyless Ignition][keyless]   | High     |
+| PBS-I Module Mounting Location    | Cabin under-dash position; module ~5.5"×3"×1.25"; away from heat and water (do NOT engine-bay mount) | [Keyless Ignition][keyless]   | High     |
+| Start Button Mounting Location    | Dash position within easy reach of driver (button + 36" harness included in PBS-I kit) | [Keyless Ignition][keyless]   | High     |
 | R2.8 Turbo Inlet OD               | Measure turbo inlet tube outside diameter to confirm AMOT 4261M-02 (2.8" body) fitment and select intake-side adapter | [Runaway Protection][runaway-protection] | High     |
 | AMOT-to-Intake Adapters           | Source NPT-to-hose fittings sized to match measured turbo inlet OD                                | [Runaway Protection][runaway-protection] | High     |
 | AMOT T-Handle Mounting Location   | Select dash mounting position for Midwest Control 30-144-TTL-BH-3 (reachable belted, away from accidental contact) | [Runaway Protection][runaway-protection] | High     |
@@ -70,6 +75,9 @@ Items that improve the design but don't block installation.
 | Winch Trigger Control Routing          | Path for 14 AWG control wire (~13 ft) from SafetyHub ATC-1 (passenger rear wheel well) to winch contactor (front bumper) | [Recovery Systems][recovery-systems] | Medium   |
 | Front Air Locker Solenoid Routing      | Path for 18 AWG (~12 ft) from SwitchPros OUTPUT-17 (passenger rear wheel well) to front axle solenoid - cross-cab + forward | [Air Lockers][air-lockers] | Medium   |
 | Radio Ground Routing                   | Path for 14 AWG ground wires from GMRS / Intercom (dashboard) to START battery negative (driver rear wheel well) - direct grounds required for RF noise isolation | [Firewall Ingress][firewall-ingress] | Medium   |
+| Programming Button Storage             | Hidden but accessible location (under dash or in trunk) for PBS-I fob-learn and 4-digit-PIN emergency bypass | [Keyless Ignition][keyless]          | Medium   |
+| PBS-I Quiescent Current                | Measure or vendor-confirm standby draw to add to START battery parasitic budget  | [Keyless Ignition][keyless]          | Medium   |
+| PBS-I Feature Programming Defaults     | Confirm shipped Feature Programming defaults are acceptable before install (no DIP/jumper menu on PBS-I) | [Keyless Ignition][keyless]          | Medium   |
 
 ---
 
@@ -221,12 +229,12 @@ Items completed since last update.
 | Priority         | Count  |
 | :--------------- | :----- |
 | 🔴 Critical      | 0      |
-| High             | 8      |
-| 📋 Medium        | 15     |
+| High             | 13     |
+| 📋 Medium        | 18     |
 | 📝 Low           | 2      |
 | 🔍 Verify        | 1      |
 | 🚙 Drivetrain    | 12     |
-| **TOTAL**        | **38** |
+| **TOTAL**        | **46** |
 
 ## Related Documentation
 

--- a/docs/jeep_lj/09-installation/00-tbd-tracker.md
+++ b/docs/jeep_lj/09-installation/00-tbd-tracker.md
@@ -113,7 +113,7 @@ Mechanical drivetrain specifications, tracked separately from the electrical bui
 | :-------------------------------- | :------------------------------------------------------------------------------------------- | :-------------------------------- | :------- |
 | TCU Brake Switch Routing          | Brake pedal switch already feeds PMU In 2 via HDP24 pin 13. Decide: shared signal tap or dedicated wire to TCU? | [Harness Inventory][harness-inventory] | Medium |
 | Transmission Pilot Bearing        | If required by flywheel/crank combination                                                    | [Transmission][transmission]      | Medium   |
-| Transfer Case Specs               | Output type, fluid type and capacity                                                         | [Transfer Case][transfer-case]    | Medium   |
+| Transfer Case Specs               | JK NVG241 (2.72:1) — input spline (per 8HP70 adapter), output type, fluid type & capacity     | [Transfer Case][transfer-case]    | Medium   |
 | Front Driveshaft Specs            | Custom (Tom Woods) decided — measure length at final ride height & order                     | [Driveshafts][driveshafts]        | Medium   |
 | Rear Driveshaft Specs             | Custom (Tom Woods) decided — measure length at final ride height & order                     | [Driveshafts][driveshafts]        | Medium   |
 | Front Axle Gearing & Manufacturer | Ratio and axle housing manufacturer                                                          | [Front Axle][front-axle]          | Medium   |

--- a/docs/jeep_lj/09-installation/00-tbd-tracker.md
+++ b/docs/jeep_lj/09-installation/00-tbd-tracker.md
@@ -122,7 +122,7 @@ Mechanical drivetrain specifications, tracked separately from the electrical bui
 | Rear Suspension Components        | Coil rate, bypass valving, control arms, track bar, sway bar                                 | [Suspension][suspension]          | Medium   |
 | Steering Pump Specs               | Kit pump PK40JP2-FH is Jeep 4.0L-only — source Cummins R2.8 PSC pump/bracket; flow/pressure/drive TBD | [Steering][steering]              | Medium   |
 | Steering Ram Specs                | PSC SC2227K1 (2.75×8 double-ended, FHK400TJ, 40"+ confirmed) on Artec D60 mount cut to D44 + Busted Knuckle stops; mount P/N + D44 stroke length TBD | [Steering][steering]              | Medium   |
-| Steering Cooler Fan (electrical)  | Mishimoto cooler + fan w/ 180°F inline thermostat (decided); fan current draw + power source/control TBD | [Steering][steering]              | Medium   |
+| Steering Cooler Fan (electrical)  | On PMU Out 8 (~15A, 180°F inline thermostat); confirm actual Mishimoto fan draw fits budget   | [Steering][steering]              | Medium   |
 | Suspension Geometry               | Departure and breakover angles (calculated from chosen suspension)                           | [Suspension][suspension]          | Low      |
 | Steering Reservoir & Fluid        | Fluid = PSC/SWEPCO 715; remote reservoir (in pump kit) model/location + system fill qty TBD  | [Steering][steering]              | Low      |
 

--- a/docs/jeep_lj/09-installation/00-tbd-tracker.md
+++ b/docs/jeep_lj/09-installation/00-tbd-tracker.md
@@ -9,7 +9,9 @@ hide:
 
 **Last Updated:** 2026-05-31
 
-**Total Open Items:** 58
+**Total Open Items:** 50
+
+> Count reflects the priority sections below. The Critical-Spec Verification Audit is a separate validation log (its open on-arrival/on-vehicle checks are tracked via GitHub issue [#29][i29]); items already marked ✅ Resolved are not counted.
 
 ---
 
@@ -63,7 +65,6 @@ Items that improve the design but don't block installation.
 | Roof/Roll Bar Routing                  | Light bars, dome lights                                                          | [Wire Routing][wire-routing]         | Medium   |
 | Speaker Mounting Locations             | Dash end caps or kick panels                                                     | [Audio Systems][audio-systems]       | Medium   |
 | RF Power Grommet Location              | Grommet 6 location near battery for radio power                                  | [Wire Routing][wire-routing]         | Medium   |
-| Solar Panel Wire Gauge                 | Wire sizing for Cascadia 4x4 80W panel connection                                | [BCDC][bcdc]                         | Medium   |
 | Alternator Output Terminal Size        | Terminal size for 1/0 AWG lug selection                                          | [Alternator][alternator]             | Medium   |
 | Alternator Voltage Regulator Set Point | Verify 14.2-14.4V for AGM batteries                                              | [Alternator][alternator]             | Medium   |
 | BODY PDU Metri-Pack Pinout             | J301-J306 connector pinout (military TM or reverse engineering)                  | [BODY PDU][body-rtmr]                | Medium   |
@@ -89,7 +90,7 @@ Items that can be determined during build.
 
 | Item                              | Description                                                                     | File                                 | Priority |
 | :-------------------------------- | :------------------------------------------------------------------------------ | :----------------------------------- | :------- |
-| BIM Module Current Draw           | Current draw for BIM-17-2, BIM-11-2, BIM-12-2, BIM-13-2 (powered via BIM cable) | [Gauge Cluster][gauge-cluster]       | Low      |
+| BIM Module Current Draw           | Current draw for BIM-01-2-J1939, GPS-50-2, BIM-22-3, BIM-17-2 (powered via BIM cable) | [Gauge Cluster][gauge-cluster]       | Low      |
 | LED4Life Wire Colors              | Confirm pod wire colors match MLC-RW pinout before install                      | [Footwell Lights][footwell-lights]   | Low      |
 
 ---
@@ -132,6 +133,7 @@ Items completed since last update.
 
 | Item                          | Resolution                                                                                                                    | Date       |
 | :---------------------------- | :---------------------------------------------------------------------------------------------------------------------------- | :--------- |
+| Solar Panel Wire Gauge        | 10 AWG minimum (for 2.23A Isc with safety margin) - already specified in solar generation doc                                 | 2026-05-30 |
 | SwitchPros Power Module Location | **Architecture change:** Moved from passenger rear wheel well to firewall (cabin side, passenger area). Output fan-out is ~58% forward — placing module near loads minimizes total output wire. SwitchPros Ground Bus moves with controller. Input is 2 AWG, ~2 ft from Firewall CONSTANT Bus. Control cable shortens from 10.5 ft to ~5 ft. | 2026-05-30 |
 | AUX Battery CONSTANT Bus #1 (rear) | **Architecture change:** Removed. With SwitchPros, BODY PDU, and Fusion Amp moved to firewall distribution, only 2 CB-protected feeds + 2 direct connections leave the AUX battery. Replaced rear CONSTANT bus with 4 stacked ring lugs on battery + 2 inline CBs (300A master + 150A SafetyHub) on a wheel well bracket. | 2026-05-30 |
 | Firewall CONSTANT Bus (new)   | **Architecture change:** Added Blue Sea 2105 MaxiBus (250A) on firewall (passenger cabin side). Fed by 2/0 AWG forward feed from AUX battery via 300A master CB. Feeds SwitchPros (150A CB), BODY PDU (100A CB), Fusion Amp (100A CB). Places distribution near loads; collapses 3 forward feeds into 1 heavy cable through cabin trunk. | 2026-05-30 |
@@ -230,18 +232,17 @@ Items completed since last update.
 | :--------------- | :----- |
 | 🔴 Critical      | 0      |
 | High             | 19     |
-| 📋 Medium        | 16     |
+| 📋 Medium        | 15     |
 | 📝 Low           | 2      |
 | 🔍 Verify        | 1      |
 | 🚙 Drivetrain    | 13     |
-| **TOTAL**        | **51** |
+| **TOTAL**        | **50** |
 
 ## Related Documentation
 
 - [Section 1 Installation Checklist][section-1-install] - Power systems installation guide
 - [Section 1.7 Wire Routing][wire-routing] - Wire routing organized by location
 
-[bcdc]: ../01-power-systems/01-power-generation/03-bcdc.md
 [gauge-cluster]: ../02-engine-systems/09-gauge-cluster/index.md
 [radiator-fan]: ../02-engine-systems/06-radiator-fan.md
 [wire-routing]: ../01-power-systems/07-wire-routing/index.md

--- a/docs/jeep_lj/09-installation/00-tbd-tracker.md
+++ b/docs/jeep_lj/09-installation/00-tbd-tracker.md
@@ -120,10 +120,11 @@ Mechanical drivetrain specifications, tracked separately from the electrical bui
 | Rear Axle Gearing & Locker        | Ratio, manufacturer, and locker type                                                         | [Rear Axle][rear-axle]            | Medium   |
 | Front Suspension Components       | Coil rate, bypass valving, control arms, track bar, sway bar                                 | [Suspension][suspension]          | Medium   |
 | Rear Suspension Components        | Coil rate, bypass valving, control arms, track bar, sway bar                                 | [Suspension][suspension]          | Medium   |
-| Hydroboost Pump Specs             | Model, flow rate, pressure, drive type                                                       | [Steering][steering]              | Medium   |
-| Hydroboost Ram Specs              | Model, bore, stroke, mount type                                                              | [Steering][steering]              | Medium   |
+| Steering Pump Specs               | PSC pump (decided) — model, flow rate, pressure, drive type (belt vs Cummins gear-drive) TBD | [Steering][steering]              | Medium   |
+| Steering Ram Specs                | PSC double-ended ram on Artec D60 mount (cut to D44) + Busted Knuckle stops to D44 stroke (decided); model/bore TBD | [Steering][steering]              | Medium   |
+| Steering Cooler Fan (electrical)  | Mishimoto cooler + fan w/ 180°F inline thermostat (decided); fan current draw + power source/control TBD | [Steering][steering]              | Medium   |
 | Suspension Geometry               | Departure and breakover angles (calculated from chosen suspension)                           | [Suspension][suspension]          | Low      |
-| Hydroboost Reservoir & Fluid      | Reservoir type/capacity/location and fluid type/capacity                                     | [Steering][steering]              | Low      |
+| Steering Reservoir & Fluid        | Reservoir type/capacity/location and fluid type/capacity                                     | [Steering][steering]              | Low      |
 
 ---
 

--- a/docs/jeep_lj/09-installation/00-tbd-tracker.md
+++ b/docs/jeep_lj/09-installation/00-tbd-tracker.md
@@ -272,6 +272,7 @@ Items completed since last update.
 [rear-axle]: ../10-drivetrain/05-rear-axle.md
 [suspension]: ../10-drivetrain/06-suspension.md
 [steering]: ../10-drivetrain/07-steering.md
+[i29]: https://github.com/sob/drawings/issues/29
 [constant-bus]: ../01-power-systems/03-aux-battery-distribution/02-constant-bus.md
 [starter-doc]: ../02-engine-systems/01-starter.md
 [keyless]: ../05-control-interfaces/06-keyless-ignition.md

--- a/docs/jeep_lj/09-installation/00-tbd-tracker.md
+++ b/docs/jeep_lj/09-installation/00-tbd-tracker.md
@@ -121,7 +121,7 @@ Mechanical drivetrain specifications, tracked separately from the electrical bui
 | Front Suspension Components       | Coil rate, bypass valving, control arms, track bar, sway bar                                 | [Suspension][suspension]          | Medium   |
 | Rear Suspension Components        | Coil rate, bypass valving, control arms, track bar, sway bar                                 | [Suspension][suspension]          | Medium   |
 | Steering Pump Specs               | Kit pump PK40JP2-FH is Jeep 4.0L-only — source Cummins R2.8 PSC pump/bracket; flow/pressure/drive TBD | [Steering][steering]              | Medium   |
-| Steering Ram Specs                | PSC SC2227K1 (2.75×8 double-ended, FHK400TJ) on Artec D60 mount cut to D44 + Busted Knuckle stops; confirm tire-size bore variant | [Steering][steering]              | Medium   |
+| Steering Ram Specs                | PSC SC2227K1 (2.75×8 double-ended, FHK400TJ, 40"+ confirmed) on Artec D60 mount cut to D44 + Busted Knuckle stops; mount P/N + D44 stroke length TBD | [Steering][steering]              | Medium   |
 | Steering Cooler Fan (electrical)  | Mishimoto cooler + fan w/ 180°F inline thermostat (decided); fan current draw + power source/control TBD | [Steering][steering]              | Medium   |
 | Suspension Geometry               | Departure and breakover angles (calculated from chosen suspension)                           | [Suspension][suspension]          | Low      |
 | Steering Reservoir & Fluid        | Fluid = PSC/SWEPCO 715; remote reservoir (in pump kit) model/location + system fill qty TBD  | [Steering][steering]              | Low      |

--- a/docs/jeep_lj/09-installation/00-tbd-tracker.md
+++ b/docs/jeep_lj/09-installation/00-tbd-tracker.md
@@ -9,7 +9,7 @@ hide:
 
 **Last Updated:** 2026-05-31
 
-**Total Open Items:** 50
+**Total Open Items:** 49
 
 > Count reflects the priority sections below. The Critical-Spec Verification Audit is a separate validation log (its open on-arrival/on-vehicle checks are tracked via GitHub issue [#29][i29]); items already marked ✅ Resolved are not counted.
 
@@ -235,8 +235,8 @@ Items completed since last update.
 | 📋 Medium        | 15     |
 | 📝 Low           | 2      |
 | 🔍 Verify        | 1      |
-| 🚙 Drivetrain    | 13     |
-| **TOTAL**        | **50** |
+| 🚙 Drivetrain    | 12     |
+| **TOTAL**        | **49** |
 
 ## Related Documentation
 

--- a/docs/jeep_lj/09-installation/00-tbd-tracker.md
+++ b/docs/jeep_lj/09-installation/00-tbd-tracker.md
@@ -9,7 +9,7 @@ hide:
 
 **Last Updated:** 2026-05-31
 
-**Total Open Items:** 47
+**Total Open Items:** 38
 
 > Count reflects the priority sections below. The Critical-Spec Verification Audit is a separate validation log (its open on-arrival/on-vehicle checks are tracked via GitHub issue [#29][i29]); items already marked ✅ Resolved are not counted.
 
@@ -34,15 +34,6 @@ Items needed before installation begins but not system-critical.
 | Dakota Digital Panel Mounting     | HDPE sheet dimensions and location                              | [Wire Routing][wire-routing]   | High     |
 | Turbolamik Aux: Reverse           | Confirm aux output channel + pinout configured for Reverse signal → PMU In 3 | [Transmission][transmission]   | High     |
 | Turbolamik Aux: P/N               | Confirm aux output channel + pinout configured for P/N (start interlock) | [Transmission][transmission]   | High     |
-| Dash Push-Button (Keyless)        | Select 19/22mm illuminated momentary NO push-button for keyless start/stop | [Keyless Ignition][keyless]   | High     |
-| ECM Ignition Relay                | Select Hella/Bosch SPST 30-40A automotive relay                 | [Keyless Ignition][keyless]   | High     |
-| P/N Interlock Relay               | Select SPST 30A automotive relay (Turbolamik P/N → coil)        | [Keyless Ignition][keyless]   | High     |
-| Engine-Running Lockout Relay      | Select SPST 30A automotive relay with NC contacts               | [Keyless Ignition][keyless]   | High     |
-| Engine-Running Voltage Filter     | Design diode + zener + resistor filter on alternator B+ tap for lockout coil drive | [Keyless Ignition][keyless]   | High     |
-| Keyless Firewall Pin Assignments  | Assign 3 new HDP24 pins (fob, OUT24 supply, gated start return); current connector is full | [Firewall Ingress][firewall-ingress] | High     |
-| Hidden Bypass Toggle              | Select part + mounting location for emergency get-home bypass   | [Keyless Ignition][keyless]   | High     |
-| PMU Output Strategy (Keyless)     | Decide: OUT24-only + engine-running lockout (current plan) vs. free OUT15 winch trigger for dedicated crank output | [Keyless Ignition][keyless]   | High     |
-| PMU24 Keyless State Machine       | Program ECUMaster Light Client logic for OFF/RUN/CRANK transitions, fob detection, kill behavior | [PMU Programming][pmu-programming]   | High     |
 | R2.8 Turbo Inlet OD               | Measure turbo inlet tube outside diameter to confirm AMOT 4261M-02 (2.8" body) fitment and select intake-side adapter | [Runaway Protection][runaway-protection] | High     |
 | AMOT-to-Intake Adapters           | Source NPT-to-hose fittings sized to match measured turbo inlet OD                                | [Runaway Protection][runaway-protection] | High     |
 | AMOT T-Handle Mounting Location   | Select dash mounting position for Midwest Control 30-144-TTL-BH-3 (reachable belted, away from accidental contact) | [Runaway Protection][runaway-protection] | High     |
@@ -230,12 +221,12 @@ Items completed since last update.
 | Priority         | Count  |
 | :--------------- | :----- |
 | 🔴 Critical      | 0      |
-| High             | 17     |
+| High             | 8      |
 | 📋 Medium        | 15     |
 | 📝 Low           | 2      |
 | 🔍 Verify        | 1      |
 | 🚙 Drivetrain    | 12     |
-| **TOTAL**        | **47** |
+| **TOTAL**        | **38** |
 
 ## Related Documentation
 

--- a/docs/jeep_lj/09-installation/00-tbd-tracker.md
+++ b/docs/jeep_lj/09-installation/00-tbd-tracker.md
@@ -114,8 +114,8 @@ Mechanical drivetrain specifications, tracked separately from the electrical bui
 | TCU Brake Switch Routing          | Brake pedal switch already feeds PMU In 2 via HDP24 pin 13. Decide: shared signal tap or dedicated wire to TCU? | [Harness Inventory][harness-inventory] | Medium |
 | Transmission Pilot Bearing        | If required by flywheel/crank combination                                                    | [Transmission][transmission]      | Medium   |
 | Transfer Case Specs               | Output type, fluid type and capacity                                                         | [Transfer Case][transfer-case]    | Medium   |
-| Front Driveshaft Specs            | Type, length, U-joint selection                                                              | [Driveshafts][driveshafts]        | Medium   |
-| Rear Driveshaft Specs             | Type, length, U-joint selection                                                              | [Driveshafts][driveshafts]        | Medium   |
+| Front Driveshaft Specs            | Custom (Tom Woods) decided — measure length at final ride height & order                     | [Driveshafts][driveshafts]        | Medium   |
+| Rear Driveshaft Specs             | Custom (Tom Woods) decided — measure length at final ride height & order                     | [Driveshafts][driveshafts]        | Medium   |
 | Front Axle Gearing & Manufacturer | Ratio and axle housing manufacturer                                                          | [Front Axle][front-axle]          | Medium   |
 | Rear Axle Gearing & Locker        | Ratio, manufacturer, and locker type                                                         | [Rear Axle][rear-axle]            | Medium   |
 | Front Suspension Components       | Coil rate, bypass valving, control arms, track bar, sway bar                                 | [Suspension][suspension]          | Medium   |

--- a/docs/jeep_lj/10-drivetrain/02-transfer-case.md
+++ b/docs/jeep_lj/10-drivetrain/02-transfer-case.md
@@ -88,6 +88,8 @@ The 8HP *family* does pair with an NV241 from the factory — the JL Wrangler au
 | Fluid Type | ATF+4[^fluid] |
 | Capacity | ≈1.6 L (3.4 pt); fill to overflow[^fluid] |
 
+[^tc-ratio]: The 2012 Jeep Wrangler JK Command-Trac (NVG241 Gen II) low-range ratio is **2.72:1** per Jeep factory specification; the 4.0:1 unit is the Rubicon-only Rock-Trac (NV241OR), which this build no longer uses. Confirm against the JK FSM transfer-case section when finalizing crawl-ratio math.
+
 ## Outstanding Items
 
 - [ ] Measure 8HP70 output-shaft protrusion (≤~96 mm, else order DomiWorks spacer plate or shorten)

--- a/docs/jeep_lj/10-drivetrain/03-driveshafts.md
+++ b/docs/jeep_lj/10-drivetrain/03-driveshafts.md
@@ -1,25 +1,29 @@
 # 10.3 - Driveshafts
 
+Both driveshafts are custom units built to measured length by Tom Woods Custom Drive Shafts after the drivetrain and suspension are mocked up at final ride height.[^driveshaft-vendor]
+
 ## Front Driveshaft
 
 | Specification | Value |
 | :------------ | :---- |
-| Type | TBD |
-| Length | TBD |
-| U-Joint | TBD |
+| Type | Custom (Tom Woods Custom Drive Shafts) |
+| Length | TBD — measure at final ride height |
+| U-Joint | TBD — per Tom Woods build spec |
 
 ## Rear Driveshaft
 
 | Specification | Value |
 | :------------ | :---- |
-| Type | TBD |
-| Length | TBD |
-| U-Joint | TBD |
+| Type | Custom (Tom Woods Custom Drive Shafts) |
+| Length | TBD — measure at final ride height |
+| U-Joint | TBD — per Tom Woods build spec |
 
 ## Outstanding Items
 
-- [ ] Document front driveshaft specifications
-- [ ] Document rear driveshaft specifications
+- [ ] Measure front driveshaft length at final ride height and order from Tom Woods
+- [ ] Measure rear driveshaft length at final ride height and order from Tom Woods
+
+[^driveshaft-vendor]: Owner decision, 2026-05-30 — custom shafts sourced from Tom Woods Custom Drive Shafts; length and U-joint series are determined by Tom Woods from the measured working length at final ride height.
 
 ## Related Documentation
 

--- a/docs/jeep_lj/10-drivetrain/07-steering.md
+++ b/docs/jeep_lj/10-drivetrain/07-steering.md
@@ -90,7 +90,6 @@ Component part numbers below come from the PSC **FHK400TJ** kit — the 1997-200
 
 ## Outstanding Items
 
-- [ ] Confirm tire size to lock the kit variant — FHK400TJ (2.75" bore / 160cc valve, 40"+) vs FHK100TJ (2.5" bore / 125cc valve, 35-42")
 - [ ] Source a Cummins R2.8-compatible PSC pump + bracket (kit PK40JP2-FH is 4.0L-only)
 - [ ] Confirm pump drive type (belt vs Cummins gear-drive), flow rate, and pressure
 - [ ] Confirm the Dana 44 stroke length set by the Busted Knuckle stops

--- a/docs/jeep_lj/10-drivetrain/07-steering.md
+++ b/docs/jeep_lj/10-drivetrain/07-steering.md
@@ -17,52 +17,57 @@ tags:
 
 Full hydraulic steering with no mechanical linkage: a PSC pump feeds a PSC orbital steering control valve, which drives a double-ended ram. Ram stroke is limited to Dana 44 spec by Busted Knuckle Off-Road steering stops, and the ram mounts via an Artec Industries Dana 60 ram mount cut down to fit the Dana 44. A Mishimoto fluid cooler with fan (gated by a 180 °F inline thermostat) cools the circuit.[^steering-config]
 
+Component part numbers below come from the PSC **FHK400TJ** kit — the 1997-2006 TJ/LJ Extreme Series full hydraulic kit with a 2.75" double-ended cylinder (PSC's 40"+ tire kit).[^psc-kit] The orbital valve and cylinder carry over directly; the kit **pump is the exception** — its PK40JP2-FH bracket is Jeep 4.0L-specific and does not fit this build's Cummins R2.8.
+
 ## Specifications
 
 | Component | Specification |
 | :-------- | :------------ |
 | Type | Full hydraulic (no mechanical linkage) |
-| Manufacturer | PSC Motorsports |
-| Pump | PSC Motorsports (model TBD) |
-| Steering Control Valve | PSC orbital valve (model TBD) |
-| Ram | PSC double-ended (model TBD) |
-| Reservoir | TBD |
+| Kit | PSC FHK400TJ (TJ/LJ Extreme Series, 2.75" double-ended) |
+| Steering Control Valve | PSC 160cc orbital (in FHA160-S accessory kit) |
+| Ram | PSC SC2227K1 (2.75" × 8.0" double-ended) |
+| Pump | Cummins-specific PSC pump TBD (kit PK40JP2-FH is 4.0L-only) |
+| Reservoir | Remote (included with pump kit) — model TBD |
 | Cooler | Mishimoto fluid cooler + fan (180 °F inline thermostat) |
+| Fluid | PSC 715 (SWEPCO 715) |
 
 ## System Components
 
 ### Hydraulic Pump
 
+> **Pump is engine-specific — the kit pump does not fit.** The FHK400TJ kit ships a **PK40JP2-FH** pump kit built for the Jeep **4.0L** accessory drive. This build runs a **Cummins R2.8**, so the kit pump/bracket does not bolt up — a Cummins-compatible PSC pump must be sourced. The kit's orbital valve and cylinder are engine-agnostic and carry over unchanged.
+
 | Specification | Value |
 | :------------ | :---- |
 | Manufacturer | PSC Motorsports |
-| Model | TBD |
+| Model | TBD — Cummins R2.8 pump + bracket (NOT the kit's PK40JP2-FH) |
 | Flow Rate | TBD |
 | Pressure | TBD |
-| Drive | TBD (belt vs. Cummins gear-drive to confirm) |
+| Drive | TBD (belt vs. Cummins gear-drive) |
 
 ### Steering Control Valve
 
 | Specification | Value |
 | :------------ | :---- |
 | Type | Orbital (PSC) |
-| Model | TBD |
+| Model | 160cc — supplied in PSC FHA160-S accessory kit |
 
 ### Steering Ram
 
 | Specification | Value |
 | :------------ | :---- |
 | Type | Double-ended (PSC) |
-| Model | TBD |
-| Bore | TBD |
-| Stroke | Limited to Dana 44 spec via Busted Knuckle Off-Road steering stops |
+| Model | SC2227K1 |
+| Bore | 2.75" |
+| Stroke | 8.0" native; effective stroke limited to Dana 44 spec via Busted Knuckle Off-Road steering stops |
 | Mount | Artec Industries Dana 60 ram mount, cut down to fit the Dana 44 |
 
 ### Reservoir
 
 | Specification | Value |
 | :------------ | :---- |
-| Type | TBD |
+| Type | Remote (included with PSC pump kit) |
 | Capacity | TBD |
 | Location | TBD |
 
@@ -80,22 +85,24 @@ Full hydraulic steering with no mechanical linkage: a PSC pump feeds a PSC orbit
 
 | Specification | Value |
 | :------------ | :---- |
-| Fluid Type | TBD |
-| Capacity | TBD |
+| Fluid Type | PSC 715 (SWEPCO 715) |
+| Capacity | TBD (kit ships ~4 qt; confirm system fill) |
 
 ## Outstanding Items
 
-- [ ] Document PSC pump model, flow rate, pressure, and drive type
-- [ ] Document PSC orbital valve model
-- [ ] Document PSC double-ended ram model and bore
+- [ ] Confirm tire size to lock the kit variant — FHK400TJ (2.75" bore / 160cc valve, 40"+) vs FHK100TJ (2.5" bore / 125cc valve, 35-42")
+- [ ] Source a Cummins R2.8-compatible PSC pump + bracket (kit PK40JP2-FH is 4.0L-only)
+- [ ] Confirm pump drive type (belt vs Cummins gear-drive), flow rate, and pressure
 - [ ] Confirm the Dana 44 stroke length set by the Busted Knuckle stops
 - [ ] Document Artec Industries ram mount part number and the Dana 44 cut dimensions
-- [ ] Document reservoir type, capacity, and location
-- [ ] Document fluid type and capacity
+- [ ] Confirm remote reservoir model and mounting location
+- [ ] Confirm fluid system fill quantity
 - [ ] Document cooler fan current draw and power source (electrical integration + thermostat control)
 - [ ] Document hydraulic line routing
 
 [^steering-config]: Owner decision, 2026-05-30 — full-hydro kit is PSC pump + PSC orbital valve + PSC double-ended ram; Busted Knuckle Off-Road steering stops limit ram stroke to Dana 44 spec; Artec Industries Dana 60 ram mount cut down to the Dana 44; Mishimoto fluid cooler + fan on a 180 °F inline thermostat. Model numbers, bore/stroke values, flow/pressure, and fluid specs remain pending.
+
+[^psc-kit]: PSC Motorsports **FHK400TJ** — 1997-2006 Jeep TJ/LJ Extreme Series full hydraulic kit, 2.75" double-ended cylinder (PSC Motorsports / pscsteering.com, accessed 2026-05-31). Kit boxes: **FHA160-S** (160cc full-hydraulic accessory kit w/ orbital valve), **PK40JP2-FH** (high-flow pump kit — **Jeep 4.0L bracket**, not used here), **SC2227K1** (2.75" × 8.0" double-ended cylinder); fluid PSC/SWEPCO 715. Smaller-tire variant is **FHK100TJ** (2.5" bore / 125cc valve, 35-42"). Pump bracket is 4.0L-specific, so it does not fit this build's Cummins R2.8 — valve and cylinder carry over.
 
 ## Related Documentation
 

--- a/docs/jeep_lj/10-drivetrain/07-steering.md
+++ b/docs/jeep_lj/10-drivetrain/07-steering.md
@@ -15,16 +15,19 @@ tags:
 
 ///
 
+Full hydraulic steering with no mechanical linkage: a PSC pump feeds a PSC orbital steering control valve, which drives a double-ended ram. Ram stroke is limited to Dana 44 spec by Busted Knuckle Off-Road steering stops, and the ram mounts via an Artec Industries Dana 60 ram mount cut down to fit the Dana 44. A Mishimoto fluid cooler with fan (gated by a 180 °F inline thermostat) cools the circuit.[^steering-config]
+
 ## Specifications
 
 | Component | Specification |
 | :-------- | :------------ |
 | Type | Full hydraulic (no mechanical linkage) |
 | Manufacturer | PSC Motorsports |
-| Pump | TBD |
-| Steering Gear | TBD |
-| Ram | TBD |
+| Pump | PSC Motorsports (model TBD) |
+| Steering Control Valve | PSC orbital valve (model TBD) |
+| Ram | PSC double-ended (model TBD) |
 | Reservoir | TBD |
+| Cooler | Mishimoto fluid cooler + fan (180 °F inline thermostat) |
 
 ## System Components
 
@@ -32,19 +35,28 @@ tags:
 
 | Specification | Value |
 | :------------ | :---- |
+| Manufacturer | PSC Motorsports |
 | Model | TBD |
 | Flow Rate | TBD |
 | Pressure | TBD |
-| Drive | TBD |
+| Drive | TBD (belt vs. Cummins gear-drive to confirm) |
+
+### Steering Control Valve
+
+| Specification | Value |
+| :------------ | :---- |
+| Type | Orbital (PSC) |
+| Model | TBD |
 
 ### Steering Ram
 
 | Specification | Value |
 | :------------ | :---- |
+| Type | Double-ended (PSC) |
 | Model | TBD |
 | Bore | TBD |
-| Stroke | TBD |
-| Mount Type | TBD |
+| Stroke | Limited to Dana 44 spec via Busted Knuckle Off-Road steering stops |
+| Mount | Artec Industries Dana 60 ram mount, cut down to fit the Dana 44 |
 
 ### Reservoir
 
@@ -53,6 +65,16 @@ tags:
 | Type | TBD |
 | Capacity | TBD |
 | Location | TBD |
+
+### Cooler
+
+| Specification | Value |
+| :------------ | :---- |
+| Unit | Mishimoto fluid cooler |
+| Fan | Mishimoto (matched to cooler) |
+| Control | 180 °F inline thermostat |
+| Fan Current Draw | TBD |
+| Fan Power Source | TBD |
 
 ## Fluid Specifications
 
@@ -63,11 +85,17 @@ tags:
 
 ## Outstanding Items
 
-- [ ] Document PSC pump model and specifications
-- [ ] Document steering ram specifications
-- [ ] Document reservoir specifications
+- [ ] Document PSC pump model, flow rate, pressure, and drive type
+- [ ] Document PSC orbital valve model
+- [ ] Document PSC double-ended ram model and bore
+- [ ] Confirm the Dana 44 stroke length set by the Busted Knuckle stops
+- [ ] Document Artec Industries ram mount part number and the Dana 44 cut dimensions
+- [ ] Document reservoir type, capacity, and location
 - [ ] Document fluid type and capacity
+- [ ] Document cooler fan current draw and power source (electrical integration + thermostat control)
 - [ ] Document hydraulic line routing
+
+[^steering-config]: Owner decision, 2026-05-30 — full-hydro kit is PSC pump + PSC orbital valve + PSC double-ended ram; Busted Knuckle Off-Road steering stops limit ram stroke to Dana 44 spec; Artec Industries Dana 60 ram mount cut down to the Dana 44; Mishimoto fluid cooler + fan on a 180 °F inline thermostat. Model numbers, bore/stroke values, flow/pressure, and fluid specs remain pending.
 
 ## Related Documentation
 

--- a/docs/jeep_lj/10-drivetrain/07-steering.md
+++ b/docs/jeep_lj/10-drivetrain/07-steering.md
@@ -78,8 +78,8 @@ Component part numbers below come from the PSC **FHK400TJ** kit — the 1997-200
 | Unit | Mishimoto fluid cooler |
 | Fan | Mishimoto (matched to cooler) |
 | Control | 180 °F inline thermostat |
-| Fan Current Draw | TBD |
-| Fan Power Source | TBD |
+| Fan Current Draw | TBD (confirm fits PMU Out 8 ~15A budget) |
+| Fan Power Source | PMU Out 8 (~15A, thermostat-switched) — see [PMU Outputs][pmu-outputs] |
 
 ## Fluid Specifications
 
@@ -96,7 +96,7 @@ Component part numbers below come from the PSC **FHK400TJ** kit — the 1997-200
 - [ ] Document Artec Industries ram mount part number and the Dana 44 cut dimensions
 - [ ] Confirm remote reservoir model and mounting location
 - [ ] Confirm fluid system fill quantity
-- [ ] Document cooler fan current draw and power source (electrical integration + thermostat control)
+- [ ] Confirm Mishimoto cooler fan current draw fits the PMU Out 8 (~15A) budget
 - [ ] Document hydraulic line routing
 
 [^steering-config]: Owner decision, 2026-05-30 — full-hydro kit is PSC pump + PSC orbital valve + PSC double-ended ram; Busted Knuckle Off-Road steering stops limit ram stroke to Dana 44 spec; Artec Industries Dana 60 ram mount cut down to the Dana 44; Mishimoto fluid cooler + fan on a 180 °F inline thermostat. Model numbers, bore/stroke values, flow/pressure, and fluid specs remain pending.
@@ -110,3 +110,4 @@ Component part numbers below come from the PSC **FHK400TJ** kit — the 1997-200
 
 [front-axle]: 04-front-axle.md
 [suspension]: 06-suspension.md
+[pmu-outputs]: ../01-power-systems/04-pmu/03-pmu-outputs.md

--- a/docs/jeep_lj/10-drivetrain/index.md
+++ b/docs/jeep_lj/10-drivetrain/index.md
@@ -30,8 +30,8 @@ Complete drivetrain system documentation for the Jeep LJ build.
 
 - Transmission: ZF 8HP70 (845RE) - 8-speed automatic from 2015-2019 RAM 1500 EcoDiesel 4x4
 - Transfer Case: NV241 GenII Command-Trac (2012 JK Sport) - 2.72:1 low range
-- Front Driveshaft: TBD
-- Rear Driveshaft: TBD
+- Front Driveshaft: Custom (Tom Woods) - measure at final ride height
+- Rear Driveshaft: Custom (Tom Woods) - measure at final ride height
 
 **Suspension:**
 


### PR DESCRIPTION
## Summary

Rebased onto current `main` and expanded scope to clean up the Boomerang-era keyless TBDs that were re-introduced as open during PR #14's conflict resolution. PBS-I is the chosen keyless system per the keyless-ignition doc, so the obsolete rows have been removed and the real PBS-I install TBDs are now tracked centrally.

Open-item count: **58 (inconsistent) → 46 (consistent)**.

## Changes

### TBD Tracker (`docs/jeep_lj/09-installation/00-tbd-tracker.md`)

**Removed as obsolete / hallucinated:**
- `Boomerang Bullet 230`, `Boomerang Mounting Location` — product was fabricated (no vendor sells it)
- `Dash Push-Button (Keyless)` — PBS-I kit includes pre-wired Start Button
- `ECM Ignition Relay` — PBS-I PINK IGN (60A onboard) replaces it
- `P/N Interlock Relay` — 8HP70 + Turbolamik handle interlock; PBS-I has brake interlock
- `Engine-Running Lockout Relay`, `Engine-Running Voltage Filter` — relying on Bendix overrunning clutch + brake-required-to-crank UX
- `Hidden Bypass Toggle` — PBS-I Emergency Bypass Card (4-digit PIN via Programming Button)
- `PMU Output Strategy (Keyless)`, `PMU24 Keyless State Machine` — PMU not in keyless logic path
- `Keyless Firewall Pin Assignments` — resolved (pin 12 = PINK IGN, pin 15 = WAIT-gated PURPLE START)

**Added as real PBS-I install TBDs (mirrored from keyless-ignition doc per project rule #6):**

| Priority | Item |
| :--- | :--- |
| High | PBS-I Kit Order |
| High | WAIT-Gate Relay Part |
| High | ECM Pin 41 Inline Fuse (5A, per Cummins R2.8 install manual 0042728) |
| High | PBS-I Module Mounting Location |
| High | Start Button Mounting Location |
| Medium | Programming Button Storage |
| Medium | PBS-I Quiescent Current |
| Medium | PBS-I Feature Programming Defaults |

**Marked resolved:**
- `Solar Panel Wire Gauge` — already specified (10 AWG min for 2.23A Isc) in solar generation doc

**Refined descriptions:** `Transfer Case Specs`, `Front/Rear Driveshaft Specs`, `Steering Pump Specs`, `Steering Ram Specs`, `Steering Cooler Fan (electrical)`, `Steering Reservoir & Fluid`, `BIM Module Current Draw` (corrected to real module numbers).

**Reconciled count:** header was 58, priority-table sum was 51; both now consistently say 46.

**Fix:** added missing `[i29]` link reference (was used in the Critical-Spec Audit note but undefined).

### Drivetrain docs

- `03-driveshafts.md` — custom Tom Woods, measure at final ride height
- `02-transfer-case.md` — adds `[^tc-ratio]` footnote citing JK factory spec
- `07-steering.md` — locks PSC FHK400TJ kit (40"+ tires confirmed), documents pump caveat (kit pump is Jeep 4.0L-only, R2.8 pump TBD)
- `index.md` — driveshafts updated to Tom Woods

### Engine systems

- `03-pmu-outputs.md` — PMU Out 8 (PS Cooler Fan) trigger corrected from CAN coolant temp to 180°F inline thermostat (it's a PS-fluid cooler, not engine-coolant)

### Keyless ignition doc

- Removed stale "Assign firewall pins for PBS-I PINK IGN / WAIT-gated PURPLE START" outstanding-items checkbox — already resolved in `firewall-ingress.md` (pins 12/15)

## Triage findings (no change — genuinely open)

Verified remaining items require real-world decisions/measurements, not doc cleanup:

- Runaway protection cluster (AMOT turbo inlet OD, T-handle mounting, cable grommet, catch can bracket)
- Drivetrain section — suspension/steering/axle/driveshaft physical specs are real outstanding design decisions
- Critical-Spec Audit on-arrival items (iBooster body-neck Ø, MC inlet thread, radiator fan current) — tracked via #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)