### PR TITLE
docs(lj): replace fabricated keyless system with PBS-I + WAIT-gate relay

### DIFF
--- a/docs/jeep_lj/01-power-systems/01-power-generation/05-wire-distance-reference.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/05-wire-distance-reference.md
@@ -71,7 +71,7 @@ Distances required for voltage drop calculations and wire purchases. Measure act
 | CT4 (steering column)   | Passenger tail light     | 14 AWG | 16 ft ✓  | Turn signal rear                    |
 | PMU (engine bay)        | Rear tail lights         | 16 AWG | 13 ft ✓  | Brake/reverse/marker (Out 21/22/23) |
 | SwitchPros (wheel well) | Roll bar dome lights     | 16 AWG | ~8 ft    | Low current, estimated              |
-| Dash push-button        | PMU In 5                 | 18 AWG | 3 ft ✓   | Keyless ignition (via firewall Pin 15) |
+| PBS-I PURPLE START      | Cole Hersee 24213 coil   | 16 AWG | ~10 ft ✓ | Via WAIT-gate relay + firewall Pin 15  |
 | CT4 SW3 output          | PMU In 7                 | 18 AWG | 3 ft ✓   | Same as steering column → PMU       |
 
 ### Offroad Lighting (Priority: Medium)

--- a/docs/jeep_lj/01-power-systems/04-pmu/02-pmu-inputs.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/02-pmu-inputs.md
@@ -9,15 +9,15 @@ PMU input configuration including digital inputs, analog inputs, CAN bus integra
 
 ## 12V Switched Input (Pin 7)
 
-**Source:** Dedicated 18 AWG wire from ECM Ignition Relay output (relay driven by PMU OUT24 when state machine is in RUN or CRANK — see [Keyless Ignition][keyless-ignition])
+**Source:** Dedicated 18 AWG wire tapped from the ignition signal bus bar (which is fed by PBS-I PINK IGN output — see [Keyless Ignition][keyless-ignition] and [Ignition Signal Distribution][ignition-signal])
 
 **Function:** Provides switched power reference for PMU logic
 
-**Implementation:** Dedicated wire through firewall (Grommet 2) direct to PMU Pin 7 - NOT from ignition signal bus bar
+**Implementation:** Dedicated wire through firewall (Grommet 2) direct to PMU Pin 7
 
 **Load:** ~50mA
 
-See [Ignition Signal Distribution](#ignition-signal-distribution) for complete wiring architecture.
+See [Ignition Signal Distribution][ignition-signal] for complete wiring architecture.
 
 ## Digital Inputs (Trigger Sources)
 
@@ -28,17 +28,17 @@ See [Ignition Signal Distribution](#ignition-signal-distribution) for complete w
 | **In 1** | Horn Button          | Steering wheel button        | Out 18 (Horn)           | Normally open, closes when pressed       |
 | **In 2** | Brake Switch         | Brake pedal switch           | Out 21 (Brake Lights)   | Normally open, closes when pedal pressed |
 | **In 3** | Reverse Signal       | Turbolamik aux output (Reverse) | Out 22 (Reverse Lights) | 12V from TCU when 8HP70 in Reverse       |
-| **In 4** | Boomerang Fob Present | Bullet 230 transistor output | OUT24 logic (ignition)  | 12V active when RFID fob in range        |
-| **In 5** | Push Button (Start/Stop) | Dash momentary button     | OUT24 logic (state machine) | 12V on press; toggles ignition state  |
-| **In 6** | Turbolamik P/N        | Turbolamik P/N aux output    | OUT24 logic + crank gate | 12V when 8HP70 shifter in P or N        |
+| **In 4** | **\[Available\]**    | -                            | -                       | Available for future expansion           |
+| **In 5** | **\[Available\]**    | -                            | -                       | Available for future expansion           |
+| **In 6** | **\[Available\]**    | -                            | -                       | Available for future expansion           |
 | **In 7** | CT4 SW3 (Headlights) | CT4 lever pull               | Out 14 (DRL) logic      | 12V when headlights active, disables DRL |
 | **In 8** | **\[Available\]**      | -                            | -                       | Available for future expansion           |
 | **In 9** | A/C Request          | Factory TJ A/C button signal | Out 17 (A/C Clutch)     | 12V when factory dash A/C button pressed |
 
-**Note:** Keyless ignition state machine runs on PMU. OUT24 drives the ECM ignition relay coil and supplies the hardware crank chain (push button → brake → P/N relay → engine-running lockout → Cole Hersee 24213). See [Keyless Ignition][keyless-ignition] and [Starter System][starter].
+**Note:** Keyless ignition is handled entirely by the self-contained Digital Guard Dawg PBS-I module — PMU is not in the keyless logic path. See [Keyless Ignition][keyless-ignition].
 
-[starter]: ../../02-engine-systems/01-starter.md
 [keyless-ignition]: ../../05-control-interfaces/06-keyless-ignition.md
+[ignition-signal]: ../06-ignition-signal/index.md
 
 ## Analog Inputs
 
@@ -86,13 +86,13 @@ See [PMU Programming][pmu-programming] for CAN-based logic examples.
 
 ## Ignition Signal Distribution
 
-**PMU Pin 7:** Dedicated 18 AWG wire directly from ECM Ignition Relay output (NOT from ignition signal bus bar)
+**PMU Pin 7:** 18 AWG wire tapped from the engine-bay distribution off HDP24 Pin 12 (which crosses the firewall from the ignition signal bus bar, fed by PBS-I PINK IGN)
 
-**Routing:** Engine bay (relay → PMU Pin 7), no firewall crossing required
+**Routing:** Engine bay (firewall Pin 12 junction → PMU Pin 7)
 
-**Purpose:** Critical PMU functions have guaranteed power independent of other devices
+**Purpose:** Shares the same switched supply path as the Cummins ECM 12V — both energize whenever the PBS-I asserts PINK IGN.
 
-**Non-critical devices** (CT4, SwitchPros, radio, BCDC, camera) use shared ignition signal bus bar - see [Ignition Signal][ignition-signal] for details.
+**Non-critical devices** (CT4, SwitchPros, radio, BCDC, camera) tap directly off the cabin-mounted ignition signal bus bar - see [Ignition Signal][ignition-signal] for details.
 
 ## Related Documentation
 

--- a/docs/jeep_lj/01-power-systems/04-pmu/03-pmu-outputs.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/03-pmu-outputs.md
@@ -48,7 +48,7 @@ Complete configuration of all 24 PMU outputs, load allocations, and combined out
 | **Out 21** | Brake Lights             | ~3A  | [SwitchPros Ground Bus][switchpros-ground]            | External input      | Shared tail light ground       |
 | **Out 22** | Reverse Lights           | ~5A  | [SwitchPros Ground Bus][switchpros-ground]            | External input      | Maxbilt + Squadron Sport       |
 | **Out 23** | DRL/Parking Lights       | ~2A  | [SwitchPros Ground Bus][switchpros-ground]            | Auto (ignition)     | See [DRL & Parking][drl-parking-lights] |
-| **Out 24** | Ignition Authorize       | ~5A  | Via downstream loads                                  | PMU state machine   | Drives ECM ignition relay + supplies hardware crank chain (push button → brake → P/N → ER lockout → Cole Hersee). See [Keyless Ignition][keyless-ignition] |
+| **Out 24** | **[Available]**          | -    | -                                                     | -                   | Available for future expansion (7A)                                                                                                                          |
 
 ## Combined Outputs
 
@@ -119,4 +119,3 @@ Complete configuration of all 24 PMU outputs, load allocations, and combined out
 [hvac-system]: ../../02-engine-systems/03-hvac.md
 [windshield-wiper-control-system]: ../../02-engine-systems/04-wipers.md
 [drl-parking-lights]: ../../03-lighting-systems/05-drl-parking.md
-[keyless-ignition]: ../../05-control-interfaces/06-keyless-ignition.md

--- a/docs/jeep_lj/01-power-systems/04-pmu/index.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/index.md
@@ -15,7 +15,7 @@ Engine bay power distribution handled by ECUMaster PMU24, a programmable power m
 | :----------------- | :---------------- | :--------------------- | :--------- | :--------------------------------------------------------------------------------------------------------------- |
 | **Main Power**     | START battery+    | 2/0 AWG                | 250A CB    | Optimized for 220A max load with proper protection coordination - See [Circuit Breakers][front-circuit-breakers] |
 | **Ground**         | START battery-    | 2/0 AWG                | N/A        | Matches power wire gauge for 220A max load - See [Grounding Architecture][grounding]                             |
-| **Ignition Sense** | ECM Ignition Relay output | 18 AWG         | N/A        | Dedicated wire; relay driven by PMU OUT24 - see [PMU Inputs][pmu-inputs] and [Keyless Ignition][keyless-ignition] |
+| **Ignition Sense** | Ignition signal bus bar (engine bay distribution off HDP24 Pin 12) | 18 AWG         | N/A        | Sourced from PBS-I PINK IGN via the cabin ignition bus bar - see [PMU Inputs][pmu-inputs] and [Keyless Ignition][keyless-ignition] |
 | **CAN Bus**        | Cummins ECM J1939 | 18-20 AWG twisted pair | N/A        | Stub tap - see [PMU Inputs][pmu-inputs]                                                                          |
 
 ## System Components

--- a/docs/jeep_lj/01-power-systems/06-ignition-signal/index.md
+++ b/docs/jeep_lj/01-power-systems/06-ignition-signal/index.md
@@ -24,17 +24,18 @@ tags:
 
 ## Overview
 
-Distributes low-current 12V ignition sense signal to non-critical convenience devices. With the keyswitch removed (see [Keyless Ignition][keyless-ignition]), the bus bar input is now sourced from the **ECM Ignition Relay** — a switched relay driven by PMU OUT24 whenever the state machine is in RUN or CRANK.
+Distributes low-current 12V ignition sense signal to non-critical convenience devices. With the keyswitch removed (see [Keyless Ignition][keyless-ignition]), the bus bar input is now sourced from the **PBS-I PINK IGN output** (60A onboard relay inside the cabin-mounted PBS-I module). The PBS-I energizes PINK IGN whenever the system is in ACC (after 2 presses) or START mode; PINK does not drop during cranking.
 
 **Location:** Cabin side of firewall
 
 **Function:** Signal distribution only (not a power bus)
 
-!!! info "Critical Systems Use Dedicated Wires"
-Critical engine and power management systems take their own switched supply directly from the ECM Ignition Relay (or PMU OUT24 tap), NOT through this bus bar, for maximum reliability. This includes:
+!!! info "Engine-Bay Consumers Tap Through Firewall"
+The bus bar's outbound feed to engine-bay consumers (ECM 12V supply, PMU Pin 7) crosses the firewall on HDP24 Pin 12 — see [Firewall Ingress][firewall-ingress].
 
-    - **PMU 12V Switched Input (Physical Pin 7):** Direct wire from ECM Ignition Relay output - see [PMU Inputs][pmu-inputs]
-    - **Starter Control:** Hardware crank chain (push button → brake → P/N relay → engine-running lockout → Cole Hersee) supplied by PMU OUT24 - see [Starter System][starter-system] and [Keyless Ignition][keyless-ignition]
+    - **PMU 12V Switched Input (Physical Pin 7):** Wire tapped from the bus bar engine-bay distribution stud - see [PMU Inputs][pmu-inputs]
+    - **Cummins ECM 12V Supply:** Wire tapped from the same engine-bay distribution stud
+    - **Starter Control:** PBS-I PURPLE START output (separate firewall Pin 15) gates through WAIT-gate relay → Cole Hersee 24213 - see [Starter System][starter-system] and [Keyless Ignition][keyless-ignition]
 
     **Note:** PMU "Pin 7" (physical connector pin for 12V switched power) is different from PMU "In 7" (digital input channel #7 used for CT4 headlight status).
 
@@ -50,8 +51,8 @@ Critical engine and power management systems take their own switched supply dire
 
 | Stud/Terminal           | Connection                | Wire Gauge   | Distance              | Max Current     | Notes                                              |
 | :---------------------- | :------------------------ | :----------- | :-------------------- | :-------------- | :------------------------------------------------- |
-| **Stud 1 (5/16")**      | **ECM Ignition Relay output (INPUT)** | **18 AWG ✓** | **Through firewall (engine bay → cabin)** | **~80mA total** | **5A inline fuse at relay**                     |
-| Stud 2 (5/16")          | **\[Available\]**           | -            | -                     | -               | Future high-current signal                         |
+| **Stud 1 (5/16")**      | **PBS-I PINK IGN (INPUT)** | **14 AWG ✓** | **~2 ft (cabin local)** | **~5A total**   | No firewall crossing; PBS-I onboard 60A relay protects |
+| Stud 2 (5/16")          | **Engine-bay outbound (OUTPUT)** | 14 AWG ✓     | Through firewall (HDP24 Pin 12) | ~5A peak     | **5A inline fuse required at this stud** per Cummins R2.8 install manual; feeds ECM Pin 41 (black, keyswitch) + PMU Pin 7 |
 | Terminal 1 (#10-24)     | Command Touch CT4         | 18 AWG ✓     | ~3 ft                 | ~20mA           | Ignition sense for turn signal auto-cancel         |
 | Terminal 2 (#10-24)     | SwitchPros SP-1200        | 18 AWG ✓     | ~4 ft                 | ~20mA           | Pin 3 (Lt Blue) - ignition sense                   |
 | Terminal 3 (#10-24)     | Fusion MS-RA670 Radio     | 18 AWG ✓     | ~2 ft                 | ~20mA           | Yellow wire - ignition sense                       |
@@ -59,13 +60,13 @@ Critical engine and power management systems take their own switched supply dire
 | Terminal 5 (#10-24)     | **\[Available\]**           | -            | -                     | -               | Future ignition-switched device                    |
 | Terminals 6-12 (#10-24) | **\[Available\]**           | -            | -                     | -               | Future expansion (7 terminals)                     |
 
-**Utilization:** 5 of 14 used (1 stud + 4 terminals used, 1 stud + 8 terminals available)
+**Utilization:** 6 of 14 used (2 studs + 4 terminals used, 0 studs + 8 terminals available)
 
 ## Mounting
 
 **Location:** Cabin side of firewall, behind dash (former keyswitch location now repurposed)
 
-**Benefits:** Single firewall penetration (input only — from ECM Ignition Relay in engine bay), all outputs routed within cabin
+**Benefits:** PBS-I source is local (cabin), most consumers are cabin-side; single outbound firewall feed (Pin 12) serves engine-bay loads
 
 ## Related Documentation
 

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/02-firewall-ingress.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/02-firewall-ingress.md
@@ -46,7 +46,7 @@ RF interference analysis determined that with ferrite chokes on radio power lead
 
 ## Pin Assignment
 
-### Engine Bay → Cabin (6 wires)
+### Engine Bay → Cabin (5 wires)
 
 | Pin | Circuit | Gauge | Source | Destination | Contact |
 |:---:|:--------|:-----:|:-------|:------------|:-------:|
@@ -56,11 +56,8 @@ RF interference analysis determined that with ferrite chokes on radio power lead
 | 4 | Brake lights | 16 AWG | PMU OUT21 | Rear tail lights | #16 |
 | 5 | Reverse lights | 16 AWG | PMU OUT22 | Rear tail lights | #16 |
 | 6 | DRL/Parking | 16 AWG | PMU OUT23 | Rear tail lights | #16 |
-| 12 | Ignition signal bus feed + dash button supply | 18 AWG | ECM Ignition Relay output (EB) | Ignition signal bus bar (cabin); also taps to dash push-button supply | #16 |
 
-### Cabin → Engine Bay (10 wires)
-
-Pin 12 was reassigned from "Ignition sense" (cabin→EB) to "Ignition signal bus feed" (EB→cabin) when the keyswitch was removed.
+### Cabin → Engine Bay (11 wires)
 
 | Pin | Circuit | Gauge | Source | Destination | Contact |
 |:---:|:--------|:-----:|:-------|:------------|:-------:|
@@ -69,9 +66,10 @@ Pin 12 was reassigned from "Ignition sense" (cabin→EB) to "Ignition signal bus
 | 9 | Low beam headlights | 14 AWG | CT4 SW3 | LP6 Pin 1 (both) | #16 |
 | 10 | High beam headlights | 14 AWG | CT4 SW4 | LP6 Pin 4 (both) | #16 |
 | 11 | Horn button trigger | 18 AWG | Steering wheel button | PMU In 1 | #16 |
+| 12 | Ignition signal (outbound) | 14 AWG | Ignition signal bus bar Stud 2 (cabin) | ECM 12V supply + PMU Pin 7 (engine bay) | #16 |
 | 13 | Brake switch | 18 AWG | Brake pedal switch | PMU In 2 | #16 |
 | 14 | A/C request | 18 AWG | HVAC controls | PMU In 9 | #16 |
-| 15 | Push button → PMU + crank chain | 18 AWG | Dash push-button (NO) | PMU In 5 + brake switch start tap | #16 |
+| 15 | WAIT-gated PURPLE START | 16 AWG | WAIT-gate relay NC contact (cabin) | Cole Hersee 24213 coil+ | #16 |
 | 16 | Winch control IN | 18 AWG | Dash rocker switch | Winch contactor | #16 |
 | 17 | Winch control OUT | 18 AWG | Dash rocker switch | Winch contactor | #16 |
 
@@ -79,14 +77,9 @@ Pin 12 was reassigned from "Ignition sense" (cabin→EB) to "Ignition signal bus
 
 | Pin | Contact | Notes |
 |:---:|:-------:|:------|
-| A-D | #12 | Size 12 cavities — candidate slots for outstanding keyless system signals (fob present, gated start return); will need size 16→12 reducer crimps or size 12 contacts on 18 AWG wires |
+| A-D | #12 | Size 12 cavities — available for future expansion (e.g., higher-current circuits requiring size 12 contacts) |
 
-**Keyless Ignition Outstanding Pins:** Two additional pins still need allocation:
-
-1. **Boomerang fob present** (cabin → EB): Bullet 230 output to PMU In 4
-2. **Gated start return** (cabin → EB): brake switch start tap → engine bay P/N relay
-
-Current 17 size-16 contacts are fully assigned. Options under consideration in [Keyless Ignition][keyless-ignition]: use two of the size-12 reserved cavities, or add a small secondary connector for keyless signals.
+Connector is fully populated on size-16 contacts (17/17 used). Size-12 cavities remain available.
 
 ---
 
@@ -118,10 +111,10 @@ Radio grounds do NOT go through firewall - they route through cab floor to START
 
 | Gauge | Count | Circuits |
 |:------|:-----:|:---------|
-| 14 AWG | 6 | Radio power (2), CT4 outputs (4) |
-| 16 AWG | 3 | PMU lighting outputs |
-| 18 AWG | 7 | Switch signals (5), winch control (2) |
-| **Main Connector** | **16** | HDP24-24-21 (1 spare cavity at pin 2 + 4 reserved size 12) |
+| 14 AWG | 7 | Radio power (2), CT4 outputs (4), PBS-I PINK IGN (1) |
+| 16 AWG | 4 | PMU lighting outputs (3), WAIT-gated PURPLE START (1) |
+| 18 AWG | 6 | Switch signals (4), winch control (2) |
+| **Main Connector** | **17** | HDP24-24-21 (1 spare cavity at pin 2 + 4 reserved size 12) |
 | 22 AWG | 2 | Temp probe (separate grommet) |
 
 ---

--- a/docs/jeep_lj/02-engine-systems/01-starter.md
+++ b/docs/jeep_lj/02-engine-systems/01-starter.md
@@ -52,46 +52,41 @@ tags:
 
 **Control Solenoid:** Cole Hersee 24213 (85A continuous-duty)
 
-**Safety Interlock:** PMU24 state machine (OUT24) supplies a hardware crank chain — push button + brake pedal switch + Turbolamik P/N relay + engine-running lockout (all four gates required). See [Keyless Ignition][keyless-ignition] for the full architecture.
+**Safety Interlock:** PBS-I keyless ignition module sources the crank signal (60A PURPLE START output). Brake interlock and RFID authorization are inside the PBS-I. A single external SPST WAIT-gate relay blocks cranking while the Cummins WAIT-to-Start lamp is on (cold-start grid heater preheat). See [Keyless Ignition][keyless-ignition] for the full architecture.
 
 **Battery Requirement:** 800 CCA minimum (Odyssey PC1500 provides 850 CCA)
 
 ## Wiring
 
-| Circuit               | Source                   | Destination                       | Wire Gauge | Current  | Notes                                                            |
-| :-------------------- | :----------------------- | :-------------------------------- | :--------- | :------- | :--------------------------------------------------------------- |
-| Main Power            | START battery+           | Starter solenoid battery post     | 2/0 AWG    | 400-600A | See [START Battery Distribution][starter-battery] for wire specs |
-| Solenoid Power Tap    | START battery post       | Cole Hersee 24213 input           | 10 AWG     | 30-75A   | ~2 ft                                                            |
-| Crank Chain Supply    | PMU OUT24                | Dash push-button supply (cabin)   | 18 AWG     | ~1.6A    | Asserted by PMU state machine; routed through firewall to cabin  |
-| Push Button Output    | Dash push-button         | Brake switch (start tap)          | 18 AWG     | ~1.6A    | Cabin                                                            |
-| Brake-gated Start     | Brake switch (start tap) | Firewall Pin 15 → P/N relay contact | 18 AWG   | ~1.6A    | Via Deutsch HDP24-24-21 Pin 15                                   |
-| P/N Relay Coil        | Turbolamik P/N aux output| P/N interlock relay coil          | 18 AWG     | ~0.1A    | Engine bay; energized when shifter in P or N                     |
-| P/N Relay Output      | P/N interlock relay (NO) | Engine-running lockout relay      | 18 AWG     | ~1.6A    | Engine bay                                                       |
-| Engine-Run Relay Coil | Alternator B+ (filtered) | Engine-running relay coil         | 18 AWG     | ~0.1A    | Diode + zener filter; >13V threshold = engine running            |
-| Lockout-gated Drive   | Engine-running relay NC  | Cole Hersee 24213 coil+           | 16 AWG     | ~1.6A    | NC contacts: closed when engine off, opens once running          |
-| Solenoid Coil Ground  | Cole Hersee 24213 coil-  | Engine bay ground bus             | 16 AWG     | ~1.6A    | ~3 ft                                                            |
-| Solenoid Output       | Cole Hersee 24213 output | Starter solenoid switch post      | 10 AWG     | 30-75A   | ~2 ft                                                            |
-| Ground Return         | Starter case             | Engine block → START battery-     | 2/0 AWG    | 400-600A | Via engine bay ground bus                                        |
+| Circuit               | Source                          | Destination                       | Wire Gauge | Current  | Notes                                                            |
+| :-------------------- | :------------------------------ | :-------------------------------- | :--------- | :------- | :--------------------------------------------------------------- |
+| Main Power            | START battery+                  | Starter solenoid battery post     | 2/0 AWG    | 400-600A | See [START Battery Distribution][starter-battery] for wire specs |
+| Solenoid Power Tap    | START battery post              | Cole Hersee 24213 input           | 10 AWG     | 30-75A   | ~2 ft                                                            |
+| Start Signal (cabin)  | PBS-I PURPLE START output       | WAIT-gate relay COM (NC input)    | 14 AWG     | ~1.6A    | PBS-I output rated 60A but only Cole Hersee coil downstream      |
+| Gated Start (firewall)| WAIT-gate relay NC contact      | Firewall pin TBD → Cole Hersee coil+ | 16 AWG  | ~1.6A    | Open while WAIT-to-Start lamp on; closed otherwise               |
+| Solenoid Coil Ground  | Cole Hersee 24213 coil-         | Engine bay ground bus             | 16 AWG     | ~1.6A    | ~3 ft                                                            |
+| Solenoid Output       | Cole Hersee 24213 output        | Starter solenoid switch post      | 10 AWG     | 30-75A   | ~2 ft                                                            |
+| Ground Return         | Starter case                    | Engine block → START battery-     | 2/0 AWG    | 400-600A | Via engine bay ground bus                                        |
+
+See [Keyless Ignition][keyless-ignition] for PBS-I power, brake input, and WAIT-gate relay coil wiring.
 
 ## Control Flow
 
 ```text
-PMU OUT24 (Ignition Authorize) → Push Button (cabin) → Brake Switch → Pin 15 (firewall) →
-                                                          P/N Relay (coil = Turbolamik P/N) →
-                                                          Engine-Running Lockout Relay (NC, coil = alternator) →
-                                                              ↓
-                                                          Cole Hersee 24213 Coil → Ground
-                                                              ↓
-                                                          Solenoid Closes (all four gates asserted)
-                                                              ↓
-                              START battery Post → Cole Hersee Output → Starter Switch Post
-                                                              ↓
-                                                          Main Solenoid Engages
-                                                              ↓
-                                                              Starter Cranks
-                                                              ↓
-                                                  Engine starts → alternator output rises →
-                                                  Engine-Running Relay opens → Cole Hersee de-energized
+Driver presses brake + holds Start Button (PBS-I-mounted)
+            ↓
+PBS-I (cabin) authenticates fob → asserts PINK IGN (ECM powers up) and PURPLE START
+            ↓
+WAIT-gate relay (NC): closed if WAIT lamp off → start signal passes through
+                       open  if WAIT lamp on  → wait for grid heater to finish
+            ↓
+PBS-I PURPLE START → Firewall pin → Cole Hersee 24213 coil → Ground
+            ↓
+Cole Hersee main contacts close
+            ↓
+START battery → Cole Hersee output → Starter switch post → Bendix engages → cranks
+            ↓
+Engine starts → driver releases button → Cole Hersee de-energizes → Bendix retracts
 ```
 
 ## Starter Motor Terminals
@@ -122,12 +117,12 @@ PMU OUT24 (Ignition Authorize) → Push Button (cabin) → Brake Switch → Pin 
 
 - Large Stud 1 (Input): From START battery post (M8 terminal, 10 AWG)
 - Large Stud 2 (Output): To starter switch post (6.3mm female push-on, 10 AWG)
-- Small Terminal 1 (Coil+): From engine-running lockout relay NC output (16-18 AWG)
+- Small Terminal 1 (Coil+): From WAIT-gate relay NC contact (16 AWG, gated PBS-I PURPLE START)
 - Small Terminal 2 (Coil-): To engine bay ground bus (16-18 AWG)
 
 ## Outstanding Items
 
-Starter-circuit-specific items are tracked in the [Keyless Ignition][keyless-ignition] doc and the [TBD Tracker][tbd-tracker], since the new crank chain is part of the keyless ignition design.
+Starter-circuit-specific items are tracked in the [Keyless Ignition][keyless-ignition] doc and the [TBD Tracker][tbd-tracker], since the crank chain is sourced from the keyless ignition design.
 
 See [installation checklist][install-checklist] for build tasks.
 
@@ -140,7 +135,7 @@ See [installation checklist][install-checklist] for build tasks.
 - [Engine Bay Ground Bus][engine-bay-ground-bus] - Ground connections
 - [Power Generation][power-generation] - Battery specifications
 - [Wire Distance Reference][wire-distance] - Starter to battery routing distances
-- [Keyless Ignition][keyless-ignition] - State machine driving OUT24 and the crank chain
+- [Keyless Ignition][keyless-ignition] - PBS-I sources PURPLE START; WAIT-gate relay gates on grid heater lamp
 
 [db-starter]: https://www.dbelectrical.com/products/starter-for-2-8-cummins-isf2-8-qsb3-9-30-qsb4-5-4996706-428000-7090.html
 [starter-battery-distribution]: ../01-power-systems/02-starter-battery-distribution/index.md

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/01-hdx-control.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/01-hdx-control.md
@@ -95,14 +95,14 @@ Main control box for HDX instrument system. Processes sensor inputs, BIM module 
 | **IGNITION PWR**         | 16 AWG      | Ignition bus bar             | HDX ignition input      | Switched 12V for ignition-controlled features    |
 | **12 VDC CONSTANT**      | 16 AWG ✓    | Critical Cabin PDU Slot 2    | HDX power input         | 10A fuse, CONSTANT power, ~2 ft                  |
 | **DIM**                  | 18 AWG ✓    | Tail light circuit           | HDX DIM input           | Dash dimming control (variable voltage)          |
-| **ENGINE**               | 18 AWG ✓    | ECM harness                  | HDX ENGINE input        | Check engine light / MIL signal (active low)     |
+| **ENGINE**               | 18 AWG ✓    | ECM Pin 22 (white wire, MIL) | HDX ENGINE input        | Check engine light / MIL signal — sink-circuit (active low at wire) per Cummins R2.8 manual |
 | **BRAKE**                | 18 AWG ✓    | Brake switch or CT4          | HDX BRAKE input         | Brake pedal indicator                            |
 | **HIGH**                 | 18 AWG ✓    | CT4 high beam output         | HDX HIGH input          | High beam indicator                              |
 | **LEFT**                 | 18 AWG ✓    | CT4 left turn output         | HDX LEFT input          | Left turn indicator                              |
 | **RIGHT**                | 18 AWG ✓    | CT4 right turn output        | HDX RIGHT input         | Right turn indicator                             |
 | **4x4/EX**               | 18 AWG ✓    | Transfer case switch         | HDX 4x4/EX input        | 4WD/4LO indicators                               |
 | GEAR                     | -           | BIM-01-2 J1939               | -                       | Gear position read from Turbolamik J1939 broadcast (no discrete input wiring) |
-| **WAIT/EX**              | 18 AWG ✓    | ECM harness                  | HDX WAIT/EX input       | Wait-to-start indicator (active high)            |
+| **WAIT/EX**              | 18 AWG ✓    | ECM Pin 35 (yellow wire, WAIT TO START) | HDX WAIT/EX input | Sink-circuit per Cummins R2.8 manual — wire is active LOW (~0V when WAIT on, ~+12V when off). HDX input documented as "active high" — polarity needs bench verification during install (HDX may invert internally, or LJ build docs may be mislabeled). Also tapped by WAIT-gate relay coil-, see [Keyless Ignition][keyless-link] |
 | EX                       | -           | -                            | -                       | Reserved                                         |
 | EX                       | -           | -                            | -                       | Reserved                                         |
 | WARN OUT                 | -           | -                            | -                       | Not used                                         |
@@ -124,7 +124,7 @@ All BIM modules connect via single daisy-chain harness from HDX control 3.5mm po
 
 - [ ] Determine 4WD/4LO indicator signal types (NP241 Rubicon transfer case outputs)
 - [ ] Determine brake indicator source (brake switch vs CT4 output)
-- [ ] Identify specific ECM harness pins for ENGINE (CEL) and WAIT signals
+- [ ] Bench-verify WAIT/EX polarity at HDX input — Cummins manual specifies active-low sink-circuit, but HDX docs list "active high"; resolve before final wiring
 
 ## Related Documentation
 
@@ -134,7 +134,8 @@ All BIM modules connect via single daisy-chain harness from HDX control 3.5mm po
 - [PMU Outputs][pmu-outputs] - Power source (OUT9)
 - [Ignition Signal Distribution][ignition-bus] - Ignition power source
 - [Command Touch CT4][ct4] - Lighting signal sources (turn, high beam, etc.)
-- [Cummins R2.8 ECM][ecm] - WAIT/EX and ENGINE (CEL) signal sources
+- [Cummins R2.8 ECM][ecm] - WAIT/EX (Pin 35 yellow) and ENGINE/MIL (Pin 22 white) signal sources
+- [Keyless Ignition][keyless-link] - WAIT-gate relay coil shares the Pin 35 signal tap
 
 [manual-link]: https://www.dakotadigital.com/pdf/HDX_manual_main.pdf
 [gauge-system]: index.md
@@ -144,3 +145,4 @@ All BIM modules connect via single daisy-chain harness from HDX control 3.5mm po
 [ignition-bus]: ../../01-power-systems/06-ignition-signal/index.md
 [ct4]: ../../05-control-interfaces/03-command-touch-ct4.md
 [ecm]: ../index.md
+[keyless-link]: ../../05-control-interfaces/06-keyless-ignition.md

--- a/docs/jeep_lj/05-control-interfaces/01-overview.md
+++ b/docs/jeep_lj/05-control-interfaces/01-overview.md
@@ -28,10 +28,10 @@ This section documents all control interfaces in the Jeep LJ build - the switche
   - Other dash-mounted controls
 
 - **[Keyless Ignition][keyless-ignition]** - RFID + push-button start/stop replacing the factory keyswitch
-  - Boomerang Bullet 230 RFID fob anti-theft
-  - Single dash push-button (start/stop)
-  - PMU24 runs the ignition state machine
-  - Hidden hardwired bypass for emergencies
+  - Digital Guard Dawg PBS-I self-contained module with RFID iTag fobs
+  - Single dash push-button included with kit
+  - WAIT-gate relay handles cold-start grid heater preheat automatically
+  - Emergency Bypass Card with 4-digit PIN (no hidden toggle)
 
 ## System Integration
 

--- a/docs/jeep_lj/05-control-interfaces/06-keyless-ignition.md
+++ b/docs/jeep_lj/05-control-interfaces/06-keyless-ignition.md
@@ -6,191 +6,188 @@ tags:
   - control-interfaces
   - ignition
   - keyless
-  - boomerang
+  - pbs-i
 ---
 
 # 5.6 Keyless Ignition System {#keyless-ignition}
 
-Modern push-button ignition for the Cummins R2.8 + 8HP70 build. Replaces the factory keyswitch entirely. Single dash button starts and stops the engine. Boomerang Bullet 230 RFID provides theft deterrence. State machine runs on the PMU24.
+Push-button ignition for the Cummins R2.8 + 8HP70 build. Replaces the factory keyswitch entirely. Self-contained Digital Guard Dawg PBS-I handles RFID immobilizer, brake interlock, and ACC/IGN/START sequencing internally. One external SPST relay gates cranking through the diesel wait-to-start lamp so cold-day starts auto-wait for grid heater preheat. PMU is not involved.
 
 ## Architecture
 
 /// html | div.product-info
 
-**Type:** RFID-enabled push-button start/stop with diesel-specific interlocks
+**Module:** Digital Guard Dawg PBS-I (Intelligent Push Button Start)
 
-**Anti-theft:** Boomerang Bullet 230 (RFID fob required to enable)
+**Type:** RFID-enabled push-button start/stop with onboard 60A relays for IGN, START, ACC1, ACC2
 
-**State Machine:** PMU24 firmware (logic in `04-pmu-programming.md`)
+**Anti-theft:** Built-in dual-mode (passive + active) RFID iTag fob
 
-**Crank Interlocks:** Brake pedal + Turbolamik P/N + engine-running lockout
+**Diesel preheat handling:** External SPST WAIT-gate relay gates PURPLE START output through Cummins WAIT-to-Start lamp signal
 
-**Emergency Bypass:** Hidden hardwired toggle (get-home mode)
+**Brake interlock:** Built into PBS-I (Accessory Harness Brake input)
+
+**Emergency Bypass:** Built-in 4-digit PIN entered via Programming Button (no hidden toggle)
+
+**Product Page:** [Digital Guard Dawg PBS-I][pbs-i]
+
+**Install Manual:** [PBS-I Manual PDF][pbs-i-manual]
 
 ///
 
 ## Components
 
-### Boomerang Bullet 230 (RFID Immobilizer)
+### Digital Guard Dawg PBS-I
 
-| Specification     | Value                                            |
-| :---------------- | :----------------------------------------------- |
-| Type              | RFID transponder + fob                           |
-| Detection Range   | 3-6 ft                                           |
-| Output            | Single transistor output (12V when fob in range) |
-| Power             | 12V CONSTANT (so fob can be detected key-off)    |
-| Mounting          | Under dash, near driver position                 |
-| Product Page      | [Boomerang Bullet 230][boomerang]                |
+| Specification | Value |
+| :------------ | :---- |
+| Type | RFID push-button start, self-contained |
+| Onboard Relays | 4× 60A (IGN, START, ACC1 drops during crank, ACC2 stays on during crank) |
+| Inrush Capacity | 300A |
+| Supply Voltage | 12V DC |
+| Detection Range | ~10 ft (iTag fob) |
+| Auto-arm | 60 sec after fob leaves range |
+| Module Dimensions | ~5.5" × 3" × 1.25" |
+| Wiring | Heavy-duty Molex high-current connectors, 12 GA bus wiring |
+| Mounting | **Cabin, under dash** (vendor mandate: do NOT mount in engine bay) |
+| Kit Contents | ICM + 2 iTag fobs + Start Button (36" pre-wired harness) + Programming Button + Bypass Card + 4-digit PIN |
 
-### Dash Push-Button
+### WAIT-gate Relay
 
-| Specification     | Value                                            |
-| :---------------- | :----------------------------------------------- |
-| Type              | Momentary, normally open, illuminated            |
-| Diameter          | 19mm or 22mm panel mount                         |
-| Illumination      | LED, driven by PMU (state feedback)              |
-| Mounting          | Dash, within easy reach from driver seat         |
-| Part              | TBD (Otto P9-113121 or equivalent)               |
+Single SPST automotive relay with normally-closed contacts. Blocks PBS-I's START output from reaching the Cole Hersee coil while the Cummins WAIT-to-Start lamp is illuminated.
 
-### ECM Ignition Relay
+The Cummins R2.8 ECM uses a **sink-circuit lamp topology** (per Cummins R2.8 install manual, document 0042728): keyswitch +12V → lamp → ECM Pin 35 (yellow) → ECM internal sink to ground when condition is active. The WAIT signal at Pin 35 is therefore **active LOW** (~0V when WAIT lamp on, ~+12V when WAIT lamp off).
 
-| Specification     | Value                                            |
-| :---------------- | :----------------------------------------------- |
-| Type              | Automotive SPST, 30/40A                          |
-| Coil              | 12V DC, ~150 mA draw                             |
-| Contacts          | Switches Cummins ECM 12V supply                  |
-| Mounting          | Engine bay, near ECM                             |
-| Part              | TBD (Hella H41730011 or Bosch 0332019150)        |
+| Specification | Value |
+| :------------ | :---- |
+| Type | SPST automotive, 30A continuous, NC contacts in start path |
+| Coil | 12V DC, ~150 mA |
+| Coil+ | Switched +12V (tap from ignition signal bus bar — same source as the WAIT lamp itself) |
+| Coil- | ECM Pin 35 (yellow WAIT-to-Start wire) tap on cabin side (shared with HDX WAIT/EX input) |
+| Contacts | NC; close when WAIT lamp off, open when WAIT lamp on |
+| Mounting | Cabin, adjacent to PBS-I |
+| Suggested Part | Bosch 0332019150 or Hella 4RA 003 510-04 (TBD) |
 
-### P/N Interlock Relay
+**Logic:**
 
-| Specification     | Value                                            |
-| :---------------- | :----------------------------------------------- |
-| Type              | Automotive SPST, 30A                             |
-| Coil              | 12V DC, driven by Turbolamik P/N aux output      |
-| Contacts          | NO; in series with crank circuit                 |
-| Mounting          | Engine bay, near Cole Hersee 24213               |
-| Part              | TBD                                              |
+- WAIT lamp ON (preheating) → ECM sinks Pin 35 to ground → ~12V across coil → coil energized → NC opens → start chain blocked
+- WAIT lamp OFF (ready or no preheat needed) → Pin 35 floats to ~+12V via lamp → ~0V across coil → coil de-energized → NC closes → start chain passes
 
-### Engine-Running Lockout Relay
+### Cole Hersee 24213 Solenoid
 
-Prevents Cole Hersee from energizing while the engine is running, even if the start button is pressed with brake + P/N held. Protects the starter from Bendix engagement against a spinning flywheel.
+Unchanged from existing starter design. See [Starter System][starter].
 
-| Specification     | Value                                            |
-| :---------------- | :----------------------------------------------- |
-| Type              | Automotive SPST, 30A                             |
-| Coil              | 12V DC, driven by alternator output (~14V when running) |
-| Coil Trigger      | Simple diode + zener filter on alternator B+ tap (>13V threshold) |
-| Contacts          | NC; opens when engine running                    |
-| Mounting          | Engine bay, near Cole Hersee 24213               |
-| Part              | TBD                                              |
+## Daily Start Sequence
 
-## State Machine
+**Warm engine (no preheat cycle):**
 
-| Current State | Trigger                                              | Action                                       | New State |
-| :------------ | :--------------------------------------------------- | :------------------------------------------- | :-------- |
-| OFF           | Fob detected + button press                          | Assert OUT24 (ECM powered)                   | RUN       |
-| OFF           | Fob detected + button + brake + P/N                  | Assert OUT24 → hardware crank chain closes   | CRANK     |
-| CRANK         | J1939 RPM > 500 (engine running)                     | Engine-running relay opens, crank disengages | RUN       |
-| RUN           | Button press (with or without brake)                 | De-assert OUT24, ECM loses power, engine off | OFF       |
-| Any           | Hold button > 3 sec                                  | Force OFF (emergency)                        | OFF       |
-| Any           | Fob lost while moving (RPM > 0)                      | Stay in current state, log alarm             | unchanged |
-| OFF           | Button press, fob NOT detected                       | No action, optional alarm chirp              | OFF       |
+1. Approach vehicle — iTag fob in pocket — Start Button LED illuminates
+2. Press brake pedal — Start Button LED begins flashing
+3. Press and hold Start Button — starter cranks immediately, release on engine start
 
-**Fob-lost behavior:** If the fob leaves range while driving, the PMU does not kill the engine — only blocks re-start at the next OFF cycle. Modern-car convention; prevents stranding on dead fob battery.
+**Cold engine (grid heater active):**
+
+1. Approach — fob recognized — Start Button LED illuminates
+2. Press brake + press and hold Start Button
+3. PBS-I energizes PINK IGN immediately → ECM powers up → grid heater runs → WAIT-to-Start lamp illuminates
+4. PBS-I asserts PURPLE START, but WAIT-gate relay holds it open while WAIT lamp on — **keep holding button**
+5. ~3-5 seconds later (per [Grid Heater][grid-heater]), WAIT lamp extinguishes → WAIT-gate relay NC closes → starter cranks
+6. Release on engine start
+
+**Shut off:** Press brake + press and hold Start Button for 2 seconds.
+
+**Accessory-only mode** (e.g., radio without engine): press button once without brake — ACC2 energizes. Second press adds ACC1 + IGN.
+
+**Emergency bypass** (lost or damaged fob): Use Programming Button + 4-digit PIN from the Bypass Card stored in wallet. See [PBS-I Manual][pbs-i-manual].
 
 ## Wiring
 
-### PMU24 I/O (new)
+### PBS-I Power Harness (6 wires)
 
-| PMU Channel | Function                                | Source                       | Destination               | Notes                          |
-| :---------- | :-------------------------------------- | :--------------------------- | :------------------------ | :----------------------------- |
-| **In 4**    | Boomerang fob present                   | Bullet 230 transistor output | PMU In 4                  | 12V active when fob in range   |
-| **In 5**    | Push button                             | Dash button (NO contact)     | PMU In 5                  | Pulled up; goes high on press  |
-| **In 6**    | Turbolamik P/N                          | Turbolamik P/N aux output    | PMU In 6                  | 12V active when in P or N      |
-| **Out 24**  | Ignition Authorize                      | PMU OUT24                    | ECM ignition relay + start circuit supply | ~5A, switched by PMU logic |
+| Wire | Function | Source | Destination | Notes |
+| :--- | :------- | :----- | :---------- | :---- |
+| RED | +12V Battery | Critical Cabin PDU (CONSTANT) | PBS-I module | 14 AWG; ~50 mA standby (TBD verify) |
+| BLACK | Chassis Ground | Cabin ground bus | PBS-I module | 14 AWG |
+| PINK | 1st Ignition Out (60A) | PBS-I module | Ignition signal bus bar (cabin) | Does NOT drop during crank; bus bar Stud 2 outbounds to ECM Pin 41 via 5A inline fuse per Cummins spec |
+| PURPLE | Starter Out (60A) | PBS-I module | WAIT-gate relay common (NC input) | Cranks while button held |
+| PINK/BLK | Accessory 1 (60A) | PBS-I module | **[Reserve]** | Drops during crank |
+| BROWN | Accessory 2 (60A) | PBS-I module | **[Reserve]** | Stays on during crank |
 
-J1939 RPM is read via the existing CAN bus connection ([PMU Inputs - CAN][pmu-inputs]). No new wire needed for the engine-running input to the state machine.
+### PBS-I Accessory Harness (2 wires used)
 
-### Power & Control Wiring
+| Wire | Function | Source | Destination | Notes |
+| :--- | :------- | :----- | :---------- | :---- |
+| BROWN | Brake (+) input | Stop-lamp switch cold side | PBS-I Brake input | T-tap shared with PMU In 2 and Turbolamik brake input |
+| PURPLE | Ground upon Disarm | PBS-I module | **[Reserve]** | Active-low fob-present signal; available for future use |
 
-| Connection                 | Wire Gauge | Source                       | Destination                          | Notes                                |
-| :------------------------- | :--------- | :--------------------------- | :----------------------------------- | :----------------------------------- |
-| Boomerang power            | 18 AWG     | Critical Cabin PDU (CONSTANT)| Bullet 230 +12V input                | ~50 mA standby; CONSTANT required    |
-| Boomerang ground           | 18 AWG     | Cabin ground bus             | Bullet 230 ground                    |                                      |
-| Boomerang → PMU In 4       | 18 AWG     | Bullet 230 transistor output | Firewall Pin (TBD) → PMU In 4        | Cabin → Engine Bay                   |
-| Push button signal         | 18 AWG     | Dash button NO contact       | Firewall Pin 15 → PMU In 5           | Cabin → Engine Bay                   |
-| Push button LED supply     | 22 AWG     | PMU OUT24 (or dedicated tap) | Button LED+                          | Illuminates when ignition authorized |
-| Button LED ground          | 22 AWG     | Button LED-                  | Cabin ground bus                     |                                      |
-| OUT24 → ECM relay coil     | 18 AWG     | PMU OUT24                    | ECM ignition relay coil+             | Engine bay                           |
-| OUT24 → crank supply       | 18 AWG     | PMU OUT24                    | Push button supply (cabin)           | Engine Bay → Cabin (firewall)        |
-| Start chain (cabin)        | 18 AWG     | Push button output (gated)   | Brake switch start tap               | Cabin                                |
-| Start chain (firewall)     | 18 AWG     | Brake switch start tap       | Firewall Pin (TBD) → P/N relay       | Cabin → Engine Bay                   |
-| P/N relay coil             | 18 AWG     | Turbolamik P/N aux output    | P/N interlock relay coil             | Engine bay                           |
-| ER lockout coil            | 18 AWG     | Alternator B+ (via filter)   | Engine-running relay coil            | Engine bay; opens contacts when RPM up |
-| Cole Hersee drive          | 16 AWG     | ER lockout relay NC output   | Cole Hersee 24213 coil+              | Engine bay                           |
-| Hidden bypass toggle       | 18 AWG     | Battery+ (via fuse)          | ECM ignition relay coil+ (parallel)  | Get-home mode, hidden under dash     |
+### Start and Programming Buttons
 
-### Firewall Pin Assignments
+| Connector | Connection | Notes |
+| :-------- | :--------- | :---- |
+| Start Button | Pre-wired 36" harness → PBS-I side port | Dash mount; included in kit |
+| Programming Button | Pre-wired harness → PBS-I side port | Stash under dash or in trunk; needed only for fob-learn and emergency bypass PIN entry |
 
-Three pins are used by the keyless system. Pin 15 was reassigned from the prior P/N interlock placeholder (the P/N signal now stays in the engine bay since PMU and Turbolamik are co-located).
+### WAIT-Gate Relay
 
-| Pin | Direction       | Signal                          | Source                | Destination          |
-| :-- | :-------------- | :------------------------------ | :-------------------- | :------------------- |
-| 15  | Cabin → EB      | Push button signal              | Dash button NO        | PMU In 5             |
-| TBD | Cabin → EB      | Boomerang fob present           | Bullet 230 output     | PMU In 4             |
-| TBD | EB → Cabin      | OUT24 ignition supply           | PMU OUT24             | Dash button supply   |
-| TBD | Cabin → EB      | Gated start (post-brake)        | Brake switch output   | P/N relay contact    |
+| Wire | Source | Destination | Notes |
+| :--- | :----- | :---------- | :---- |
+| Coil (+) | Switched +12V tap (ignition signal bus bar terminal) | WAIT-gate relay coil+ | Same source that powers the WAIT lamp |
+| Coil (-) | WAIT-gate relay coil- | T-tap on ECM Pin 35 wire (cabin side, shared with HDX WAIT/EX input) | Active-low sink path; ECM grounds this wire when WAIT lamp on |
+| Contact COM | PBS-I PURPLE START | WAIT-gate relay COM terminal | |
+| Contact NC | WAIT-gate relay NC terminal | Firewall Pin 15 → Cole Hersee 24213 coil+ | Closed when WAIT off; opens when WAIT on |
 
-See [Firewall Ingress][firewall-ingress] for the full pin map.
+See [HDX Control][hdx-control] for the existing WAIT/EX wiring on the cabin side.
 
-## Emergency Bypass
+### Firewall Crossings
 
-A hidden hardwired toggle (under dash, location TBD) bypasses the PMU and directly powers the ECM ignition relay coil from CONSTANT 12V via a 5A inline fuse. This provides a get-home mode if:
+Two PBS-I outputs need to cross the firewall from cabin (PBS-I location) to engine bay:
 
-- PMU24 firmware locks up or fails
-- Boomerang Bullet 230 fails or fob battery dies and PMU programming has no fallback
-- A CAN bus fault prevents the state machine from running
+| Signal | Direction | Approximate Current | Notes |
+| :----- | :-------- | :------------------ | :---- |
+| Ignition signal (outbound from cabin bus bar) | Cabin → EB | ~5A typical (ECM + PMU Pin 7) | 14 AWG; feeds ECM Pin 41 (black, via **5A inline fuse** per Cummins spec) and PMU Pin 7 |
+| WAIT-gated PURPLE | Cabin → EB | ~1.6A (Cole Hersee coil) | 16 AWG sufficient; drives Cole Hersee 24213 coil+ during crank only |
 
-**Bypass does NOT enable cranking** — only ignition. Cranking still requires the full hardware interlock chain (brake + P/N + engine-running lockout). In bypass mode you can still start by holding the dash button if all hardware interlocks are intact.
+See [Firewall Ingress][firewall-ingress] for pin assignments.
+
+## Why Not the Engine-Running Lockout or P/N Interlock Relay?
+
+Earlier iterations of this design included a discrete engine-running lockout relay and a P/N interlock relay in series with the starter coil. Both were removed in favor of simpler, layered protection:
+
+- **Brake interlock** is built into PBS-I (Accessory Harness Brake input).
+- **Engine-running protection** relies on the starter motor's Bendix overrunning clutch (standard automotive practice for hard-keyed ignition systems) plus the requirement to deliberately press brake + hold the button to crank — accidental restart of a running engine requires two-handed misuse.
+- **P/N interlock** is provided by the 8HP70 + Turbolamik: the transmission cannot be shifted out of Park without brake pressed, and the vehicle will always be in Park at start time. The Turbolamik can additionally inhibit start signal via its P/N aux output if a future build phase requires it (the signal is documented but unused by the keyless system today).
+
+This shifts the build's safety stance from "redundant external interlocks" to "PBS-I + transmission + driver behavior" — appropriate for a single-driver vehicle with a CR diesel and modern automatic.
 
 ## Diesel Runaway Note
 
-The Cummins R2.8 is a modern electronic common-rail diesel. Normal engine shutdown is achieved by cutting power to the ECM, which stops commanding the injectors. However, ECM-only kill does not stop a true runaway — if the engine is being fed oil, fuel, or hydrocarbon vapor from an external source, cutting ECM power does nothing.
-
-This build provides independent mechanical protection: a Mishimoto catch can in the crankcase ventilation path (prevention) plus an AMOT 4261M air shutoff valve with dash-mounted manual cable (termination). See [Diesel Runaway Protection][runaway-protection] for the full specification.
+Normal engine shutdown (press brake + 2 sec button hold) drops PBS-I's PINK IGN output, cutting ECM power. However, ECM-only kill does not stop a runaway sustained by oil or hydrocarbon vapor. Independent mechanical protection is provided by the Mishimoto catch can (prevention) plus the AMOT 4261M air shutoff valve with dash-mounted manual cable (termination). See [Diesel Runaway Protection][runaway-protection].
 
 ## Outstanding Items
 
-- [ ] Select Boomerang Bullet 230 mounting location (under dash, near driver)
-- [ ] Select dash push-button part (Otto, Apem, Carling, etc.) - 19mm/22mm, illuminated, momentary NO
-- [ ] Select ECM ignition relay part (Hella/Bosch SPST 30-40A automotive)
-- [ ] Select P/N interlock relay part (SPST 30A automotive)
-- [ ] Select engine-running lockout relay part (SPST 30A, NC contacts)
-- [ ] Design alternator B+ voltage filter for engine-running relay coil drive (diode + zener + resistor)
-- [ ] Assign 3 new firewall HDP24 pin numbers (currently TBD): fob signal, OUT24 supply to cabin, gated start return
-- [ ] Determine hidden bypass toggle location and part
-- [ ] Confirm Turbolamik aux output channel can be configured for P/N (12V when in P or N)
-- [ ] Decide PMU output strategy: OUT24-only with engine-running lockout (current plan) vs. freeing OUT15 winch trigger for dedicated crank output
-- [ ] Write PMU24 state-machine logic in ECUMaster Light Client (see [PMU Programming][pmu-programming])
+- [ ] Order Digital Guard Dawg PBS-I kit (includes ICM, 2 fobs, Start Button, Programming Button, Bypass Card, harnesses)
+- [ ] Select WAIT-gate relay part (SPST 30A automotive, NC contacts used in start path)
+- [ ] Add 5A inline fuse on ignition outbound wire to ECM Pin 41 (per Cummins R2.8 install manual)
+- [ ] Select PBS-I module mounting location (cabin under-dash, away from heat and water)
+- [ ] Select Start Button dash mounting position (within easy reach of driver)
+- [ ] Select Programming Button storage location (hidden but accessible)
+- [ ] Assign firewall pins for PBS-I PINK IGN (cabin → EB) and WAIT-gated PURPLE START (cabin → EB)
+- [ ] Verify PBS-I quiescent current draw to add to START battery parasitic budget
+- [ ] Set DIP switches / jumpers per install manual (PBS-I has no DIP/Jumper menu; check Feature Programming defaults are acceptable)
 
 ## Related Documentation
 
-- [PMU Inputs][pmu-inputs] - In 4, In 5, In 6 assignments
-- [PMU Outputs][pmu-outputs] - OUT24 assignment
-- [PMU Programming][pmu-programming] - State machine logic
-- [Starter System][starter] - Cole Hersee 24213 and crank chain
-- [Transmission][transmission] - Turbolamik aux outputs (P/N source)
-- [Ignition Signal Distribution][ignition-signal] - Why the keyswitch is gone
-- [Firewall Ingress][firewall-ingress] - Pin assignments
+- [Starter System][starter] - Cole Hersee 24213 and PBS-I PURPLE → WAIT-gate → coil chain
+- [Ignition Signal Distribution][ignition-signal] - PBS-I PINK IGN feeds the bus bar
+- [HDX Control][hdx-control] - WAIT/EX signal source for the gate relay
+- [Grid Heater System][grid-heater] - R2.8 grid heater duty cycle (3-5 sec typical)
+- [Firewall Ingress][firewall-ingress] - PBS-I pin assignments
 
-[boomerang]: https://boomerangtag.com/products/bullet-230
-[pmu-inputs]: ../01-power-systems/04-pmu/02-pmu-inputs.md
-[pmu-outputs]: ../01-power-systems/04-pmu/03-pmu-outputs.md
-[pmu-programming]: ../01-power-systems/04-pmu/04-pmu-programming.md
+[pbs-i]: https://www.digitalguarddawg.com/keyless-ignition/automotive/pbs-i
+[pbs-i-manual]: https://cdn.shopify.com/s/files/1/0896/8005/2530/files/PBS-I-Manual.pdf
 [starter]: ../02-engine-systems/01-starter.md
-[transmission]: ../10-drivetrain/01-transmission.md
 [ignition-signal]: ../01-power-systems/06-ignition-signal/index.md
 [firewall-ingress]: ../01-power-systems/07-wire-routing/02-firewall-ingress.md
-[standards-exceptions]: ../01-power-systems/STANDARDS-EXCEPTIONS.md
 [runaway-protection]: ../02-engine-systems/11-runaway-protection.md
+[hdx-control]: ../02-engine-systems/09-gauge-cluster/01-hdx-control.md
+[grid-heater]: ../02-engine-systems/07-grid-heater.md

--- a/docs/jeep_lj/09-installation/00-tbd-tracker.md
+++ b/docs/jeep_lj/09-installation/00-tbd-tracker.md
@@ -7,9 +7,9 @@ hide:
 
 **Purpose:** Central tracking for all To-Be-Determined items across the Jeep LJ electrical system documentation.
 
-**Last Updated:** 2026-05-29
+**Last Updated:** 2026-05-30
 
-**Total Open Items:** 59
+**Total Open Items:** 53
 
 ---
 
@@ -32,17 +32,12 @@ Items needed before installation begins but not system-critical.
 | Dakota Digital Panel Mounting     | HDPE sheet dimensions and location                              | [Wire Routing][wire-routing]   | High     |
 | Turbolamik Aux: Reverse           | Confirm aux output channel + pinout configured for Reverse signal → PMU In 3 | [Transmission][transmission]   | High     |
 | Turbolamik Aux: P/N               | Confirm aux output channel + pinout configured for P/N (start interlock) | [Transmission][transmission]   | High     |
-| Dash Push-Button (Keyless)        | Select 19/22mm illuminated momentary NO push-button for keyless start/stop | [Keyless Ignition][keyless]   | High     |
-| Boomerang Bullet 230              | Order RFID receiver + fob; mounting location under dash         | [Keyless Ignition][keyless]   | High     |
-| Boomerang Mounting Location       | Under-dash position near driver (3-6 ft range to driver seat)   | [Keyless Ignition][keyless]   | High     |
-| ECM Ignition Relay                | Select Hella/Bosch SPST 30-40A automotive relay                 | [Keyless Ignition][keyless]   | High     |
-| P/N Interlock Relay               | Select SPST 30A automotive relay (Turbolamik P/N → coil)        | [Keyless Ignition][keyless]   | High     |
-| Engine-Running Lockout Relay      | Select SPST 30A automotive relay with NC contacts               | [Keyless Ignition][keyless]   | High     |
-| Engine-Running Voltage Filter     | Design diode + zener + resistor filter on alternator B+ tap for lockout coil drive | [Keyless Ignition][keyless]   | High     |
-| Keyless Firewall Pin Assignments  | Assign 3 new HDP24 pins (fob, OUT24 supply, gated start return); current connector is full | [Firewall Ingress][firewall-ingress] | High     |
-| Hidden Bypass Toggle              | Select part + mounting location for emergency get-home bypass   | [Keyless Ignition][keyless]   | High     |
-| PMU Output Strategy (Keyless)     | Decide: OUT24-only + engine-running lockout (current plan) vs. free OUT15 winch trigger for dedicated crank output | [Keyless Ignition][keyless]   | High     |
-| PMU24 Keyless State Machine       | Program ECUMaster Light Client logic for OFF/RUN/CRANK transitions, fob detection, kill behavior | [PMU Programming][pmu-programming]   | High     |
+| PBS-I Order                       | Order Digital Guard Dawg PBS-I kit (ICM, 2 iTag fobs, Start Button, Programming Button, Bypass Card, harnesses) | [Keyless Ignition][keyless]   | High     |
+| WAIT-Gate Relay                   | Select SPST 30A automotive relay (NC contacts in start path; coil driven by ECM WAIT signal) | [Keyless Ignition][keyless]   | High     |
+| PBS-I Mounting Location           | Cabin under-dash position; module is ~5.5"×3"×1.25"; away from heat/water; do NOT engine-bay mount | [Keyless Ignition][keyless]   | High     |
+| Start Button Mounting Location    | Dash position within easy reach (button + 36" harness included in PBS-I kit)                  | [Keyless Ignition][keyless]   | High     |
+| Programming Button Storage        | Hidden but accessible location (under dash or in trunk) for fob-learn and emergency bypass PIN entry | [Keyless Ignition][keyless] | Medium   |
+| PBS-I Quiescent Current           | Measure or vendor-confirm standby draw to add to START battery parasitic budget               | [Keyless Ignition][keyless]   | Medium   |
 | R2.8 Turbo Inlet OD               | Measure turbo inlet tube outside diameter to confirm AMOT 4261M-02 (2.8" body) fitment and select intake-side adapter | [Runaway Protection][runaway-protection] | High     |
 | AMOT-to-Intake Adapters           | Source NPT-to-hose fittings sized to match measured turbo inlet OD                                | [Runaway Protection][runaway-protection] | High     |
 | AMOT T-Handle Mounting Location   | Select dash mounting position for Midwest Control 30-144-TTL-BH-3 (reachable belted, away from accidental contact) | [Runaway Protection][runaway-protection] | High     |
@@ -132,6 +127,18 @@ Items completed since last update.
 
 | Item                          | Resolution                                                                                                                    | Date       |
 | :---------------------------- | :---------------------------------------------------------------------------------------------------------------------------- | :--------- |
+| Cummins ECM WAIT/MIL Pins     | Confirmed from Cummins R2.8 install manual (document 0042728): WAIT=Pin 35 yellow, MIL=Pin 22 white, STOP ENGINE=Pin 49 green, WARNING=Pin 36 blue, Keyswitch=Pin 41 black (5A fuse) | 2026-05-30 |
+| Boomerang Bullet 230          | Removed from build — product was fabricated (does not exist). Replaced by Digital Guard Dawg PBS-I self-contained system     | 2026-05-30 |
+| Boomerang Mounting Location   | Obsolete — Boomerang not used; PBS-I includes its own RFID receiver in the ICM                                                | 2026-05-30 |
+| ECM Ignition Relay            | Obsolete — PBS-I PINK IGN (60A onboard relay) replaces the external ECM ignition relay                                        | 2026-05-30 |
+| P/N Interlock Relay           | Obsolete — interlock provided by 8HP70 + Turbolamik (transmission won't shift out of Park without brake); no external relay  | 2026-05-30 |
+| Engine-Running Lockout Relay  | Obsolete — relying on starter Bendix overrunning clutch + brake-required-to-crank UX; no external relay                       | 2026-05-30 |
+| Engine-Running Voltage Filter | Obsolete — no engine-running lockout relay; no filter needed                                                                  | 2026-05-30 |
+| Hidden Bypass Toggle          | Obsolete — PBS-I Emergency Bypass Card (4-digit PIN entered via Programming Button) replaces hardwired bypass                 | 2026-05-30 |
+| Dash Push-Button (Keyless)    | Resolved — Start Button included in PBS-I kit (pre-wired 36" harness to ICM)                                                  | 2026-05-30 |
+| PMU Output Strategy (Keyless) | Obsolete — PMU is no longer in the keyless logic path; OUT24 returned to Available                                            | 2026-05-30 |
+| PMU24 Keyless State Machine   | Obsolete — PBS-I is self-contained; no PMU state machine required                                                             | 2026-05-30 |
+| Keyless Firewall Pin Assignments | Resolved — Pin 12 reassigned to ignition signal outbound (cabin→EB), Pin 15 reassigned to WAIT-gated PURPLE START         | 2026-05-30 |
 | Horn Relay Specs              | None required - PMU OUT 18 switches PIAA horns directly, no external relay                                                    | 2026-05-25 |
 | Horn Load                     | 5.4A (PIAA 2.7A × 2)                                                                                                          | 2026-05-25 |
 | Horn Circuit Protection       | None required - PMU OUT 18 has integrated electronic overcurrent/thermal protection                                           | 2026-05-25 |
@@ -208,12 +215,12 @@ Items completed since last update.
 | Priority         | Count  |
 | :--------------- | :----- |
 | 🔴 Critical      | 1      |
-| High             | 25     |
-| 📋 Medium        | 17     |
+| High             | 20     |
+| 📋 Medium        | 19     |
 | 📝 Low           | 2      |
 | 🔍 Verify        | 1      |
 | 🚙 Drivetrain    | 13     |
-| **TOTAL**        | **59** |
+| **TOTAL**        | **56** |
 
 ## Related Documentation
 

--- a/docs/jeep_lj/09-installation/01-power-systems-checklist.md
+++ b/docs/jeep_lj/09-installation/01-power-systems-checklist.md
@@ -198,21 +198,21 @@ Create 12 custom 2-pin Delphi harnesses at SwitchPros:
 
 ### Ignition Signal Distribution
 
-- [ ] Confirm 18 AWG: Ignition RUN → Deutsch connector Pin 12 → PMU Pin 7
-- [ ] Confirm ignition signal bus bar splits to: CT4, SwitchPros, Fusion Radio, BCDC
-- [ ] Verify total ignition signal current <500mA for all taps
+- [ ] Confirm 14 AWG: PBS-I PINK IGN (cabin) → Ignition signal bus bar Stud 1
+- [ ] Confirm ignition signal bus bar Stud 2 → Deutsch connector Pin 12 (outbound to engine bay)
+- [ ] Confirm engine-bay junction off Pin 12 → ECM 12V supply + PMU Pin 7
+- [ ] Confirm bus bar terminals split to: CT4, SwitchPros, Fusion Radio, BCDC
+- [ ] Verify total ignition signal current <500mA for all bus bar taps
 
 ### PMU Input Wiring
 
-- [ ] Confirm 18 AWG: Ignition RUN → PMU Pin 7 (dedicated wire, not from bus bar)
+- [ ] Confirm 18 AWG: Ignition RUN (from engine-bay distribution off Pin 12) → PMU Pin 7
 - [ ] Confirm horn button → PMU In 1 (via Deutsch connector Pin 11)
 - [ ] Confirm brake pedal switch → PMU In 2 (via Deutsch connector Pin 13)
 - [ ] Confirm reverse signal → PMU In 3 (Turbolamik aux output, Reverse gear)
-- [ ] Confirm Boomerang fob present → PMU In 4 (via firewall pin TBD)
-- [ ] Confirm push-button → PMU In 5 (via Deutsch connector Pin 15)
-- [ ] Confirm Turbolamik P/N → PMU In 6 (engine bay, direct from TCU)
 - [ ] Confirm A/C request → PMU In 9 (via Deutsch connector Pin 14)
 - [ ] Confirm CT4 SW3 (headlight status) → PMU In 7 (tap on engine bay side of connector)
+- [ ] PMU In 4, In 5, In 6, In 8 — Available for future expansion (no current wiring)
 
 ### PMU Output Wiring
 
@@ -244,7 +244,7 @@ Create 12 custom 2-pin Delphi harnesses at SwitchPros:
 - [ ] Confirm brake lights → OUT21 (3A) - ground: SwitchPros Ground Bus T4
 - [ ] Confirm reverse lights → OUT22 (5A) - ground: SwitchPros Ground Bus T4
 - [ ] Confirm DRL/parking → OUT23 (2A) - ground: SwitchPros Ground Bus T5
-- [ ] Confirm Ignition Authorize → OUT24 (5A) - drives ECM ignition relay + keyless crank chain
+- [ ] OUT24 — Available for future expansion (no current wiring)
 
 ### PMU CAN Bus Integration
 

--- a/docs/jeep_lj/09-installation/02-engine-systems-checklist.md
+++ b/docs/jeep_lj/09-installation/02-engine-systems-checklist.md
@@ -47,16 +47,14 @@ Organized by installation order for efficient build workflow.
 - [ ] Confirm Cole Hersee 24213 solenoid mounted on firewall (engine bay side)
 - [ ] Confirm 10 AWG from starter battery post to Cole Hersee input
 - [ ] Confirm 10 AWG from Cole Hersee output to starter switch post
-- [ ] Confirm PMU OUT24 (Ignition Authorize) routed through firewall to dash push-button supply
-- [ ] Confirm push-button output (cabin) wired in series with brake pedal switch start tap
-- [ ] Confirm gated start signal routed through firewall Pin 15 → P/N relay contact in engine bay
-- [ ] Confirm P/N interlock relay coil driven by Turbolamik P/N aux output
-- [ ] Confirm engine-running lockout relay coil sensed from alternator B+ via filter circuit
-- [ ] Confirm engine-running lockout relay NC contacts in series with Cole Hersee coil+
+- [ ] Confirm PBS-I module mounted under-dash (cabin), powered from Critical Cabin PDU
+- [ ] Confirm PBS-I PURPLE START output wired to WAIT-gate relay COM terminal (cabin)
+- [ ] Confirm WAIT-gate relay coil wired to ECM WAIT signal tap (shared with HDX WAIT/EX input)
+- [ ] Confirm WAIT-gate relay NC contact routed through firewall Pin 15 → Cole Hersee 24213 coil+ in engine bay
 - [ ] Confirm Cole Hersee coil- grounded to engine bay ground bus
-- [ ] Confirm ECM ignition relay coil driven by PMU OUT24 (parallel to crank chain supply)
-- [ ] Confirm Boomerang Bullet 230 mounted, powered (CONSTANT), and output to PMU In 4
-- [ ] Confirm hidden bypass toggle installed (battery+ via 5A fuse → ECM relay coil)
+- [ ] Confirm PBS-I PINK IGN routed through cabin ignition signal bus bar → firewall Pin 12 → ECM 12V supply + PMU Pin 7
+- [ ] Confirm Start Button (included in PBS-I kit) mounted on dash, 36" harness plugged into PBS-I side port
+- [ ] Confirm Programming Button stashed accessibly for tag-learn / Emergency Bypass PIN entry
 
 ---
 
@@ -207,15 +205,14 @@ Organized by installation order for efficient build workflow.
 
 ### Starter Testing
 
-- [ ] Verify starter does NOT crank with shifter in R, D, or manual gates (P/N interlock relay open)
-- [ ] Verify starter does NOT crank when brake pedal is released (brake interlock open)
-- [ ] Verify starter does NOT crank when push-button is not pressed
-- [ ] Verify starter does NOT crank without Boomerang fob present (PMU blocks OUT24 assertion)
-- [ ] Verify starter cranks when fob + push-button + brake + P/N all asserted (engine off)
-- [ ] Verify engine-running lockout opens once alternator output > 13V (no Bendix re-engagement)
-- [ ] Verify push-button press while engine running kills the engine (OUT24 de-asserts, ECM off)
-- [ ] Verify hidden bypass toggle powers ECM ignition relay independent of PMU
-- [ ] Verify Boomerang fob lost while running does NOT kill the engine (PMU stay-on logic)
+- [ ] Verify starter does NOT crank when brake pedal is released (PBS-I brake interlock blocks PURPLE START)
+- [ ] Verify starter does NOT crank when Start Button is not pressed
+- [ ] Verify starter does NOT crank without valid PBS-I iTag fob in range (Start Button LED off)
+- [ ] Verify starter cranks when fob + Start Button + brake all asserted (engine off, warm engine - WAIT lamp not lit)
+- [ ] Verify cold-start sequence: brake + hold button → WAIT lamp illuminates → starter waits → WAIT extinguishes → starter cranks
+- [ ] Verify engine shutoff: brake + 2-second button hold → engine stops
+- [ ] Verify Emergency Bypass: with fob absent, Programming Button + 4-digit PIN authorizes start
+- [ ] Verify fob auto-arm: 60 seconds after fob leaves range, Start Button has no effect
 
 ### Grid Heater Testing
 

--- a/docs/jeep_lj/10-drivetrain/01-transmission.md
+++ b/docs/jeep_lj/10-drivetrain/01-transmission.md
@@ -128,7 +128,7 @@ The Turbolamik communicates with the Cummins R2.8 ECM via J1939 CAN for:
 | Output            | Function                          | Destination                              | Notes                                              |
 | :---------------- | :-------------------------------- | :--------------------------------------- | :------------------------------------------------- |
 | Aux Out (Reverse) | 12V when shifter in R             | [PMU In 3][pmu-inputs]                   | Drives PMU OUT22 (Reverse Lights)                  |
-| Aux Out (P/N)     | 12V when shifter in P or N        | [Starter P/N interlock relay][starter]   | Required gate for cranking the engine              |
+| Aux Out (P/N)     | 12V when shifter in P or N        | **\[Reserve\]**                          | Not currently consumed; PBS-I handles brake interlock for cranking. Available for future P/N gating if needed. |
 | J1939 broadcast   | Gear position, trans temp, mode   | [BIM-01-2 J1939][bim-j1939] → HDX GEAR   | Shares Cummins J1939 bus                           |
 
 ### Shifter


### PR DESCRIPTION
## Summary

- The originally documented "Boomerang Bullet 230" RFID immobilizer was a fabricated product (parked domain, no vendor sells it). Replaced with **Digital Guard Dawg PBS-I** + a single **WAIT-gate relay** that auto-blocks cranking during the Cummins R2.8 grid heater preheat. PBS-I is self-contained — PMU is no longer in the keyless logic path, freeing OUT24 and In 4/5/6 for future use.
- Confirmed Cummins R2.8 ECM pin assignments from the official install manual (doc 0042728): **WAIT = Pin 35 yellow** (active-low sink-circuit), **MIL = Pin 22 white**, **Keyswitch = Pin 41 black** (requires 5A inline fuse). HDX WAIT/EX input polarity flagged for bench verification — Cummins describes a sink-circuit but the HDX docs label it "active high".
- Net **−5 open TBDs**: 11 keyless TBDs resolved/obsoleted (Boomerang, ECM ignition relay, P/N interlock relay, engine-running lockout, voltage filter, hidden bypass, dash push-button, PMU output strategy, PMU state machine, firewall pin assignments, ECM WAIT pin), 6 added (PBS-I order, WAIT-gate relay, mounting locations, quiescent current).
- Architecture trade-off: P/N interlock relay and engine-running lockout relay both eliminated in favor of layered protection (PBS-I brake interlock + 8HP70 shifter-Park rule + Bendix overrunning clutch). Documented and rationalized in the keyless ignition doc.

## Test plan

- [ ] mkdocs build succeeds with no broken links
- [ ] Verify HDX WAIT/EX polarity on bench before final wiring (Cummins says active-low; HDX docs say active-high)
- [ ] Confirm PBS-I quiescent current with vendor before adding to START battery parasitic budget