### PR TITLE
docs(lj): wiring harness planning - architecture + tub map + inventory

### DIFF
--- a/Jeep LJ Tub Map.drawio
+++ b/Jeep LJ Tub Map.drawio
@@ -1,0 +1,1523 @@
+<mxfile host="65bd71144e">
+    <diagram id="page-1" name="Power Distribution">
+        <mxGraphModel dx="1058" dy="547" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1500" pageHeight="1550" math="0" shadow="0">
+            <root>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="title" value="Jeep LJ - Power Distribution" style="whiteSpace=wrap;text;html=1;align=center;verticalAlign=middle;fontSize=22;fontStyle=1;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="40" y="20" width="900" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="subtitle" value="Battery trunks, charging cross-cab, winch feed - heavy current paths and direct-battery loads" style="whiteSpace=wrap;text;html=1;align=center;verticalAlign=middle;fontSize=12;fontStyle=2;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;fontColor=#666666;" parent="1" vertex="1">
+                    <mxGeometry x="40" y="60" width="900" height="24" as="geometry"/>
+                </mxCell>
+                <mxCell id="rear-bumper" value="" style="rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#2a2a2a;strokeColor=#000000;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="240" y="948" width="320" height="32" as="geometry"/>
+                </mxCell>
+                <mxCell id="orient-arrow" value="FRONT" style="endArrow=classic;html=1;rounded=0;fontSize=12;fontStyle=1;strokeWidth=2;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="60" y="200" as="sourcePoint"/>
+                        <mxPoint x="60" y="130" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="body-tub" value="" style="rounded=1;arcSize=6;whiteSpace=wrap;html=1;fillColor=#e8d8b8;strokeColor=#5a4a2a;strokeWidth=3;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="240" y="180" width="320" height="790" as="geometry"/>
+                </mxCell>
+                <mxCell id="hood" value="" style="rounded=1;arcSize=4;whiteSpace=wrap;html=1;fillColor=#d8c89a;strokeColor=#5a4a2a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="250" y="200" width="300" height="200" as="geometry"/>
+                </mxCell>
+                <mxCell id="hood-crease" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#5a4a2a;strokeWidth=1;dashed=1;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="400" y="220" as="sourcePoint"/>
+                        <mxPoint x="400" y="380" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="grille" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#3a3a3a;strokeColor=#000000;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="260" y="200" width="280" height="38" as="geometry"/>
+                </mxCell>
+                <mxCell id="slat1" value="" style="endArrow=none;html=1;strokeColor=#888888;strokeWidth=1;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="310" y="205" as="sourcePoint"/>
+                        <mxPoint x="310" y="233" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="slat2" value="" style="endArrow=none;html=1;strokeColor=#888888;strokeWidth=1;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="335" y="205" as="sourcePoint"/>
+                        <mxPoint x="335" y="233" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="slat3" value="" style="endArrow=none;html=1;strokeColor=#888888;strokeWidth=1;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="360" y="205" as="sourcePoint"/>
+                        <mxPoint x="360" y="233" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="slat4" value="" style="endArrow=none;html=1;strokeColor=#888888;strokeWidth=1;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="440" y="205" as="sourcePoint"/>
+                        <mxPoint x="440" y="233" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="slat5" value="" style="endArrow=none;html=1;strokeColor=#888888;strokeWidth=1;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="465" y="205" as="sourcePoint"/>
+                        <mxPoint x="465" y="233" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="slat6" value="" style="endArrow=none;html=1;strokeColor=#888888;strokeWidth=1;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="490" y="205" as="sourcePoint"/>
+                        <mxPoint x="490" y="233" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="headlight-l" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff7c0;strokeColor=#000000;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="278" y="200" width="36" height="36" as="geometry"/>
+                </mxCell>
+                <mxCell id="headlight-r" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff7c0;strokeColor=#000000;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="486" y="200" width="36" height="36" as="geometry"/>
+                </mxCell>
+                <mxCell id="front-bumper" value="" style="rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#2a2a2a;strokeColor=#000000;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="300" y="158" width="190" height="32" as="geometry"/>
+                </mxCell>
+                <mxCell id="fairlead" value="" style="rounded=1;arcSize=40;whiteSpace=wrap;html=1;fillColor=#888888;strokeColor=#000000;strokeWidth=1;" parent="1" vertex="1">
+                    <mxGeometry x="370" y="166" width="60" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="cowl" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#a89868;strokeColor=#5a4a2a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="248" y="390" width="304" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="windshield" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#c8d8e8;fillStyle=hatch;strokeColor=#5a4a2a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="252" y="404" width="296" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="door-fl" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#5a4a2a;strokeWidth=1.5;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="240" y="460" as="sourcePoint"/>
+                        <mxPoint x="240" y="700" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="door-fl-h" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#5a4a2a;strokeWidth=1.5;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="240" y="700" as="sourcePoint"/>
+                        <mxPoint x="260" y="700" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="door-fr" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#5a4a2a;strokeWidth=1.5;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="560" y="460" as="sourcePoint"/>
+                        <mxPoint x="560" y="700" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="door-fr-h" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#5a4a2a;strokeWidth=1.5;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="560" y="700" as="sourcePoint"/>
+                        <mxPoint x="540" y="700" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="door-rl" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#5a4a2a;strokeWidth=1.5;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="240" y="710" as="sourcePoint"/>
+                        <mxPoint x="240" y="810" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="door-rr" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#5a4a2a;strokeWidth=1.5;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="560" y="710" as="sourcePoint"/>
+                        <mxPoint x="560" y="810" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="seat-dr" value="" style="rounded=1;arcSize=30;whiteSpace=wrap;html=1;fillColor=#7a6a4a;strokeColor=#3a2a0a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="278" y="500" width="90" height="150" as="geometry"/>
+                </mxCell>
+                <mxCell id="seat-pass" value="" style="rounded=1;arcSize=30;whiteSpace=wrap;html=1;fillColor=#7a6a4a;strokeColor=#3a2a0a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="432" y="500" width="90" height="150" as="geometry"/>
+                </mxCell>
+                <mxCell id="steering" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#3a2a0a;strokeWidth=3;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="295" y="468" width="56" height="34" as="geometry"/>
+                </mxCell>
+                <mxCell id="console" value="" style="rounded=1;arcSize=20;whiteSpace=wrap;html=1;fillColor=#6a5a3a;strokeColor=#3a2a0a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="375" y="510" width="50" height="180" as="geometry"/>
+                </mxCell>
+                <mxCell id="ww-intrude-l" value="" style="rounded=1;arcSize=30;whiteSpace=wrap;html=1;fillColor=#c8b888;strokeColor=#5a4a2a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="240" y="710" width="70" height="180" as="geometry"/>
+                </mxCell>
+                <mxCell id="ww-intrude-r" value="" style="rounded=1;arcSize=30;whiteSpace=wrap;html=1;fillColor=#c8b888;strokeColor=#5a4a2a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="490" y="710" width="70" height="190" as="geometry"/>
+                </mxCell>
+                <mxCell id="cb-fu" value="100A→Fusion" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=1;fontColor=#ffffff;fontSize=7;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="493" y="793" width="64" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="cb-sh" value="150A→SH" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=1;fontColor=#ffffff;fontSize=7;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="494" y="840" width="64" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="ctrl-bcdc" value="BCDC" style="rounded=1;arcSize=15;whiteSpace=wrap;html=1;fillColor=#ffb870;strokeColor=#aa5500;strokeWidth=2;fontColor=#3a2a0a;fontSize=9;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="492" y="816" width="64" height="18" as="geometry"/>
+                </mxCell>
+                <mxCell id="ctrl-switchpros" value="SwitchPros" style="rounded=1;arcSize=15;whiteSpace=wrap;html=1;fillColor=#d8b8e8;strokeColor=#664488;strokeWidth=2;fontColor=#2a1a3a;fontSize=10;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="370" y="460" width="90" height="28" as="geometry"/>
+                </mxCell>
+                <mxCell id="ctrl-bus2" value="CONSTANT BUS" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#aaaaaa;strokeColor=#444444;strokeWidth=1;fontColor=#000000;fontSize=8;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="370" y="414" width="185" height="12" as="geometry"/>
+                </mxCell>
+                <mxCell id="cb-fw-sp" value="150A→SP" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=1;fontColor=#ffffff;fontSize=7;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="370" y="429" width="90" height="12" as="geometry"/>
+                </mxCell>
+                <mxCell id="cb-fw-bp" value="100A→BP" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=1;fontColor=#ffffff;fontSize=7;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="465" y="429" width="90" height="12" as="geometry"/>
+                </mxCell>
+                <mxCell id="ctrl-sp-gnd" value="SwitchPros GND BUS" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#888888;strokeColor=#333333;strokeWidth=1;fontColor=#ffffff;fontSize=7;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="370" y="446" width="185" height="12" as="geometry"/>
+                </mxCell>
+                <mxCell id="ctrl-safetyhub" value="SafetyHub" style="rounded=1;arcSize=15;whiteSpace=wrap;html=1;fillColor=#ffb0b0;strokeColor=#aa3333;strokeWidth=2;fontColor=#3a0a0a;fontSize=9;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="493" y="860" width="64" height="18" as="geometry"/>
+                </mxCell>
+                <mxCell id="ctrl-pmu" value="PMU24" style="rounded=1;arcSize=15;whiteSpace=wrap;html=1;fillColor=#b8d4f0;strokeColor=#2a5a8a;strokeWidth=2;fontColor=#1a3a5a;fontSize=11;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="440" y="350" width="100" height="25" as="geometry"/>
+                </mxCell>
+                <mxCell id="ctrl-bodypdu" value="BODY PDU" style="rounded=1;arcSize=15;whiteSpace=wrap;html=1;fillColor=#cce4b8;strokeColor=#558833;strokeWidth=2;fontColor=#2a4a1a;fontSize=10;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="465" y="460" width="90" height="28" as="geometry"/>
+                </mxCell>
+                <mxCell id="seat-rear" value="" style="rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#7a6a4a;strokeColor=#3a2a0a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="316" y="724" width="168" height="140" as="geometry"/>
+                </mxCell>
+                <mxCell id="bench-div-1" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#5a4a2a;strokeWidth=1;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="372" y="685" as="sourcePoint"/>
+                        <mxPoint x="372" y="800" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="bench-div-2" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#5a4a2a;strokeWidth=1;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="428" y="685" as="sourcePoint"/>
+                        <mxPoint x="428" y="800" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="tailgate" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#c8b888;strokeColor=#5a4a2a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="244" y="934" width="312" height="34" as="geometry"/>
+                </mxCell>
+                <mxCell id="bb-aux-fwd" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#cc2222;strokeWidth=5;sketch=1;curveFitting=1;jiggle=2;edgeStyle=orthogonalEdgeStyle;curved=0;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="525" y="720" as="sourcePoint"/>
+                        <mxPoint x="555" y="420" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="540" y="715"/>
+                            <mxPoint x="540" y="420"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="bb-aux-fwd-lbl" value="&lt;font style=&quot;&quot;&gt;&lt;u style=&quot;&quot;&gt;&lt;span style=&quot;font-size: 14px;&quot;&gt;HARNESS &lt;/span&gt;&lt;font style=&quot;font-size: 15px;&quot;&gt;H1/4&lt;/font&gt;&lt;/u&gt;&lt;br&gt;&lt;/font&gt;&lt;font style=&quot;font-size: 12px;&quot;&gt;1× 2/0 AWG (AUX fwd feed)&lt;br&gt;2× 1/0 AWG (winch)&lt;/font&gt;" style="whiteSpace=wrap;text;html=1;align=center;fontSize=11;fontStyle=1;fontColor=#aa1111;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;fillColor=#fff5f5;strokeColor=#aa1111;spacing=8;rounded=0;" parent="1" vertex="1">
+                    <mxGeometry x="595" y="620" width="195" height="70" as="geometry"/>
+                </mxCell>
+                <mxCell id="bb-start-fwd-lbl" value="&lt;font style=&quot;&quot;&gt;&lt;u style=&quot;&quot;&gt;&lt;span style=&quot;font-size: 14px;&quot;&gt;HARNESS &lt;/span&gt;&lt;font style=&quot;font-size: 15px;&quot;&gt;H2&lt;/font&gt;&lt;/u&gt;&lt;br&gt;&lt;/font&gt;&lt;font style=&quot;font-size: 12px;&quot;&gt;3× 2/0 AWG (alt, starter, PMU)&lt;br&gt;3 direct (grid, ECM, iBooster)&lt;/font&gt;" style="whiteSpace=wrap;text;html=1;align=center;fontSize=11;fontStyle=1;fontColor=#aa1111;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;fillColor=#fff5f5;strokeColor=#aa1111;spacing=8;rounded=0;" parent="1" vertex="1">
+                    <mxGeometry x="10" y="620" width="200" height="70" as="geometry"/>
+                </mxCell>
+                <mxCell id="bb-bcdc-cross" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#2266aa;strokeWidth=4;sketch=1;curveFitting=1;jiggle=2;edgeStyle=orthogonalEdgeStyle;curved=0;entryX=0.057;entryY=0.611;entryDx=0;entryDy=0;entryPerimeter=0;exitX=1;exitY=0.5;exitDx=0;exitDy=0;" parent="1" source="cb-bcdc-in" target="ww-intrude-r" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="261" y="779" as="sourcePoint"/>
+                        <mxPoint x="494" y="865" as="targetPoint"/>
+                        <Array as="points"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="12" value="&lt;font data-font-src=&quot;https://fonts.googleapis.com/css?family=Architects+Daughter&quot; face=&quot;Architects Daughter&quot; style=&quot;font-size: 20px;&quot;&gt;H3&lt;/font&gt;" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];spacing=3;labelBorderColor=light-dark(#102370, #ededed);" parent="bb-bcdc-cross" vertex="1" connectable="0">
+                    <mxGeometry x="-0.2802" relative="1" as="geometry">
+                        <mxPoint x="26" y="-3" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="bb-bcdc-cross-lbl" value="&lt;font style=&quot;font-size: 14px;&quot;&gt;&lt;u style=&quot;&quot;&gt;HARNESS H3&lt;/u&gt;&lt;/font&gt;&lt;div&gt;&lt;font style=&quot;font-size: 10px;&quot;&gt;4 AWG BCDC inter-battery&lt;br&gt;4 AWG + 1/0 AWG cross-gnd&lt;/font&gt;&lt;/div&gt;" style="whiteSpace=wrap;text;html=1;align=center;fontSize=8;fontStyle=1;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;fillColor=#dae8fc;strokeColor=#6c8ebf;spacing=10;" parent="1" vertex="1">
+                    <mxGeometry x="10" y="699" width="200" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="bb-winch" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#880000;strokeWidth=6;sketch=1;curveFitting=1;jiggle=2;edgeStyle=orthogonalEdgeStyle;curved=0;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="511" y="752" as="sourcePoint"/>
+                        <mxPoint x="400" y="190" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="540" y="745"/>
+                            <mxPoint x="540" y="240"/>
+                            <mxPoint x="425" y="200"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="bb-winch-lbl" value="H1/4 winch&amp;#10;continues to&amp;#10;front bumper" style="whiteSpace=wrap;text;html=1;align=center;fontSize=8;fontStyle=1;fontColor=#880000;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;fillColor=#fff0f0;strokeColor=#880000;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="570" y="260" width="110" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="lbl-dash" value="DASHBOARD + FIREWALL&#xa;CONSTANT BUS&#xa;CBs: 150A→SP, 100A→BP&#xa;SwitchPros, BODY PDU&#xa;SwitchPros GND bus&#xa;Dakota HDX, CT4 panel, SP panel,&#xa;HVAC, radio, gauges&#xa;(Fusion amp relocated under rear seat)" style="whiteSpace=wrap;text;html=1;align=center;fontSize=10;fontStyle=1;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;fillColor=#dde6f0;strokeColor=#445566;" parent="1" vertex="1">
+                    <mxGeometry x="700" y="460" width="200" height="110" as="geometry"/>
+                </mxCell>
+                <mxCell id="ldr-dash" style="endArrow=open;html=1;endSize=8;strokeColor=#445566;sketch=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="710" y="476" as="sourcePoint"/>
+                        <mxPoint x="555" y="450" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="lbl-rlhub" value="RL WHEEL WELL  ★&lt;br&gt;START BATTERY&lt;br&gt;&lt;br&gt;Circuit Breakers: &lt;br&gt;250A→PMU&lt;br&gt;80A→BCDC in" style="whiteSpace=wrap;text;html=1;align=center;fontSize=11;fontStyle=1;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;fillColor=#fff0d8;strokeColor=#cc6600;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="26.25" y="830" width="172.5" height="150" as="geometry"/>
+                </mxCell>
+                <mxCell id="lbl-rrhub" value="RR WHEEL WELL  ★&lt;br&gt;AUX BATTERY&lt;br&gt;&lt;br&gt;&lt;div&gt;Circuit Breakers:&lt;/div&gt;&lt;div&gt;300A -&amp;gt; FWD&lt;/div&gt;&lt;div&gt;150A -&amp;gt; SafetyHub&lt;/div&gt;&lt;div&gt;100A -&amp;gt; Fusion Amp&lt;/div&gt;&lt;div&gt;&lt;br&gt;&lt;/div&gt;&lt;div&gt;Direct Connections:&lt;/div&gt;&lt;div&gt;BCDC Output&lt;/div&gt;&lt;div&gt;Warn Winch&lt;/div&gt;" style="whiteSpace=wrap;text;html=1;align=center;fontSize=11;fontStyle=1;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;fillColor=#fff0d8;strokeColor=#cc6600;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="600" y="834" width="170" height="156" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-footer" value="See docs/jeep_lj/01-power-systems/07-wire-routing/03-harness-inventory.md for full harness BOMs, connector specs, and routing details." style="text;html=1;align=center;verticalAlign=middle;fontSize=10;fontStyle=2;fontColor=#666666;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;whiteSpace=wrap;" parent="1" vertex="1">
+                    <mxGeometry x="40" y="1340" width="1400" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="roster" value="LOADS ON THIS PAGE (●) — bundled with H1, H2, or H4 trunks&amp;#10;• Alternator (engine bay, via H2)&amp;#10;• Starter (engine bay, via H2)&amp;#10;• Grid heater (engine bay, direct via fusible link, shares H2 trunk)&amp;#10;• ECM (engine bay, direct via Cummins harness, shares H2 trunk)&amp;#10;&amp;#10;Plus H1 forward feed → Firewall CONSTANT Bus (shown as box)&amp;#10;and H4 winch power → contactor at front bumper" style="text;html=1;align=left;verticalAlign=top;fontSize=12;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;whiteSpace=wrap;fillColor=#fff5f5;strokeColor=#cc3333;" parent="1" vertex="1">
+                    <mxGeometry x="40" y="1080" width="600" height="160" as="geometry"/>
+                </mxCell>
+                <mxCell id="conn-h2-starter" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#aa1111;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="350" y="378" as="sourcePoint"/>
+                        <mxPoint x="430" y="295" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="conn-h2-alternator" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#aa1111;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="350" y="378" as="sourcePoint"/>
+                        <mxPoint x="370" y="225" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p1-h2branch-gridheater" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#aa1111;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="350" y="378" as="sourcePoint"/>
+                        <mxPoint x="420" y="260" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p1-h2branch-ecm" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#aa1111;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="350" y="378" as="sourcePoint"/>
+                        <mxPoint x="465" y="329" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="ld-alternator" value="Alternator" style="rounded=1;arcSize=15;whiteSpace=wrap;html=1;fillColor=#fff5f5;strokeColor=#880000;strokeWidth=2;fontColor=#440000;fontSize=10;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="330" y="215" width="80" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-gridheater" value="Grid heater" style="rounded=1;arcSize=15;whiteSpace=wrap;html=1;fillColor=#fff5f5;strokeColor=#880000;strokeWidth=2;fontColor=#440000;fontSize=10;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="420" y="250" width="85" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-starter" value="Starter" style="rounded=1;arcSize=15;whiteSpace=wrap;html=1;fillColor=#fff5f5;strokeColor=#880000;strokeWidth=2;fontColor=#440000;fontSize=10;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="430" y="285" width="70" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-ecm" value="ECM" style="rounded=1;arcSize=15;whiteSpace=wrap;html=1;fillColor=#fff5f5;strokeColor=#880000;strokeWidth=2;fontColor=#440000;fontSize=10;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="465" y="318" width="55" height="22" as="geometry"/>
+                </mxCell>
+                <mxCell id="conn-h2-pmu" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#aa1111;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="350" y="378" as="sourcePoint"/>
+                        <mxPoint x="440" y="363" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="7" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#2266aa;strokeWidth=4;sketch=1;curveFitting=1;jiggle=2;edgeStyle=orthogonalEdgeStyle;curved=0;exitX=0.25;exitY=0;exitDx=0;exitDy=0;entryX=0.5;entryY=1;entryDx=0;entryDy=0;" parent="1" source="cb-bcdc-in" target="batt-start-pos" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="278" y="873" as="sourcePoint"/>
+                        <mxPoint x="504" y="739" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="cb-bcdc-in" value="80A→BCDC in" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=1;fontColor=#ffffff;fontSize=7;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="246" y="821" width="54" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="bb-start-fwd" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#aa1111;strokeWidth=5;sketch=1;curveFitting=1;jiggle=2;edgeStyle=orthogonalEdgeStyle;curved=0;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="261" y="779" as="sourcePoint"/>
+                        <mxPoint x="350" y="378" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="260" y="708"/>
+                            <mxPoint x="260" y="378"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="6" value="H2" style="edgeLabel;html=1;align=center;verticalAlign=middle;resizable=0;points=[];spacing=0;spacingTop=0;spacingBottom=0;spacingLeft=0;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;fontStyle=1;fontSize=20;labelBorderColor=default;fontColor=#990000;" parent="bb-start-fwd" vertex="1" connectable="0">
+                    <mxGeometry x="-0.9434" y="1" relative="1" as="geometry">
+                        <mxPoint x="1" y="-131" as="offset"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="cb-pmu" value="250A→PMU" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=1;fontColor=#ffffff;fontSize=7;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="244" y="720" width="58" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="8" value="" style="group" parent="1" vertex="1" connectable="0">
+                    <mxGeometry x="246" y="740" width="58" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="batt-start" value="START" style="rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#ffd84d;strokeColor=#aa6600;strokeWidth=2;fontColor=#3a2a0a;fontSize=10;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="8" vertex="1">
+                    <mxGeometry width="58" height="59.99999999999999" as="geometry"/>
+                </mxCell>
+                <mxCell id="batt-start-neg" value="-" style="ellipse;whiteSpace=wrap;html=1;fillColor=#222222;strokeColor=#000000;fontColor=#ffffff;fontSize=11;fontStyle=1;align=center;verticalAlign=middle;" parent="8" vertex="1">
+                    <mxGeometry x="36" y="7.636363636363636" width="14" height="15.272727272727272" as="geometry"/>
+                </mxCell>
+                <mxCell id="batt-start-pos" value="+" style="ellipse;whiteSpace=wrap;html=1;fillColor=#cc0000;strokeColor=#660000;fontColor=#ffffff;fontSize=10;fontStyle=1;align=center;verticalAlign=middle;" parent="8" vertex="1">
+                    <mxGeometry x="8" y="7.636363636363636" width="14" height="15.272727272727272" as="geometry"/>
+                </mxCell>
+                <mxCell id="ctrl-fusion" value="Fusion Amp&#xa;(under rear seat)" style="rounded=1;arcSize=15;whiteSpace=wrap;html=1;fillColor=#e8d4f0;strokeColor=#7744aa;strokeWidth=2;fontColor=#3a1a4a;fontSize=8;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="353" y="755" width="84" height="28" as="geometry"/>
+                </mxCell>
+                <mxCell id="bb-fusion-feed" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#7744aa;strokeWidth=3;sketch=1;curveFitting=1;jiggle=2;edgeStyle=orthogonalEdgeStyle;curved=0;entryX=1;entryY=0.5;entryDx=0;entryDy=0;exitX=0;exitY=0.5;exitDx=0;exitDy=0;" parent="1" edge="1" target="ctrl-fusion" source="cb-fu">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="494" y="843" as="sourcePoint"/>
+                        <mxPoint x="412" y="840" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="fp3-marker" value="FP3" style="ellipse;whiteSpace=wrap;html=1;fillColor=#c8b888;strokeColor=#5a4a2a;strokeWidth=2;fontColor=#3a2a0a;fontSize=9;fontStyle=1;align=center;verticalAlign=middle;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="251" y="382" width="24" height="24" as="geometry"/>
+                </mxCell>
+                <mxCell id="fp4-marker" value="FP4" style="ellipse;whiteSpace=wrap;html=1;fillColor=#c8b888;strokeColor=#5a4a2a;strokeWidth=2;fontColor=#3a2a0a;fontSize=9;fontStyle=1;align=center;verticalAlign=middle;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="528" y="382" width="24" height="24" as="geometry"/>
+                </mxCell>
+                <mxCell id="fp-legend" value="FIREWALL PENETRATIONS (this page)&amp;#10;FP3 Heavy grommet (driver) — H2 bundle&amp;#10;FP4 Heavy grommet (passenger) — H1/H4 bundle" style="text;html=1;align=left;verticalAlign=top;fontSize=10;fontStyle=1;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;whiteSpace=wrap;fillColor=#eeeeee;strokeColor=#666666;strokeWidth=1;" parent="1" vertex="1">
+                    <mxGeometry x="710" y="380" width="280" height="60" as="geometry"/>
+                </mxCell>
+                <mxCell id="cb-master" value="300A→fwd" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=1;fontColor=#ffffff;fontSize=7;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="494" y="720" width="64" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="batt-aux" value="AUX" style="rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#ffd84d;strokeColor=#aa6600;strokeWidth=2;fontColor=#3a2a0a;fontSize=10;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="496" y="738" width="58" height="52" as="geometry"/>
+                </mxCell>
+                <mxCell id="batt-aux-pos" value="+" style="ellipse;whiteSpace=wrap;html=1;fillColor=#cc0000;strokeColor=#660000;fontColor=#ffffff;fontSize=10;fontStyle=1;align=center;verticalAlign=middle;" parent="1" vertex="1">
+                    <mxGeometry x="504" y="745" width="14" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="batt-aux-neg" value="-" style="ellipse;whiteSpace=wrap;html=1;fillColor=#222222;strokeColor=#000000;fontColor=#ffffff;fontSize=11;fontStyle=1;align=center;verticalAlign=middle;" parent="1" vertex="1">
+                    <mxGeometry x="532" y="745" width="14" height="14" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+    <diagram id="page-2" name="Lighting &amp; SwitchPros">
+        <mxGraphModel dx="1058" dy="547" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1500" pageHeight="1550" math="0" shadow="0">
+            <root>
+                <mxCell id="title" value="Jeep LJ - Lighting &amp; SwitchPros Fan-Out" style="whiteSpace=wrap;text;html=1;align=center;verticalAlign=middle;fontSize=22;fontStyle=1;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="40" y="20" width="900" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="subtitle" value="PMU rear lighting + SwitchPros front/rear bundles - all lights and turn signals" style="whiteSpace=wrap;text;html=1;align=center;verticalAlign=middle;fontSize=12;fontStyle=2;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;fontColor=#666666;" parent="1" vertex="1">
+                    <mxGeometry x="40" y="60" width="900" height="24" as="geometry"/>
+                </mxCell>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="rear-bumper" value="" style="rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#2a2a2a;strokeColor=#000000;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="240" y="948" width="320" height="32" as="geometry"/>
+                </mxCell>
+                <mxCell id="orient-arrow" value="FRONT" style="endArrow=classic;html=1;rounded=0;fontSize=12;fontStyle=1;strokeWidth=2;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="60" y="200" as="sourcePoint"/>
+                        <mxPoint x="60" y="130" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="body-tub" value="" style="rounded=1;arcSize=6;whiteSpace=wrap;html=1;fillColor=#e8d8b8;strokeColor=#5a4a2a;strokeWidth=3;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="240" y="180" width="320" height="790" as="geometry"/>
+                </mxCell>
+                <mxCell id="hood" value="" style="rounded=1;arcSize=4;whiteSpace=wrap;html=1;fillColor=#d8c89a;strokeColor=#5a4a2a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="250" y="200" width="300" height="200" as="geometry"/>
+                </mxCell>
+                <mxCell id="hood-crease" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#5a4a2a;strokeWidth=1;dashed=1;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="400" y="220" as="sourcePoint"/>
+                        <mxPoint x="400" y="380" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="grille" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#3a3a3a;strokeColor=#000000;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="260" y="200" width="280" height="38" as="geometry"/>
+                </mxCell>
+                <mxCell id="slat1" value="" style="endArrow=none;html=1;strokeColor=#888888;strokeWidth=1;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="310" y="205" as="sourcePoint"/>
+                        <mxPoint x="310" y="233" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="slat2" value="" style="endArrow=none;html=1;strokeColor=#888888;strokeWidth=1;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="335" y="205" as="sourcePoint"/>
+                        <mxPoint x="335" y="233" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="slat3" value="" style="endArrow=none;html=1;strokeColor=#888888;strokeWidth=1;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="360" y="205" as="sourcePoint"/>
+                        <mxPoint x="360" y="233" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="slat4" value="" style="endArrow=none;html=1;strokeColor=#888888;strokeWidth=1;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="440" y="205" as="sourcePoint"/>
+                        <mxPoint x="440" y="233" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="slat5" value="" style="endArrow=none;html=1;strokeColor=#888888;strokeWidth=1;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="465" y="205" as="sourcePoint"/>
+                        <mxPoint x="465" y="233" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="slat6" value="" style="endArrow=none;html=1;strokeColor=#888888;strokeWidth=1;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="490" y="205" as="sourcePoint"/>
+                        <mxPoint x="490" y="233" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="headlight-l" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff7c0;strokeColor=#000000;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="278" y="200" width="36" height="36" as="geometry"/>
+                </mxCell>
+                <mxCell id="headlight-r" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff7c0;strokeColor=#000000;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="486" y="200" width="36" height="36" as="geometry"/>
+                </mxCell>
+                <mxCell id="front-bumper" value="" style="rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#2a2a2a;strokeColor=#000000;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="300" y="158" width="190" height="32" as="geometry"/>
+                </mxCell>
+                <mxCell id="fairlead" value="" style="rounded=1;arcSize=40;whiteSpace=wrap;html=1;fillColor=#888888;strokeColor=#000000;strokeWidth=1;" parent="1" vertex="1">
+                    <mxGeometry x="370" y="166" width="60" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="cowl" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#a89868;strokeColor=#5a4a2a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="248" y="390" width="304" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="windshield" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#c8d8e8;fillStyle=hatch;strokeColor=#5a4a2a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="252" y="404" width="296" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="door-fl" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#5a4a2a;strokeWidth=1.5;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="240" y="460" as="sourcePoint"/>
+                        <mxPoint x="240" y="700" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="door-fl-h" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#5a4a2a;strokeWidth=1.5;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="240" y="700" as="sourcePoint"/>
+                        <mxPoint x="260" y="700" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="door-fr" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#5a4a2a;strokeWidth=1.5;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="560" y="460" as="sourcePoint"/>
+                        <mxPoint x="560" y="700" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="door-fr-h" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#5a4a2a;strokeWidth=1.5;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="560" y="700" as="sourcePoint"/>
+                        <mxPoint x="540" y="700" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="door-rl" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#5a4a2a;strokeWidth=1.5;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="240" y="710" as="sourcePoint"/>
+                        <mxPoint x="240" y="810" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="door-rr" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#5a4a2a;strokeWidth=1.5;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="560" y="710" as="sourcePoint"/>
+                        <mxPoint x="560" y="810" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="seat-dr" value="" style="rounded=1;arcSize=30;whiteSpace=wrap;html=1;fillColor=#7a6a4a;strokeColor=#3a2a0a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="278" y="500" width="90" height="150" as="geometry"/>
+                </mxCell>
+                <mxCell id="seat-pass" value="" style="rounded=1;arcSize=30;whiteSpace=wrap;html=1;fillColor=#7a6a4a;strokeColor=#3a2a0a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="432" y="500" width="90" height="150" as="geometry"/>
+                </mxCell>
+                <mxCell id="steering" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#3a2a0a;strokeWidth=3;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="295" y="468" width="56" height="34" as="geometry"/>
+                </mxCell>
+                <mxCell id="console" value="" style="rounded=1;arcSize=20;whiteSpace=wrap;html=1;fillColor=#6a5a3a;strokeColor=#3a2a0a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="375" y="510" width="50" height="180" as="geometry"/>
+                </mxCell>
+                <mxCell id="ww-intrude-l" value="" style="rounded=1;arcSize=30;whiteSpace=wrap;html=1;fillColor=#c8b888;strokeColor=#5a4a2a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="240" y="710" width="70" height="180" as="geometry"/>
+                </mxCell>
+                <mxCell id="ww-intrude-r" value="" style="rounded=1;arcSize=30;whiteSpace=wrap;html=1;fillColor=#c8b888;strokeColor=#5a4a2a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="490" y="710" width="70" height="180" as="geometry"/>
+                </mxCell>
+                <mxCell id="batt-start" value="START" style="rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#ffd84d;strokeColor=#aa6600;strokeWidth=2;fontColor=#3a2a0a;fontSize=10;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="246" y="765" width="58" height="78" as="geometry"/>
+                </mxCell>
+                <mxCell id="batt-start-pos" value="+" style="ellipse;whiteSpace=wrap;html=1;fillColor=#cc0000;strokeColor=#660000;fontColor=#ffffff;fontSize=10;fontStyle=1;align=center;verticalAlign=middle;" parent="1" vertex="1">
+                    <mxGeometry x="254" y="772" width="14" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="batt-start-neg" value="-" style="ellipse;whiteSpace=wrap;html=1;fillColor=#222222;strokeColor=#000000;fontColor=#ffffff;fontSize=11;fontStyle=1;align=center;verticalAlign=middle;" parent="1" vertex="1">
+                    <mxGeometry x="282" y="772" width="14" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="cb-pmu" value="250A→PMU" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=1;fontColor=#ffffff;fontSize=7;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="246" y="720" width="58" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="cb-bcdc-in" value="80A→BCDC in" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=1;fontColor=#ffffff;fontSize=7;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="246" y="738" width="58" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="batt-aux" value="AUX" style="rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#ffd84d;strokeColor=#aa6600;strokeWidth=2;fontColor=#3a2a0a;fontSize=10;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="496" y="738" width="58" height="78" as="geometry"/>
+                </mxCell>
+                <mxCell id="batt-aux-pos" value="+" style="ellipse;whiteSpace=wrap;html=1;fillColor=#cc0000;strokeColor=#660000;fontColor=#ffffff;fontSize=10;fontStyle=1;align=center;verticalAlign=middle;" parent="1" vertex="1">
+                    <mxGeometry x="504" y="745" width="14" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="batt-aux-neg" value="-" style="ellipse;whiteSpace=wrap;html=1;fillColor=#222222;strokeColor=#000000;fontColor=#ffffff;fontSize=11;fontStyle=1;align=center;verticalAlign=middle;" parent="1" vertex="1">
+                    <mxGeometry x="532" y="745" width="14" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="cb-master" value="300A→fwd" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=1;fontColor=#ffffff;fontSize=7;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="494" y="720" width="64" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="cb-fu" value="100A→Fusion" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=1;fontColor=#ffffff;fontSize=7;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="494" y="836" width="64" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="cb-sh" value="150A→SH" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=1;fontColor=#ffffff;fontSize=7;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="494" y="820" width="64" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="ctrl-bcdc" value="BCDC" style="rounded=1;arcSize=15;whiteSpace=wrap;html=1;fillColor=#ffb870;strokeColor=#aa5500;strokeWidth=2;fontColor=#3a2a0a;fontSize=9;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="494" y="872" width="64" height="18" as="geometry"/>
+                </mxCell>
+                <mxCell id="ctrl-switchpros" value="SwitchPros" style="rounded=1;arcSize=15;whiteSpace=wrap;html=1;fillColor=#d8b8e8;strokeColor=#664488;strokeWidth=2;fontColor=#2a1a3a;fontSize=10;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="370" y="460" width="90" height="28" as="geometry"/>
+                </mxCell>
+                <mxCell id="ctrl-bus2" value="CONSTANT BUS" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#aaaaaa;strokeColor=#444444;strokeWidth=1;fontColor=#000000;fontSize=8;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="370" y="414" width="185" height="12" as="geometry"/>
+                </mxCell>
+                <mxCell id="cb-fw-sp" value="150A→SP" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=1;fontColor=#ffffff;fontSize=7;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="370" y="429" width="90" height="12" as="geometry"/>
+                </mxCell>
+                <mxCell id="cb-fw-bp" value="100A→BP" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=1;fontColor=#ffffff;fontSize=7;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="465" y="429" width="90" height="12" as="geometry"/>
+                </mxCell>
+                <mxCell id="ctrl-sp-gnd" value="SwitchPros GND BUS" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#888888;strokeColor=#333333;strokeWidth=1;fontColor=#ffffff;fontSize=7;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="370" y="446" width="185" height="12" as="geometry"/>
+                </mxCell>
+                <mxCell id="ctrl-safetyhub" value="SafetyHub" style="rounded=1;arcSize=15;whiteSpace=wrap;html=1;fillColor=#ffb0b0;strokeColor=#aa3333;strokeWidth=2;fontColor=#3a0a0a;fontSize=9;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="494" y="852" width="64" height="18" as="geometry"/>
+                </mxCell>
+                <mxCell id="ctrl-pmu" value="PMU24" style="rounded=1;arcSize=15;whiteSpace=wrap;html=1;fillColor=#b8d4f0;strokeColor=#2a5a8a;strokeWidth=2;fontColor=#1a3a5a;fontSize=11;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="440" y="350" width="100" height="25" as="geometry"/>
+                </mxCell>
+                <mxCell id="ctrl-bodypdu" value="BODY PDU" style="rounded=1;arcSize=15;whiteSpace=wrap;html=1;fillColor=#cce4b8;strokeColor=#558833;strokeWidth=2;fontColor=#2a4a1a;fontSize=10;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="465" y="460" width="90" height="28" as="geometry"/>
+                </mxCell>
+                <mxCell id="seat-rear" value="" style="rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#7a6a4a;strokeColor=#3a2a0a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="316" y="724" width="168" height="140" as="geometry"/>
+                </mxCell>
+                <mxCell id="bench-div-1" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#5a4a2a;strokeWidth=1;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="372" y="685" as="sourcePoint"/>
+                        <mxPoint x="372" y="800" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="bench-div-2" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#5a4a2a;strokeWidth=1;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="428" y="685" as="sourcePoint"/>
+                        <mxPoint x="428" y="800" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="tailgate" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#c8b888;strokeColor=#5a4a2a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="244" y="934" width="312" height="34" as="geometry"/>
+                </mxCell>
+                <mxCell id="bb-sp-front" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#aa44aa;strokeWidth=3;sketch=1;curveFitting=1;jiggle=2;edgeStyle=orthogonalEdgeStyle;curved=0;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="415" y="460" as="sourcePoint"/>
+                        <mxPoint x="380" y="240" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="380" y="460"/>
+                            <mxPoint x="380" y="405"/>
+                            <mxPoint x="380" y="300"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="bb-sp-front-lbl" value="H5 SwitchPros front&amp;#10;(fog, front locker,&amp;#10;front rock lights)" style="whiteSpace=wrap;text;html=1;align=center;fontSize=8;fontStyle=1;fontColor=#aa44aa;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;fillColor=#faf0fa;strokeColor=#aa44aa;" parent="1" vertex="1">
+                    <mxGeometry x="200" y="330" width="100" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="bb-sp-rear" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#cc66cc;strokeWidth=3;sketch=1;curveFitting=1;jiggle=2;edgeStyle=orthogonalEdgeStyle;curved=0;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="415" y="488" as="sourcePoint"/>
+                        <mxPoint x="400" y="930" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="380" y="500"/>
+                            <mxPoint x="380" y="690"/>
+                            <mxPoint x="380" y="900"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="bb-sp-rear-lbl" value="H6/7 Rear cabin trunk&amp;#10;SwitchPros rear portion&amp;#10;(combined with H7)" style="whiteSpace=wrap;text;html=1;align=center;fontSize=8;fontStyle=1;fontColor=#cc66cc;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;fillColor=#faf0fa;strokeColor=#cc66cc;" parent="1" vertex="1">
+                    <mxGeometry x="195" y="640" width="110" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="bb-pmu-rear" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#3388cc;strokeWidth=3;sketch=1;curveFitting=1;jiggle=2;edgeStyle=orthogonalEdgeStyle;curved=0;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="350" y="380" as="targetPoint"/>
+                        <mxPoint x="400" y="930" as="sourcePoint"/>
+                        <Array as="points">
+                            <mxPoint x="370" y="930"/>
+                            <mxPoint x="370" y="700"/>
+                            <mxPoint x="370" y="500"/>
+                            <mxPoint x="370" y="405"/>
+                            <mxPoint x="370" y="395"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="bb-pmu-rear-lbl" value="H6/7 Rear cabin trunk&amp;#10;PMU rear portion&amp;#10;(combined with H6)" style="whiteSpace=wrap;text;html=1;align=center;fontSize=8;fontStyle=1;fontColor=#3388cc;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;fillColor=#f0f5fa;strokeColor=#3388cc;" parent="1" vertex="1">
+                    <mxGeometry x="195" y="780" width="110" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-drl-l" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="265" y="222" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-drl-r" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="525" y="222" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-fturn-l" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#ffcc33;strokeColor=#aa7700;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="252" y="170" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-fturn-r" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#ffcc33;strokeColor=#aa7700;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="538" y="170" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-fog" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#ff8833;strokeColor=#aa4400;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="335" y="168" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-frock" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#ff8833;strokeColor=#aa4400;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="450" y="168" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-rrock-l" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#ff8833;strokeColor=#aa4400;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="158" y="800" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-rrock-r" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#ff8833;strokeColor=#aa4400;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="642" y="800" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-cargo-l" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#ff8833;strokeColor=#aa4400;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="252" y="892" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-cargo-r" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#ff8833;strokeColor=#aa4400;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="498" y="892" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-tail-l" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=3;" parent="1" vertex="1">
+                    <mxGeometry x="248" y="918" width="12" height="12" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-rturn-l" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#ffcc33;strokeColor=#aa7700;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="262" y="918" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-tail-r" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=3;" parent="1" vertex="1">
+                    <mxGeometry x="540" y="918" width="12" height="12" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-rturn-r" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#ffcc33;strokeColor=#aa7700;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="528" y="918" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-license" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="378" y="942" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-3rdbrake" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="418" y="942" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-chase" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#ff8833;strokeColor=#aa4400;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="395" y="980" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-rwork-l" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#ff8833;strokeColor=#aa4400;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="345" y="985" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-rwork-r" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#ff8833;strokeColor=#aa4400;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="445" y="985" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="lbl-dash" value="DASHBOARD + FIREWALL&#xa;CONSTANT BUS&#xa;CBs: 150A→SP, 100A→BP&#xa;SwitchPros, BODY PDU&#xa;SwitchPros GND bus&#xa;Dakota HDX, CT4 panel, SP panel,&#xa;HVAC, radio, gauges&#xa;(Fusion amp relocated under rear seat)" style="whiteSpace=wrap;text;html=1;align=center;fontSize=10;fontStyle=1;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;fillColor=#dde6f0;strokeColor=#445566;" parent="1" vertex="1">
+                    <mxGeometry x="710" y="430" width="200" height="110" as="geometry"/>
+                </mxCell>
+                <mxCell id="ldr-dash" style="endArrow=open;html=1;endSize=8;strokeColor=#445566;sketch=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="710" y="476" as="sourcePoint"/>
+                        <mxPoint x="555" y="450" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="lbl-rlhub" value="RL WHEEL WELL  ★&#xa;START BATTERY&#xa;CBs: 250A→PMU, 80A→BCDC in&#xa;(rear-left, beside bench)" style="whiteSpace=wrap;text;html=1;align=center;fontSize=11;fontStyle=1;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;fillColor=#fff0d8;strokeColor=#cc6600;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="20" y="730" width="170" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="ldr-rlhub" style="endArrow=open;html=1;endSize=8;strokeColor=#cc6600;sketch=1;jiggle=2;strokeWidth=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="170" y="760" as="sourcePoint"/>
+                        <mxPoint x="275" y="760" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="lbl-rrhub" value="RR WHEEL WELL  ★&#xa;AUX BATTERY (5 stacked lugs)&#xa;Inline CBs: 300A→fwd, 150A→SH, 100A→Fusion&#xa;Direct: Winch, BCDC output&#xa;SafetyHub, BCDC, Fusion Amp&#xa;(amp mounted under rear seat)" style="whiteSpace=wrap;text;html=1;align=center;fontSize=11;fontStyle=1;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;fillColor=#fff0d8;strokeColor=#cc6600;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="710" y="730" width="200" height="100" as="geometry"/>
+                </mxCell>
+                <mxCell id="ldr-rrhub" style="endArrow=open;html=1;endSize=8;strokeColor=#cc6600;sketch=1;jiggle=2;strokeWidth=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="710" y="760" as="sourcePoint"/>
+                        <mxPoint x="525" y="760" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="lg-title" value="LEGEND" style="whiteSpace=wrap;text;html=1;align=center;fontSize=13;fontStyle=1;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="20.0" y="1080.0" width="180" height="22" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-batt-s" value="BATT" style="rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#ffd84d;strokeColor=#aa6600;strokeWidth=2;fontColor=#3a2a0a;fontSize=8;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="40.0" y="1110.0" width="36" height="22" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-batt-t" value="Battery (START on driver side, AUX on passenger - both in rear wheel wells)" style="whiteSpace=wrap;text;html=1;align=left;verticalAlign=middle;fontSize=10;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="84.0" y="1110.0" width="430" height="22" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-hub-s" value="★" style="ellipse;whiteSpace=wrap;html=1;fillColor=#ff9933;strokeColor=#aa4400;strokeWidth=2;fontColor=#ffffff;fontSize=12;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;" parent="1" vertex="1">
+                    <mxGeometry x="40.0" y="1140.0" width="26" height="26" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-hub-t" value="Confirmed distribution hub" style="whiteSpace=wrap;text;html=1;align=left;verticalAlign=middle;fontSize=10;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="74.0" y="1138.0" width="200" height="26" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-cabin-s" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#e8d8b8;strokeColor=#5a4a2a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="40.0" y="1174.0" width="28" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-cabin-t" value="Body / cabin - protected interior space" style="whiteSpace=wrap;text;html=1;align=left;verticalAlign=middle;fontSize=10;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="78.0" y="1171.0" width="430" height="24" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-bb-title" value="BACKBONE RUNS" style="whiteSpace=wrap;text;html=1;align=left;verticalAlign=middle;fontSize=11;fontStyle=1;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="540.0" y="1080.0" width="200" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-bb-spf" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#aa44aa;strokeWidth=3;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="540.0" y="1190.0" as="sourcePoint"/>
+                        <mxPoint x="580.0" y="1190.0" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="lg-bb-spf-t" value="H5 SwitchPros front bundle (fog, front locker, front rock)" style="whiteSpace=wrap;text;html=1;align=left;verticalAlign=middle;fontSize=9;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="588.0" y="1183.0" width="320" height="16" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-bb-spr" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#cc66cc;strokeWidth=3;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="540.0" y="1210.0" as="sourcePoint"/>
+                        <mxPoint x="580.0" y="1210.0" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="lg-bb-spr-t" value="H6/7 Rear cabin trunk - SwitchPros rear portion" style="whiteSpace=wrap;text;html=1;align=left;verticalAlign=middle;fontSize=9;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="588.0" y="1203.0" width="380" height="16" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-bb-pmu" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#3388cc;strokeWidth=3;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="540.0" y="1230.0" as="sourcePoint"/>
+                        <mxPoint x="580.0" y="1230.0" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="lg-bb-pmu-t" value="H6/7 Rear cabin trunk - PMU rear portion (16 AWG)" style="whiteSpace=wrap;text;html=1;align=left;verticalAlign=middle;fontSize=9;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="588.0" y="1223.0" width="380" height="16" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-ld-title" value="LOADS (●)" style="whiteSpace=wrap;text;html=1;align=left;verticalAlign=middle;fontSize=11;fontStyle=1;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="1020.0" y="1080.0" width="100" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-ld-2" value="●" style="whiteSpace=wrap;text;html=1;align=center;verticalAlign=middle;fontSize=14;fontColor=#cc3333;fontStyle=1;" parent="1" vertex="1">
+                    <mxGeometry x="1020.0" y="1120.0" width="14" height="16" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-ld-2-t" value="PMU outputs (rad fan, HVAC, wipers, horn, DRL, tail/brake/reverse, license)" style="whiteSpace=wrap;text;html=1;align=left;verticalAlign=middle;fontSize=9;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="1038.0" y="1120.0" width="320" height="16" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-ld-3" value="●" style="whiteSpace=wrap;text;html=1;align=center;verticalAlign=middle;fontSize=14;fontColor=#ffcc33;fontStyle=1;" parent="1" vertex="1">
+                    <mxGeometry x="1020.0" y="1138.0" width="14" height="16" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-ld-3-t" value="CT4 (turn signals, headlight low/high)" style="whiteSpace=wrap;text;html=1;align=left;verticalAlign=middle;fontSize=9;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="1038.0" y="1138.0" width="290" height="16" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-ld-4" value="●" style="whiteSpace=wrap;text;html=1;align=center;verticalAlign=middle;fontSize=14;fontColor=#ff8833;fontStyle=1;" parent="1" vertex="1">
+                    <mxGeometry x="1020.0" y="1156.0" width="14" height="16" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-ld-4-t" value="SwitchPros (offroad lights, rock, chase, work, cargo, lockers, compressor ctrl)" style="whiteSpace=wrap;text;html=1;align=left;verticalAlign=middle;fontSize=9;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="1038.0" y="1156.0" width="320" height="16" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-footer" value="See docs/jeep_lj/01-power-systems/07-wire-routing/03-harness-inventory.md for full harness BOMs, connector specs, and routing details." style="text;html=1;align=center;verticalAlign=middle;fontSize=10;fontStyle=2;fontColor=#666666;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;whiteSpace=wrap;" parent="1" vertex="1">
+                    <mxGeometry x="40" y="1340" width="1400" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="p2-h5-fog" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#aa44aa;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="380" y="240" as="sourcePoint"/>
+                        <mxPoint x="341" y="174" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p2-h5-frock" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#aa44aa;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="380" y="240" as="sourcePoint"/>
+                        <mxPoint x="456" y="174" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p2-sprear-rrock-l" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#cc66cc;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="400" y="900" as="sourcePoint"/>
+                        <mxPoint x="164" y="806" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p2-sprear-rrock-r" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#cc66cc;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="400" y="900" as="sourcePoint"/>
+                        <mxPoint x="648" y="806" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p2-sprear-cargo-l" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#cc66cc;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="400" y="900" as="sourcePoint"/>
+                        <mxPoint x="258" y="898" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p2-sprear-cargo-r" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#cc66cc;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="400" y="900" as="sourcePoint"/>
+                        <mxPoint x="504" y="898" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p2-sprear-chase" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#cc66cc;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="400" y="900" as="sourcePoint"/>
+                        <mxPoint x="401" y="986" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p2-sprear-rwork-l" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#cc66cc;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="400" y="900" as="sourcePoint"/>
+                        <mxPoint x="351" y="991" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p2-sprear-rwork-r" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#cc66cc;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="400" y="900" as="sourcePoint"/>
+                        <mxPoint x="451" y="991" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p2-pmurear-tail-l" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#3388cc;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="370" y="900" as="sourcePoint"/>
+                        <mxPoint x="254" y="924" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p2-pmurear-tail-r" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#3388cc;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="370" y="900" as="sourcePoint"/>
+                        <mxPoint x="546" y="924" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p2-pmurear-license" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#3388cc;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="370" y="900" as="sourcePoint"/>
+                        <mxPoint x="384" y="948" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p2-pmurear-3rdbrake" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#3388cc;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="370" y="900" as="sourcePoint"/>
+                        <mxPoint x="424" y="948" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p2-pmu-drl-l" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#cc3333;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="440" y="363" as="sourcePoint"/>
+                        <mxPoint x="271" y="228" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p2-pmu-drl-r" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#cc3333;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="440" y="363" as="sourcePoint"/>
+                        <mxPoint x="531" y="228" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p2-ct4-fturn-l" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#ffcc33;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="323" y="485" as="sourcePoint"/>
+                        <mxPoint x="258" y="176" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p2-ct4-fturn-r" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#ffcc33;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="323" y="485" as="sourcePoint"/>
+                        <mxPoint x="544" y="176" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p2-ct4-rturn-l" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#ffcc33;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="323" y="485" as="sourcePoint"/>
+                        <mxPoint x="268" y="924" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p2-ct4-rturn-r" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#ffcc33;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="323" y="485" as="sourcePoint"/>
+                        <mxPoint x="534" y="924" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="fp1-marker" value="FP1" style="ellipse;whiteSpace=wrap;html=1;fillColor=#555555;strokeColor=#000000;strokeWidth=2;fontColor=#ffffff;fontSize=9;fontStyle=1;align=center;verticalAlign=middle;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="456" y="382" width="24" height="24" as="geometry"/>
+                </mxCell>
+                <mxCell id="fp2-marker" value="FP2" style="ellipse;whiteSpace=wrap;html=1;fillColor=#555555;strokeColor=#000000;strokeWidth=2;fontColor=#ffffff;fontSize=9;fontStyle=1;align=center;verticalAlign=middle;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="398" y="382" width="24" height="24" as="geometry"/>
+                </mxCell>
+                <mxCell id="fp-legend" value="FIREWALL PENETRATIONS (this page)&amp;#10;FP1 HDP24-24-29 (signal/control, passenger)&amp;#10;FP2 HDP24-18-14 (SwitchPros, passenger)" style="text;html=1;align=left;verticalAlign=top;fontSize=10;fontStyle=1;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;whiteSpace=wrap;fillColor=#eeeeee;strokeColor=#666666;strokeWidth=1;" parent="1" vertex="1">
+                    <mxGeometry x="710" y="380" width="280" height="60" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+    <diagram id="page-3" name="Controls, Recovery &amp; Drivetrain">
+        <mxGraphModel dx="1058" dy="547" grid="1" gridSize="10" guides="1" tooltips="1" connect="1" arrows="1" fold="1" page="1" pageScale="1" pageWidth="1500" pageHeight="1550" math="0" shadow="0">
+            <root>
+                <mxCell id="title" value="Jeep LJ - Controls, Recovery &amp; Drivetrain" style="whiteSpace=wrap;text;html=1;align=center;verticalAlign=middle;fontSize=22;fontStyle=1;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="40" y="20" width="900" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="subtitle" value="ARB compressor, winch trigger, Kilduff shifter, TCU + dash controls, comms, sensors, engine accessories" style="whiteSpace=wrap;text;html=1;align=center;verticalAlign=middle;fontSize=12;fontStyle=2;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;fontColor=#666666;" parent="1" vertex="1">
+                    <mxGeometry x="40" y="60" width="900" height="24" as="geometry"/>
+                </mxCell>
+                <mxCell id="0"/>
+                <mxCell id="1" parent="0"/>
+                <mxCell id="rear-bumper" value="" style="rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#2a2a2a;strokeColor=#000000;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="240" y="948" width="320" height="32" as="geometry"/>
+                </mxCell>
+                <mxCell id="orient-arrow" value="FRONT" style="endArrow=classic;html=1;rounded=0;fontSize=12;fontStyle=1;strokeWidth=2;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="60" y="200" as="sourcePoint"/>
+                        <mxPoint x="60" y="130" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="body-tub" value="" style="rounded=1;arcSize=6;whiteSpace=wrap;html=1;fillColor=#e8d8b8;strokeColor=#5a4a2a;strokeWidth=3;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="240" y="180" width="320" height="790" as="geometry"/>
+                </mxCell>
+                <mxCell id="hood" value="" style="rounded=1;arcSize=4;whiteSpace=wrap;html=1;fillColor=#d8c89a;strokeColor=#5a4a2a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="250" y="200" width="300" height="200" as="geometry"/>
+                </mxCell>
+                <mxCell id="hood-crease" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#5a4a2a;strokeWidth=1;dashed=1;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="400" y="220" as="sourcePoint"/>
+                        <mxPoint x="400" y="380" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="grille" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#3a3a3a;strokeColor=#000000;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="260" y="200" width="280" height="38" as="geometry"/>
+                </mxCell>
+                <mxCell id="slat1" value="" style="endArrow=none;html=1;strokeColor=#888888;strokeWidth=1;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="310" y="205" as="sourcePoint"/>
+                        <mxPoint x="310" y="233" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="slat2" value="" style="endArrow=none;html=1;strokeColor=#888888;strokeWidth=1;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="335" y="205" as="sourcePoint"/>
+                        <mxPoint x="335" y="233" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="slat3" value="" style="endArrow=none;html=1;strokeColor=#888888;strokeWidth=1;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="360" y="205" as="sourcePoint"/>
+                        <mxPoint x="360" y="233" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="slat4" value="" style="endArrow=none;html=1;strokeColor=#888888;strokeWidth=1;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="440" y="205" as="sourcePoint"/>
+                        <mxPoint x="440" y="233" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="slat5" value="" style="endArrow=none;html=1;strokeColor=#888888;strokeWidth=1;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="465" y="205" as="sourcePoint"/>
+                        <mxPoint x="465" y="233" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="slat6" value="" style="endArrow=none;html=1;strokeColor=#888888;strokeWidth=1;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="490" y="205" as="sourcePoint"/>
+                        <mxPoint x="490" y="233" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="headlight-l" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff7c0;strokeColor=#000000;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="278" y="200" width="36" height="36" as="geometry"/>
+                </mxCell>
+                <mxCell id="headlight-r" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#fff7c0;strokeColor=#000000;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="486" y="200" width="36" height="36" as="geometry"/>
+                </mxCell>
+                <mxCell id="front-bumper" value="" style="rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#2a2a2a;strokeColor=#000000;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="300" y="158" width="190" height="32" as="geometry"/>
+                </mxCell>
+                <mxCell id="fairlead" value="" style="rounded=1;arcSize=40;whiteSpace=wrap;html=1;fillColor=#888888;strokeColor=#000000;strokeWidth=1;" parent="1" vertex="1">
+                    <mxGeometry x="370" y="166" width="60" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="cowl" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#a89868;strokeColor=#5a4a2a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="248" y="390" width="304" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="windshield" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#c8d8e8;fillStyle=hatch;strokeColor=#5a4a2a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="252" y="404" width="296" height="50" as="geometry"/>
+                </mxCell>
+                <mxCell id="door-fl" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#5a4a2a;strokeWidth=1.5;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="240" y="460" as="sourcePoint"/>
+                        <mxPoint x="240" y="700" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="door-fl-h" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#5a4a2a;strokeWidth=1.5;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="240" y="700" as="sourcePoint"/>
+                        <mxPoint x="260" y="700" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="door-fr" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#5a4a2a;strokeWidth=1.5;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="560" y="460" as="sourcePoint"/>
+                        <mxPoint x="560" y="700" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="door-fr-h" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#5a4a2a;strokeWidth=1.5;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="560" y="700" as="sourcePoint"/>
+                        <mxPoint x="540" y="700" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="door-rl" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#5a4a2a;strokeWidth=1.5;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="240" y="710" as="sourcePoint"/>
+                        <mxPoint x="240" y="810" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="door-rr" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#5a4a2a;strokeWidth=1.5;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="560" y="710" as="sourcePoint"/>
+                        <mxPoint x="560" y="810" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="seat-dr" value="" style="rounded=1;arcSize=30;whiteSpace=wrap;html=1;fillColor=#7a6a4a;strokeColor=#3a2a0a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="278" y="500" width="90" height="150" as="geometry"/>
+                </mxCell>
+                <mxCell id="seat-pass" value="" style="rounded=1;arcSize=30;whiteSpace=wrap;html=1;fillColor=#7a6a4a;strokeColor=#3a2a0a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="432" y="500" width="90" height="150" as="geometry"/>
+                </mxCell>
+                <mxCell id="steering" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=none;strokeColor=#3a2a0a;strokeWidth=3;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="295" y="468" width="56" height="34" as="geometry"/>
+                </mxCell>
+                <mxCell id="console" value="" style="rounded=1;arcSize=20;whiteSpace=wrap;html=1;fillColor=#6a5a3a;strokeColor=#3a2a0a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="375" y="510" width="50" height="180" as="geometry"/>
+                </mxCell>
+                <mxCell id="ww-intrude-l" value="" style="rounded=1;arcSize=30;whiteSpace=wrap;html=1;fillColor=#c8b888;strokeColor=#5a4a2a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="240" y="710" width="70" height="180" as="geometry"/>
+                </mxCell>
+                <mxCell id="ww-intrude-r" value="" style="rounded=1;arcSize=30;whiteSpace=wrap;html=1;fillColor=#c8b888;strokeColor=#5a4a2a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="490" y="710" width="70" height="180" as="geometry"/>
+                </mxCell>
+                <mxCell id="batt-start" value="START" style="rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#ffd84d;strokeColor=#aa6600;strokeWidth=2;fontColor=#3a2a0a;fontSize=10;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="246" y="765" width="58" height="78" as="geometry"/>
+                </mxCell>
+                <mxCell id="batt-start-pos" value="+" style="ellipse;whiteSpace=wrap;html=1;fillColor=#cc0000;strokeColor=#660000;fontColor=#ffffff;fontSize=10;fontStyle=1;align=center;verticalAlign=middle;" parent="1" vertex="1">
+                    <mxGeometry x="254" y="772" width="14" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="batt-start-neg" value="-" style="ellipse;whiteSpace=wrap;html=1;fillColor=#222222;strokeColor=#000000;fontColor=#ffffff;fontSize=11;fontStyle=1;align=center;verticalAlign=middle;" parent="1" vertex="1">
+                    <mxGeometry x="282" y="772" width="14" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="cb-pmu" value="250A→PMU" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=1;fontColor=#ffffff;fontSize=7;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="246" y="720" width="58" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="cb-bcdc-in" value="80A→BCDC in" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=1;fontColor=#ffffff;fontSize=7;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="246" y="738" width="58" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="batt-aux" value="AUX" style="rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#ffd84d;strokeColor=#aa6600;strokeWidth=2;fontColor=#3a2a0a;fontSize=10;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="496" y="738" width="58" height="78" as="geometry"/>
+                </mxCell>
+                <mxCell id="batt-aux-pos" value="+" style="ellipse;whiteSpace=wrap;html=1;fillColor=#cc0000;strokeColor=#660000;fontColor=#ffffff;fontSize=10;fontStyle=1;align=center;verticalAlign=middle;" parent="1" vertex="1">
+                    <mxGeometry x="504" y="745" width="14" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="batt-aux-neg" value="-" style="ellipse;whiteSpace=wrap;html=1;fillColor=#222222;strokeColor=#000000;fontColor=#ffffff;fontSize=11;fontStyle=1;align=center;verticalAlign=middle;" parent="1" vertex="1">
+                    <mxGeometry x="532" y="745" width="14" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="cb-master" value="300A→fwd" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=1;fontColor=#ffffff;fontSize=7;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="494" y="720" width="64" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="cb-fu" value="100A→Fusion" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=1;fontColor=#ffffff;fontSize=7;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="494" y="836" width="64" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="cb-sh" value="150A→SH" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=1;fontColor=#ffffff;fontSize=7;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="494" y="820" width="64" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="ctrl-bcdc" value="BCDC" style="rounded=1;arcSize=15;whiteSpace=wrap;html=1;fillColor=#ffb870;strokeColor=#aa5500;strokeWidth=2;fontColor=#3a2a0a;fontSize=9;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="494" y="872" width="64" height="18" as="geometry"/>
+                </mxCell>
+                <mxCell id="ctrl-switchpros" value="SwitchPros" style="rounded=1;arcSize=15;whiteSpace=wrap;html=1;fillColor=#d8b8e8;strokeColor=#664488;strokeWidth=2;fontColor=#2a1a3a;fontSize=10;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="370" y="460" width="90" height="28" as="geometry"/>
+                </mxCell>
+                <mxCell id="ctrl-bus2" value="CONSTANT BUS" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#aaaaaa;strokeColor=#444444;strokeWidth=1;fontColor=#000000;fontSize=8;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="370" y="414" width="185" height="12" as="geometry"/>
+                </mxCell>
+                <mxCell id="cb-fw-sp" value="150A→SP" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=1;fontColor=#ffffff;fontSize=7;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="370" y="429" width="90" height="12" as="geometry"/>
+                </mxCell>
+                <mxCell id="cb-fw-bp" value="100A→BP" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=1;fontColor=#ffffff;fontSize=7;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="465" y="429" width="90" height="12" as="geometry"/>
+                </mxCell>
+                <mxCell id="ctrl-sp-gnd" value="SwitchPros GND BUS" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#888888;strokeColor=#333333;strokeWidth=1;fontColor=#ffffff;fontSize=7;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="370" y="446" width="185" height="12" as="geometry"/>
+                </mxCell>
+                <mxCell id="ctrl-safetyhub" value="SafetyHub" style="rounded=1;arcSize=15;whiteSpace=wrap;html=1;fillColor=#ffb0b0;strokeColor=#aa3333;strokeWidth=2;fontColor=#3a0a0a;fontSize=9;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="494" y="852" width="64" height="18" as="geometry"/>
+                </mxCell>
+                <mxCell id="ctrl-pmu" value="PMU24" style="rounded=1;arcSize=15;whiteSpace=wrap;html=1;fillColor=#b8d4f0;strokeColor=#2a5a8a;strokeWidth=2;fontColor=#1a3a5a;fontSize=11;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="440" y="350" width="100" height="25" as="geometry"/>
+                </mxCell>
+                <mxCell id="ctrl-bodypdu" value="BODY PDU" style="rounded=1;arcSize=15;whiteSpace=wrap;html=1;fillColor=#cce4b8;strokeColor=#558833;strokeWidth=2;fontColor=#2a4a1a;fontSize=10;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="465" y="460" width="90" height="28" as="geometry"/>
+                </mxCell>
+                <mxCell id="seat-rear" value="" style="rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#7a6a4a;strokeColor=#3a2a0a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="316" y="724" width="168" height="140" as="geometry"/>
+                </mxCell>
+                <mxCell id="bench-div-1" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#5a4a2a;strokeWidth=1;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="372" y="685" as="sourcePoint"/>
+                        <mxPoint x="372" y="800" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="bench-div-2" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#5a4a2a;strokeWidth=1;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="428" y="685" as="sourcePoint"/>
+                        <mxPoint x="428" y="800" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="tailgate" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#c8b888;strokeColor=#5a4a2a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="244" y="934" width="312" height="34" as="geometry"/>
+                </mxCell>
+                <mxCell id="bb-arb" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#ff8833;strokeWidth=4;sketch=1;curveFitting=1;jiggle=2;edgeStyle=orthogonalEdgeStyle;curved=0;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="525" y="760" as="sourcePoint"/>
+                        <mxPoint x="477" y="667" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="525" y="700"/>
+                            <mxPoint x="475" y="700"/>
+                            <mxPoint x="475" y="620"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="bb-arb-lbl" value="H8 ARB compressor&amp;#10;(6 AWG ×2 + 14 AWG ctrl)&amp;#10;to under passenger seat" style="whiteSpace=wrap;text;html=1;align=center;fontSize=8;fontStyle=1;fontColor=#cc6611;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;fillColor=#fff5ee;strokeColor=#ff8833;" parent="1" vertex="1">
+                    <mxGeometry x="600" y="680" width="120" height="42" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-radfan" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="340" y="252" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-hvac" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="475" y="352" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-wipers" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="445" y="392" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-horn" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="298" y="298" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-hdx" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#33aacc;strokeColor=#226688;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="378" y="462" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-gmrs" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#33aacc;strokeColor=#226688;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="435" y="472" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-sp-panel" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#33aacc;strokeColor=#226688;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="455" y="462" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-garmin" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#33aacc;strokeColor=#226688;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="358" y="475" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-keyless" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#33aacc;strokeColor=#226688;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="298" y="466" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-wolfbox" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#33aacc;strokeColor=#226688;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="395" y="458" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-fusion-hu" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#3366cc;strokeColor=#224488;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="418" y="488" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-hs-dr" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#66aa66;strokeColor=#336633;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="318" y="570" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-hs-pass" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#66aa66;strokeColor=#336633;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="472" y="570" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-usb" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#66aa66;strokeColor=#336633;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="395" y="555" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-intercom-f" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#33aacc;strokeColor=#226688;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="395" y="540" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-arb-mani" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#888888;strokeColor=#444444;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="490" y="668" width="8" height="8" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-intercom-r" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#33aacc;strokeColor=#226688;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="395" y="745" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-cargo-sw" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#888888;strokeColor=#444444;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="540" y="892" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-rcam" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#33aacc;strokeColor=#226688;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="398" y="965" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-airchuck" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#888888;strokeColor=#444444;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="478" y="985" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="lbl-dash" value="DASHBOARD + FIREWALL&#xa;CONSTANT BUS&#xa;CBs: 150A→SP, 100A→BP&#xa;SwitchPros, BODY PDU&#xa;SwitchPros GND bus&#xa;Dakota HDX, CT4 panel, SP panel,&#xa;HVAC, radio, gauges&#xa;(Fusion amp relocated under rear seat)" style="whiteSpace=wrap;text;html=1;align=center;fontSize=10;fontStyle=1;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;fillColor=#dde6f0;strokeColor=#445566;" parent="1" vertex="1">
+                    <mxGeometry x="710" y="430" width="200" height="110" as="geometry"/>
+                </mxCell>
+                <mxCell id="ldr-dash" style="endArrow=open;html=1;endSize=8;strokeColor=#445566;sketch=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="710" y="476" as="sourcePoint"/>
+                        <mxPoint x="555" y="450" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="lbl-rlhub" value="RL WHEEL WELL  ★&#xa;START BATTERY&#xa;CBs: 250A→PMU, 80A→BCDC in&#xa;(rear-left, beside bench)" style="whiteSpace=wrap;text;html=1;align=center;fontSize=11;fontStyle=1;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;fillColor=#fff0d8;strokeColor=#cc6600;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="20" y="730" width="170" height="80" as="geometry"/>
+                </mxCell>
+                <mxCell id="ldr-rlhub" style="endArrow=open;html=1;endSize=8;strokeColor=#cc6600;sketch=1;jiggle=2;strokeWidth=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="170" y="760" as="sourcePoint"/>
+                        <mxPoint x="275" y="760" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="lbl-rrhub" value="RR WHEEL WELL  ★&#xa;AUX BATTERY (5 stacked lugs)&#xa;Inline CBs: 300A→fwd, 150A→SH, 100A→Fusion&#xa;Direct: Winch, BCDC output&#xa;SafetyHub, BCDC, Fusion Amp&#xa;(amp mounted under rear seat)" style="whiteSpace=wrap;text;html=1;align=center;fontSize=11;fontStyle=1;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;fillColor=#fff0d8;strokeColor=#cc6600;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="710" y="730" width="200" height="100" as="geometry"/>
+                </mxCell>
+                <mxCell id="ldr-rrhub" style="endArrow=open;html=1;endSize=8;strokeColor=#cc6600;sketch=1;jiggle=2;strokeWidth=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="710" y="760" as="sourcePoint"/>
+                        <mxPoint x="525" y="760" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="lg-title" value="LEGEND" style="whiteSpace=wrap;text;html=1;align=center;fontSize=13;fontStyle=1;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="20.0" y="1080.0" width="180" height="22" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-batt-s" value="BATT" style="rounded=1;arcSize=10;whiteSpace=wrap;html=1;fillColor=#ffd84d;strokeColor=#aa6600;strokeWidth=2;fontColor=#3a2a0a;fontSize=8;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="40.0" y="1110.0" width="36" height="22" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-batt-t" value="Battery (START on driver side, AUX on passenger - both in rear wheel wells)" style="whiteSpace=wrap;text;html=1;align=left;verticalAlign=middle;fontSize=10;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="84.0" y="1110.0" width="430" height="22" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-hub-s" value="★" style="ellipse;whiteSpace=wrap;html=1;fillColor=#ff9933;strokeColor=#aa4400;strokeWidth=2;fontColor=#ffffff;fontSize=12;fontStyle=1;align=center;verticalAlign=middle;sketch=1;curveFitting=1;jiggle=2;" parent="1" vertex="1">
+                    <mxGeometry x="40.0" y="1140.0" width="26" height="26" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-hub-t" value="Confirmed distribution hub" style="whiteSpace=wrap;text;html=1;align=left;verticalAlign=middle;fontSize=10;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="74.0" y="1138.0" width="200" height="26" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-cabin-s" value="" style="rounded=0;whiteSpace=wrap;html=1;fillColor=#e8d8b8;strokeColor=#5a4a2a;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;sketchStyle=comic;" parent="1" vertex="1">
+                    <mxGeometry x="40.0" y="1174.0" width="28" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-cabin-t" value="Body / cabin - protected interior space" style="whiteSpace=wrap;text;html=1;align=left;verticalAlign=middle;fontSize=10;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="78.0" y="1171.0" width="430" height="24" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-bb-title" value="BACKBONE RUNS" style="whiteSpace=wrap;text;html=1;align=left;verticalAlign=middle;fontSize=11;fontStyle=1;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="540.0" y="1080.0" width="200" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-bb-arb" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#ff8833;strokeWidth=4;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="540.0" y="1250.0" as="sourcePoint"/>
+                        <mxPoint x="580.0" y="1250.0" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="lg-bb-arb-t" value="H8 ARB compressor (6 AWG ×2 motor + 14 AWG control)" style="whiteSpace=wrap;text;html=1;align=left;verticalAlign=middle;fontSize=9;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="588.0" y="1243.0" width="380" height="16" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-ld-title" value="LOADS (●)" style="whiteSpace=wrap;text;html=1;align=left;verticalAlign=middle;fontSize=11;fontStyle=1;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="1020.0" y="1080.0" width="100" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-ld-2" value="●" style="whiteSpace=wrap;text;html=1;align=center;verticalAlign=middle;fontSize=14;fontColor=#cc3333;fontStyle=1;" parent="1" vertex="1">
+                    <mxGeometry x="1020.0" y="1120.0" width="14" height="16" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-ld-2-t" value="PMU outputs (rad fan, HVAC, wipers, horn, DRL, tail/brake/reverse, license)" style="whiteSpace=wrap;text;html=1;align=left;verticalAlign=middle;fontSize=9;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="1038.0" y="1120.0" width="320" height="16" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-ld-5" value="●" style="whiteSpace=wrap;text;html=1;align=center;verticalAlign=middle;fontSize=14;fontColor=#66aa66;fontStyle=1;" parent="1" vertex="1">
+                    <mxGeometry x="1020.0" y="1174.0" width="14" height="16" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-ld-5-t" value="BODY PDU (heated seats, USB, radio, camera)" style="whiteSpace=wrap;text;html=1;align=left;verticalAlign=middle;fontSize=9;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="1038.0" y="1174.0" width="290" height="16" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-ld-6" value="●" style="whiteSpace=wrap;text;html=1;align=center;verticalAlign=middle;fontSize=14;fontColor=#3366cc;fontStyle=1;" parent="1" vertex="1">
+                    <mxGeometry x="1020.0" y="1192.0" width="14" height="16" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-ld-6-t" value="Audio (amp, head unit, speakers)" style="whiteSpace=wrap;text;html=1;align=left;verticalAlign=middle;fontSize=9;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="1038.0" y="1192.0" width="290" height="16" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-ld-7" value="●" style="whiteSpace=wrap;text;html=1;align=center;verticalAlign=middle;fontSize=14;fontColor=#33aacc;fontStyle=1;" parent="1" vertex="1">
+                    <mxGeometry x="1020.0" y="1210.0" width="14" height="16" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-ld-7-t" value="Instruments / control (HDX, CT4, panels, GMRS, intercom, GPS, keyless, cam)" style="whiteSpace=wrap;text;html=1;align=left;verticalAlign=middle;fontSize=9;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="1038.0" y="1210.0" width="320" height="16" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-ld-8" value="●" style="whiteSpace=wrap;text;html=1;align=center;verticalAlign=middle;fontSize=14;fontColor=#888888;fontStyle=1;" parent="1" vertex="1">
+                    <mxGeometry x="1020.0" y="1228.0" width="14" height="16" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-ld-8-t" value="Sensors / triggers (door, pressure, cargo rocker, air chuck)" style="whiteSpace=wrap;text;html=1;align=left;verticalAlign=middle;fontSize=9;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="1038.0" y="1228.0" width="290" height="16" as="geometry"/>
+                </mxCell>
+                <mxCell id="bb-winch-trig" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#996633;strokeWidth=3;sketch=1;curveFitting=1;jiggle=2;edgeStyle=orthogonalEdgeStyle;curved=0;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="510" y="475" as="sourcePoint"/>
+                        <mxPoint x="400" y="190" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="390" y="475"/>
+                            <mxPoint x="390" y="430"/>
+                            <mxPoint x="430" y="430"/>
+                            <mxPoint x="430" y="395"/>
+                            <mxPoint x="430" y="300"/>
+                            <mxPoint x="430" y="240"/>
+                            <mxPoint x="430" y="200"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="bb-winch-trig-lbl" value="H9 Winch trigger&#xa;(18 AWG via CH4X4&#xa;at dash, BODY PDU CB43)" style="whiteSpace=wrap;text;html=1;align=center;fontSize=8;fontStyle=1;fontColor=#996633;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;fillColor=#fff5ee;strokeColor=#996633;" parent="1" vertex="1">
+                    <mxGeometry x="190" y="200" width="120" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="bb-shifter" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#444488;strokeWidth=4;sketch=1;curveFitting=1;jiggle=2;edgeStyle=orthogonalEdgeStyle;curved=0;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="400" y="600" as="sourcePoint"/>
+                        <mxPoint x="400" y="690" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="bb-shifter-lbl" value="H10 Kilduff → TCU&#xa;(factory 8HP70 connector,&#xa;~3-5 ft, trans tunnel)" style="whiteSpace=wrap;text;html=1;align=center;fontSize=8;fontStyle=1;fontColor=#444488;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;fillColor=#f0f0fa;strokeColor=#444488;" parent="1" vertex="1">
+                    <mxGeometry x="600" y="600" width="140" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="bb-tcu-eb" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#226633;strokeWidth=3;sketch=1;curveFitting=1;jiggle=2;edgeStyle=orthogonalEdgeStyle;curved=0;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="400" y="690" as="sourcePoint"/>
+                        <mxPoint x="440" y="363" as="targetPoint"/>
+                        <Array as="points">
+                            <mxPoint x="400" y="500"/>
+                            <mxPoint x="400" y="395"/>
+                            <mxPoint x="370" y="395"/>
+                        </Array>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="bb-tcu-eb-lbl" value="H11 TCU → engine bay&#xa;(14 AWG power, J1939,&#xa;aux Reverse/PN, ground)" style="whiteSpace=wrap;text;html=1;align=center;fontSize=8;fontStyle=1;fontColor=#226633;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;fillColor=#f0faf0;strokeColor=#226633;" parent="1" vertex="1">
+                    <mxGeometry x="195" y="430" width="130" height="40" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-bb-wtrig" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#996633;strokeWidth=3;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="540.0" y="1230.0" as="sourcePoint"/>
+                        <mxPoint x="580.0" y="1230.0" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="lg-bb-wtrig-t" value="H9 Winch trigger (18 AWG, via BODY PDU CB43 + CH4X4 switch)" style="whiteSpace=wrap;text;html=1;align=left;verticalAlign=middle;fontSize=9;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="588.0" y="1223.0" width="380" height="16" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-bb-shifter" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#444488;strokeWidth=4;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="540.0" y="1250.0" as="sourcePoint"/>
+                        <mxPoint x="580.0" y="1250.0" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="lg-bb-shifter-t" value="H10 Kilduff shifter → TCU (factory 8HP70 connector)" style="whiteSpace=wrap;text;html=1;align=left;verticalAlign=middle;fontSize=9;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="588.0" y="1243.0" width="380" height="16" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-bb-tcueb" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#226633;strokeWidth=3;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="540.0" y="1270.0" as="sourcePoint"/>
+                        <mxPoint x="580.0" y="1270.0" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="lg-bb-tcueb-t" value="H11 TCU → engine bay (power, J1939, aux outputs)" style="whiteSpace=wrap;text;html=1;align=left;verticalAlign=middle;fontSize=9;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="588.0" y="1263.0" width="380" height="16" as="geometry"/>
+                </mxCell>
+                <mxCell id="lg-footer" value="See docs/jeep_lj/01-power-systems/07-wire-routing/03-harness-inventory.md for full harness BOMs, connector specs, and routing details." style="text;html=1;align=center;verticalAlign=middle;fontSize=10;fontStyle=2;fontColor=#666666;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;whiteSpace=wrap;" parent="1" vertex="1">
+                    <mxGeometry x="40" y="1340" width="1400" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="p3-pmu-radfan" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#cc3333;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="440" y="363" as="sourcePoint"/>
+                        <mxPoint x="346" y="258" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p3-pmu-hvac" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#cc3333;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="440" y="363" as="sourcePoint"/>
+                        <mxPoint x="481" y="358" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p3-pmu-wipers" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#cc3333;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="440" y="363" as="sourcePoint"/>
+                        <mxPoint x="451" y="398" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p3-pmu-horn" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#cc3333;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="440" y="363" as="sourcePoint"/>
+                        <mxPoint x="304" y="304" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p3-pmu-hdx" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#cc3333;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="440" y="363" as="sourcePoint"/>
+                        <mxPoint x="384" y="468" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p3-pmu-gmrs" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#cc3333;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="440" y="363" as="sourcePoint"/>
+                        <mxPoint x="441" y="478" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p3-pmu-garmin" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#cc3333;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="440" y="363" as="sourcePoint"/>
+                        <mxPoint x="364" y="481" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p3-pmu-keyless" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#cc3333;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="440" y="363" as="sourcePoint"/>
+                        <mxPoint x="304" y="472" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p3-pmu-intercom-f" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#cc3333;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="440" y="363" as="sourcePoint"/>
+                        <mxPoint x="401" y="546" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p3-pmu-intercom-r" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#cc3333;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="440" y="363" as="sourcePoint"/>
+                        <mxPoint x="401" y="751" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p3-sp-panel" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#aa44aa;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="415" y="474" as="sourcePoint"/>
+                        <mxPoint x="461" y="468" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p3-sp-arb-mani" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#aa44aa;strokeWidth=2;dashed=1;dashPattern=4 4;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="415" y="474" as="sourcePoint"/>
+                        <mxPoint x="494" y="672" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p3-sp-cargo-sw" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#aa44aa;strokeWidth=2;dashed=1;dashPattern=4 4;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="415" y="474" as="sourcePoint"/>
+                        <mxPoint x="546" y="898" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p3-bp-wolfbox" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#66aa66;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="510" y="474" as="sourcePoint"/>
+                        <mxPoint x="401" y="464" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p3-bp-fusion-hu" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#66aa66;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="510" y="474" as="sourcePoint"/>
+                        <mxPoint x="424" y="494" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p3-bp-hs-dr" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#66aa66;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="510" y="474" as="sourcePoint"/>
+                        <mxPoint x="324" y="576" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p3-bp-hs-pass" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#66aa66;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="510" y="474" as="sourcePoint"/>
+                        <mxPoint x="478" y="576" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p3-bp-usb" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#66aa66;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="510" y="474" as="sourcePoint"/>
+                        <mxPoint x="401" y="561" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="p3-bp-rcam" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#66aa66;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="510" y="474" as="sourcePoint"/>
+                        <mxPoint x="404" y="971" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="ld-ibooster" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#cc3333;strokeColor=#660000;strokeWidth=2;" parent="1" vertex="1">
+                    <mxGeometry x="268" y="382" width="13" height="13" as="geometry"/>
+                </mxCell>
+                <mxCell id="ld-arb-comp" value="" style="ellipse;whiteSpace=wrap;html=1;fillColor=#ff8833;strokeColor=#aa4400;strokeWidth=3;" parent="1" vertex="1">
+                    <mxGeometry x="470" y="660" width="14" height="14" as="geometry"/>
+                </mxCell>
+                <mxCell id="p3-pmu-ibooster" value="" style="endArrow=none;html=1;rounded=0;strokeColor=#cc3333;strokeWidth=2;sketch=1;curveFitting=1;jiggle=2;" parent="1" edge="1">
+                    <mxGeometry relative="1" as="geometry">
+                        <mxPoint x="440" y="363" as="sourcePoint"/>
+                        <mxPoint x="282" y="389" as="targetPoint"/>
+                    </mxGeometry>
+                </mxCell>
+                <mxCell id="fp1-marker" value="FP1" style="ellipse;whiteSpace=wrap;html=1;fillColor=#555555;strokeColor=#000000;strokeWidth=2;fontColor=#ffffff;fontSize=9;fontStyle=1;align=center;verticalAlign=middle;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="456" y="382" width="24" height="24" as="geometry"/>
+                </mxCell>
+                <mxCell id="fp5-marker" value="FP5" style="ellipse;whiteSpace=wrap;html=1;fillColor=#c8b888;strokeColor=#5a4a2a;strokeWidth=2;fontColor=#3a2a0a;fontSize=9;fontStyle=1;align=center;verticalAlign=middle;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;" parent="1" vertex="1">
+                    <mxGeometry x="294" y="384" width="20" height="20" as="geometry"/>
+                </mxCell>
+                <mxCell id="fp-legend" value="FIREWALL PENETRATIONS (this page)&amp;#10;FP1 HDP24-24-29 (signal/control, passenger)&amp;#10;FP5 Small grommet (driver) — Dakota Digital BIM-17-2 → grille temp sensor" style="text;html=1;align=left;verticalAlign=top;fontSize=10;fontStyle=1;fontFamily=Architects Daughter;fontSource=https%3A%2F%2Ffonts.googleapis.com%2Fcss%3Ffamily%3DArchitects%2BDaughter;whiteSpace=wrap;fillColor=#eeeeee;strokeColor=#666666;strokeWidth=1;" parent="1" vertex="1">
+                    <mxGeometry x="710" y="380" width="280" height="60" as="geometry"/>
+                </mxCell>
+            </root>
+        </mxGraphModel>
+    </diagram>
+</mxfile>

--- a/docs/jeep_lj/01-power-systems/01-power-generation/01-batteries.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/01-batteries.md
@@ -97,16 +97,16 @@ Accessories and high-draw auxiliary loads:
 
 ## System Configuration
 
-- **START battery (Driver Wheel Well):** Odyssey PC1500 - critical systems
-- **AUX battery (Passenger Wheel Well):** Dakota Lithium 135Ah - accessories
+- **START battery (Driver Rear Wheel Well):** Odyssey PC1500 - critical systems
+- **AUX battery (Passenger Rear Wheel Well):** Dakota Lithium 135Ah - accessories
 - **Isolation:** BCDC Alpha 50 (independent operation when engine off)
 - **Jump Start:** BCDC jump start assist can parallel batteries if START fails
 - **Redundancy:** Vehicle operates on START battery alone if AUX system fails
 
 ## Mounting
 
-- **START battery:** Driver wheel well - enclosed compartment with access panel
-- **AUX battery:** Passenger wheel well - Barnes 4WD battery box (Group 24 compatible)
+- **START battery:** Driver rear wheel well - enclosed compartment with access panel
+- **AUX battery:** Passenger rear wheel well - Barnes 4WD battery box (Group 24 compatible)
 
 ## Outstanding Items
 

--- a/docs/jeep_lj/01-power-systems/01-power-generation/02-alternator.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/02-alternator.md
@@ -48,10 +48,10 @@ tags:
 
 | Connection      | Destination                        | Notes                                                            |
 | :-------------- | :--------------------------------- | :--------------------------------------------------------------- |
-| Positive Output | START battery+ (driver wheel well) | See [START Battery Distribution][starter-battery] for wire specs |
+| Positive Output | START battery+ (driver rear wheel well) | See [START Battery Distribution][starter-battery] for wire specs |
 | Ground          | Engine block                       | Bonded via alternator mounting bolts                             |
 
-**Ground Path:** Alternator case → Engine block → Frame rail → START battery-
+**Ground Path:** Alternator case → Engine block → Engine bay ground bus → START battery- (driver rear wheel well)
 
 See [START Battery Distribution][starter-battery] for complete wire specifications (gauge, distance, voltage drop calculations).
 

--- a/docs/jeep_lj/01-power-systems/01-power-generation/03-bcdc.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/03-bcdc.md
@@ -76,7 +76,7 @@ See [AUX Battery Load Analysis][aux-load-analysis] for complete scenario details
 
 ## Mounting
 
-- **Location:** Passenger wheel well near AUX battery (water-protected, accessible for LED visibility)
+- **Location:** Passenger rear wheel well near AUX battery (water-protected, accessible for LED visibility)
 - **Installation:** See [Section 1 Installation Checklist][installation-checklist]
 
 ## Temperature Sensor Installation
@@ -105,7 +105,7 @@ The BCDC includes a battery temperature sensor (2-pin, polarity reversible) that
 **Installation Notes:**
 
 1. Install ring terminal on AUX battery positive terminal bolt
-2. Route sensor cable to BCDC (short run - both in passenger wheel well)
+2. Route sensor cable to BCDC (short run - both in passenger rear wheel well)
 3. Plug into BCDC temperature sensor port (2-pin connector)
 
 [redarc-bcdc]: https://www.redarcelectronics.com/products/the-manager30

--- a/docs/jeep_lj/01-power-systems/01-power-generation/04-solar.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/04-solar.md
@@ -57,7 +57,7 @@ tags:
 - **Positive (+):** Panel output → BCDC Alpha 50 solar input positive terminal
 - **Negative (-):** Panel output → Chassis ground (NOT to BCDC negative)
 - **Wire Gauge:** 10 AWG minimum (for 2.23A Isc with safety margin)
-- **Routing:** Hood → Firewall → BCDC location in wheel well
+- **Routing:** Hood → Firewall → BCDC location in passenger rear wheel well
 - **Maximum Current:** 2.23A (Isc) - well within BCDC solar input capacity
 
 **VSS System Note:** VSS kit includes standalone MPPT controller - **not used**. BCDC has built-in MPPT on solar input, providing Green Power Priority and unified charge control.
@@ -130,7 +130,7 @@ Voltage Module Power: Self-powered from solar panel voltage
 
 ### Installation Notes
 
-- Mount module in weatherproof location (near BCDC in wheel well, or sealed enclosure)
+- Mount module in weatherproof location (near BCDC in passenger rear wheel well, or sealed enclosure)
 - Use MC4 inline connectors for easy solar disconnect during installation
 - Consider conformal coating on PCB for moisture protection
 - Test threshold settings before final installation

--- a/docs/jeep_lj/01-power-systems/01-power-generation/05-wire-distance-reference.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/05-wire-distance-reference.md
@@ -10,21 +10,21 @@ Measured wire routing distances between major electrical components for voltage 
 !!! note "Measurement Method"
 These distances represent actual measured cable routing paths (not straight-line distances) following frame rails, firewall passages, and avoiding obstacles. All measurements are one-way cable length.
 
-!!! info "Dual Wheel Well Battery Configuration"
+!!! info "Dual Rear Wheel Well Battery Configuration"
 Both batteries located in rear wheel wells for optimal wire routing:
 
-    - **Driver Wheel Well** = START battery (critical systems)
-    - **Passenger Wheel Well** = AUX battery (accessories)
+    - **Driver Rear Wheel Well** = START battery (critical systems)
+    - **Passenger Rear Wheel Well** = AUX battery (accessories)
 
 ## Component Distance Matrix
 
 | From                         | To                                     | Distance | Notes                                                 |
 |:-----------------------------|:---------------------------------------|:---------|:------------------------------------------------------|
-| **Alternator**               | **START battery** (driver wheel well)  | 8 ft     | Primary charging path                                 |
-| **Starter**                  | **START battery** (driver wheel well)  | 6 ft     | Cranking power                                        |
-| **PMU24**                    | **START battery** (driver wheel well)  | 7 ft     | Critical systems power                                |
-| **BCDC Alpha 50**            | START battery → AUX battery            | 5-6 ft   | Inter-battery charging (BCDC in passenger wheel well) |
-| **Winch** (front bumper)     | **AUX battery** (passenger wheel well) | 13 ft    | Recovery system power                                 |
+| **Alternator**               | **START battery** (driver rear wheel well)  | 8 ft     | Primary charging path                                 |
+| **Starter**                  | **START battery** (driver rear wheel well)  | 6 ft     | Cranking power                                        |
+| **PMU24**                    | **START battery** (driver rear wheel well)  | 7 ft     | Critical systems power                                |
+| **BCDC Alpha 50**            | START battery → AUX battery            | 5-6 ft   | Inter-battery charging (BCDC in passenger rear wheel well) |
+| **Winch** (front bumper)     | **AUX battery** (passenger rear wheel well) | 13 ft    | Recovery system power                                 |
 | **OEM Battery** (engine bay) | **Starter**                            | 4 ft     | Reference: original configuration                     |
 | **OEM Battery** (engine bay) | **Winch** (front bumper)               | 5 ft     | Reference: original configuration                     |
 | **OEM Battery** (engine bay) | **Alternator**                         | 4 ft     | Reference: original configuration                     |
@@ -46,8 +46,8 @@ Wire gauges optimized for performance at measured routing distances:
 | **Alternator → START battery** | 8 ft                          | 2/0 AWG    | 270A                    | 2.81% @ 60°C                     | Charging system - temp derating applied                   |
 | **PMU24 Power Feed**           | 7 ft                          | 2/0 AWG    | 220A                    | 2.40% @ 60°C                     | Direct connection via 250A CB - upgraded from 1/0 AWG     |
 | **Starter Motor**              | 6 ft                          | 2/0 AWG    | 400-600A                | <3% @ 20°C                       | Brief cranking load - minimal temp effect                 |
-| **BCDC Inter-Battery**         | 5-6 ft                        | 4 AWG      | 50A                     | 0.94% @ 20°C                     | Wheel well to wheel well via frame rail                   |
-| **Winch → AUX battery**        | 13 ft one-way (26 ft circuit) | 1/0 AWG    | 250A typical, 400A peak | 6.3% @ 250A, 10.1% @ 400A @ 20°C | Wheel well routing, system voltage 13.8V (engine running) |
+| **BCDC Inter-Battery**         | 5-6 ft                        | 4 AWG      | 50A                     | 0.94% @ 20°C                     | Rear wheel well to rear wheel well (cross-cab routing TBD - see [Wire Routing][wire-routing]) |
+| **Winch → AUX battery**        | 13 ft one-way (26 ft circuit) | 1/0 AWG    | 250A typical, 400A peak | 6.3% @ 250A, 10.1% @ 400A @ 20°C | Passenger rear wheel well to front bumper routing (path TBD - see [Wire Routing][wire-routing]) |
 
 **Temperature Derating Notes:**
 
@@ -70,7 +70,7 @@ Distances required for voltage drop calculations and wire purchases. Measure act
 | CT4 (steering column)   | Driver tail light        | 14 AWG | 11 ft ✓  | Turn signal rear                    |
 | CT4 (steering column)   | Passenger tail light     | 14 AWG | 16 ft ✓  | Turn signal rear                    |
 | PMU (engine bay)        | Rear tail lights         | 16 AWG | 13 ft ✓  | Brake/reverse/marker (Out 21/22/23) |
-| SwitchPros (wheel well) | Roll bar dome lights     | 16 AWG | ~8 ft    | Low current, estimated              |
+| SwitchPros (firewall) | Roll bar dome lights     | 16 AWG | ~8 ft    | Low current, estimated              |
 | PBS-I PURPLE START      | Cole Hersee 24213 coil   | 16 AWG | ~10 ft ✓ | Via WAIT-gate relay + firewall Pin 15  |
 | CT4 SW3 output          | PMU In 7                 | 18 AWG | 3 ft ✓   | Same as steering column → PMU       |
 
@@ -78,10 +78,10 @@ Distances required for voltage drop calculations and wire purchases. Measure act
 
 | From                    | To                           | Distance | Notes                                  |
 |:------------------------|:-----------------------------|:---------|:---------------------------------------|
-| SwitchPros (wheel well) | A-pillar ditch lights        | 7 ft ✓   | Via Baja harness                       |
-| SwitchPros (wheel well) | Roof                         | 6 ft ✓   | Roof-mounted lights                    |
-| SwitchPros (wheel well) | Rear rock lights (2)         | 2-3 ft   | Low current, voltage drop negligible   |
-| SwitchPros (wheel well) | Front rock lights (4)        | ~10 ft   | Estimated via frame rail               |
+| SwitchPros (firewall) | A-pillar ditch lights        | 7 ft ✓   | Via Baja harness                       |
+| SwitchPros (firewall) | Roof                         | 6 ft ✓   | Roof-mounted lights                    |
+| SwitchPros (firewall) | Rear rock lights (2)         | 2-3 ft   | Low current, voltage drop negligible   |
+| SwitchPros (firewall) | Front rock lights (4)        | ~10 ft   | Estimated via frame rail               |
 
 ### Air System (Priority: High)
 
@@ -89,7 +89,7 @@ Distances required for voltage drop calculations and wire purchases. Measure act
 |:--------------------------|:----------------------------|:----------|:---------|:------------------|
 | SafetyHub (engine bay)    | ARB compressor (under seat) | 6 AWG × 2 | ~8 ft    | Compressor power (through firewall) |
 | ARB compressor            | Chassis ground              | 6 AWG     | ~2 ft    | Local ground      |
-| SwitchPros (wheel well)   | Compressor control terminal | 14 AWG    | ~6 ft    | Control signal    |
+| SwitchPros (firewall)   | Compressor control terminal | 14 AWG    | ~6 ft    | Control signal    |
 | Air manifold (under seat) | Front axle locker           | Air line  | ~6 ft    | Custom air line   |
 | Air manifold (under seat) | Rear axle locker            | Air line  | ~6 ft    | Custom air line   |
 
@@ -106,11 +106,13 @@ Distances required for voltage drop calculations and wire purchases. Measure act
 
 | Component                       | Status                                      |
 |:--------------------------------|:--------------------------------------------|
-| SwitchPros power module         | ✓ Passenger rear wheel well                 |
+| SwitchPros power module         | ✓ Firewall (cabin side, passenger area, with BODY PDU + Firewall CONSTANT Bus) |
 | SwitchPros control panel        | ✓ Dash mounted                              |
-| SwitchPros control cable length | 10.5 ft (standard cable)                    |
+| SwitchPros control cable length | 5 ft (firewall to dash, short run)          |
+| Firewall CONSTANT Bus           | ✓ Firewall (cabin side, passenger area)     |
+| Firewall CONSTANT Bus feed      | 2/0 AWG, ~13 ft from AUX battery+, 300A CB at battery |
 | CT4 GPS antenna                 | ✓ Integrated in CT4 unit                    |
-| Rear cargo rocker switch        | ✓ Blue Sea 4160 on wheel well top           |
+| Rear cargo rocker switch        | ✓ Blue Sea 4160 on rear wheel well top      |
 | Rear seat dome override switch  | ✓ Blue Sea 4160, rear passenger accessible  |
 
 ## Related Documentation
@@ -121,8 +123,8 @@ Distances required for voltage drop calculations and wire purchases. Measure act
 - [PMU24][pmu] - Power management unit
 - [Starter System][starter] - Starter power requirements
 - [Recovery Systems][recovery] - Winch specifications
-- [START battery Distribution][starter-battery] - Driver wheel well battery terminal connections
-- [AUX battery Distribution][aux-battery] - Passenger wheel well battery terminal connections
+- [START battery Distribution][starter-battery] - Driver rear wheel well battery terminal connections
+- [AUX battery Distribution][aux-battery] - Passenger rear wheel well battery terminal connections
 
 [batteries]: 01-batteries.md
 [bcdc]: 03-bcdc.md
@@ -132,3 +134,4 @@ Distances required for voltage drop calculations and wire purchases. Measure act
 [recovery]: ../../08-exterior-systems/01-winch.md
 [starter-battery]: ../02-starter-battery-distribution/index.md
 [aux-battery]: ../03-aux-battery-distribution/index.md
+[wire-routing]: ../07-wire-routing/index.md

--- a/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/01-circuit-breakers.md
+++ b/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/01-circuit-breakers.md
@@ -9,7 +9,7 @@ hide:
 
 All START battery positive circuits protected by Mechanical Products Series 17 circuit breakers with direct battery connections.
 
-**Location:** Wheel well, within 7" of START battery positive terminal (ABYC/NEC code compliant)
+**Location:** Driver rear wheel well, within 7" of START battery positive terminal (ABYC/NEC code compliant)
 
 ## Circuit Breaker Specifications
 
@@ -32,7 +32,7 @@ All START battery positive circuits protected by Mechanical Products Series 17 c
 - Dimensions: 3.39" L × 1.9" W (per unit)
 - Ratings: 48V DC (20-150A), 30V DC (175-200A), 14V DC (225-300A)
 - Standards: Marine-rated (SAE J1171, ABYC E-11, UL1500, IP67, MIL-STD-202)
-- Mounting: Wheel well within 7" of battery positive terminal
+- Mounting: Driver rear wheel well within 7" of battery positive terminal
 
 **Space Requirements:** 2 CBs side-by-side with wiring clearance for 2/0 AWG cables: ~7" × 4" (~28 sq in)
 

--- a/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/CLAUDE.md
+++ b/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What's Here
 
-Documents START battery power distribution from the driver wheel well (Odyssey PC1500).
+Documents START battery power distribution from the driver rear wheel well (Odyssey PC1500).
 
 ## Files
 
@@ -14,33 +14,27 @@ Documents START battery power distribution from the driver wheel well (Odyssey P
 
 ### `01-circuit-breakers.md` - Circuit Breakers
 
-**Contains:** All START battery circuit breaker specifications and ratings
+**Contains:** All START battery circuit breaker specifications and ratings (250A → PMU, 80A → BCDC input)
 
 **Use when:** Finding circuit breaker size for PMU, BCDC, or other loads
 
-### `02-constant-bus.md` - CONSTANT Bus Bar
-
-**Contains:** Blue Sea 2107 PowerBar specifications, stud assignments, load distribution
-
-**Use when:** Finding CONSTANT bus bar capacity, available studs, or what connects to the bus
+Note: The START battery has no CONSTANT bus. All loads connect via inline CBs at the battery (within 7" per code) or direct (ECM, grid heater via integrated fusible link).
 
 ## Cross-Section References
 
-**To PMU (1.4):** PMU power source via circuit breaker - see `01-circuit-breakers.md`, communication loads now PMU-powered
+**To PMU (1.4):** PMU power source via 250A inline circuit breaker - see `01-circuit-breakers.md`
 
-**To BCDC (1.1.3):** BCDC input circuit breaker specifications
+**To BCDC (1.1.3):** BCDC input circuit breaker specifications (80A inline)
 
 **To Grounding (1.5):** START battery negative connections, engine bay ground bus
 
 ## Navigation Scenarios
 
-**"What circuit breaker protects the PMU?"** → `01-circuit-breakers.md`
+**"What circuit breaker protects the PMU?"** → `01-circuit-breakers.md` (250A inline CB at battery)
 
 **"What connects to START battery positive terminal?"** → `index.md` terminal table
 
-**"What connects to the CONSTANT bus bar?"** → `02-constant-bus.md` stud assignments
-
-**"Where does BCDC get power?"** → `02-constant-bus.md` → `01-circuit-breakers.md`
+**"Where does BCDC get power?"** → `01-circuit-breakers.md` (80A inline CB at START battery+)
 
 **"Where do radios/intercom get power?"** → PMU outputs (Section 1.4) - OUT6 (GMRS), OUT20 (Intercom)
 
@@ -48,8 +42,8 @@ Documents START battery power distribution from the driver wheel well (Odyssey P
 
 **Adding new START battery load:**
 
-1. Determine if direct battery connection or CONSTANT bus connection
-2. Update `index.md` terminal table OR `02-constant-bus.md` stud table
+1. Determine if direct battery connection or CB-protected
+2. Update `index.md` terminal table
 3. Add circuit breaker in `01-circuit-breakers.md` if needed
 4. Update grounding files (Section 1.5)
 

--- a/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
+++ b/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
@@ -3,7 +3,7 @@ hide:
   - toc
 ---
 
-# 1.2 START battery Distribution (Driver Wheel Well) {#starter-battery-distribution}
+# 1.2 START battery Distribution (Driver Rear Wheel Well) {#starter-battery-distribution}
 
 /// html | div.product-info
 ![Odyssey PC1500 Battery Terminals](../../images/odyssey-pc1500.jpg){ loading=lazy }
@@ -11,13 +11,13 @@ hide:
 
 ## Overview
 
-The START battery (driver wheel well) provides power for critical engine and safety systems:
+The START battery (driver rear wheel well) provides power for critical engine and safety systems:
 
 1. **Direct high-current** → Starter (no CB), alternator charging input (no CB)
 2. **Circuit breaker protected** → PMU (250A CB), BCDC (80A CB)
 3. **Direct low-current** → ECM, grid heater (fusible link protection)
 
-See [Circuit Breakers][circuit-breakers] for complete CB specifications. All CBs mounted in wheel well within 7" of battery (code compliant).
+See [Circuit Breakers][circuit-breakers] for complete CB specifications. All CBs mounted in rear wheel well within 7" of battery (code compliant).
 
 !!! info "Single Source of Truth"
 This page is the authoritative source for all START battery wire specs (gauge, distance, voltage drop). Component pages reference here. For battery specs see [Section 1.1][batteries]. For ground bus bars see [Section 1.5][grounding].
@@ -31,7 +31,7 @@ This page is the authoritative source for all START battery wire specs (gauge, d
 | [PMU24][pmu]               | Engine bay           | 2/0 AWG     | ~7 ft    | 250A max | 2.4% @ 60°C     | 250A CB      |
 | ECM                        | Engine bay           | Per Cummins | Short    | <5A      | Negligible      | Fusible link |
 | [Grid Heater][grid-heater] | Engine bay           | Per Cummins | Short    | ~80A     | Negligible      | Fusible link |
-| [BCDC Alpha 50][bcdc]      | Passenger wheel well | 4 AWG       | ~6 ft    | 50A      | 0.94% @ 20°C    | 80A CB       |
+| [BCDC Alpha 50][bcdc]      | Passenger rear wheel well | 4 AWG       | ~6 ft    | 50A      | 0.94% @ 20°C    | 80A CB       |
 
 All circuit breakers mounted within 7" of battery (ABYC/NEC compliant). See [Circuit Breakers][circuit-breakers].
 
@@ -42,7 +42,7 @@ All circuit breakers mounted within 7" of battery (ABYC/NEC compliant). See [Cir
 | [Engine Bay Ground Bus][engine-ground-bus] | Engine bay           | 2/0 AWG     | ~8 ft    | 600A+ peak | <0.1V @ 60°C  |
 | ECM                                        | Engine bay           | 12 AWG      | Short    | <5A        | Negligible    |
 | [Grid Heater][grid-heater]                 | Engine bay           | Per Cummins | Short    | ~80A       | Negligible    |
-| [AUX Battery][aux-battery]                 | Passenger wheel well | 1/0 AWG     | 5-6 ft   | 75A max    | <0.05V @ 20°C |
+| [AUX Battery][aux-battery]                 | Passenger rear wheel well | 1/0 AWG     | 5-6 ft   | 75A max    | <0.05V @ 20°C |
 | [G1 GMRS Radio][radios]                    | Dashboard            | 10 AWG      | ~8 ft    | 15A TX     | 1.2% @ 20°C   |
 | [STX Intercom][radios]                     | Dashboard            | 10 AWG      | ~8 ft    | 5A         | 0.4% @ 20°C   |
 

--- a/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/01-circuit-breakers.md
+++ b/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/01-circuit-breakers.md
@@ -3,27 +3,40 @@ hide:
   - toc
 ---
 
-# 1.3.1 Circuit Breakers {#rear-battery-circuit-breakers}
+# 1.3.1 Circuit Breakers {#aux-battery-circuit-breakers}
 
 ## Overview
 
-All CONSTANT bus loads protected by Mechanical Products Series 17 circuit breakers.
+AUX-side circuit breakers split into **two banks**:
 
-**Location:** Rear wheel well near CONSTANT bus bar
+1. **Battery-side bank** (3 CBs at AUX battery+ in passenger rear wheel well, within 7" per code)
+2. **Firewall-side bank** (2 CBs at [Firewall CONSTANT Bus][constant-bus] in cabin)
 
-## Circuit Breaker Specifications
+All Mechanical Products Series 17 (except Fusion Amp on Blue Sea 187).
 
-| Circuit                      | Model                                             | Rating | Reset Type | Power Path                                                                   | Max Load                                                  | Sizing                                   |
-| :--------------------------- | :------------------------------------------------ | :----: | :--------- | :--------------------------------------------------------------------------- | :-------------------------------------------------------- | :--------------------------------------- |
-| **SwitchPros RCR-Force 12**  | Mechanical Products<br/>([174-S2-150-2][mp-150])  |  150A  | Manual     | CONSTANT bus<br/>└→ 150A CB<br/>&nbsp;&nbsp;&nbsp;└→ SwitchPros RCR-Force 12 | ~100A (all lighting outputs on)                           | 150% of max load                         |
-| **SafetyHub 150 (Recovery)** | Mechanical Products<br/>([174-S2-150-2][mp-150b]) |  150A  | Manual     | CONSTANT bus<br/>└→ 150A CB<br/>&nbsp;&nbsp;&nbsp;└→ SafetyHub 150           | ~100A (ARB 90A + Winch Trigger 10A)                       | Future-proofed to SafetyHub max capacity |
-| **BODY PDU**                 | Mechanical Products<br/>([174-S2-100-2][mp-100])  |  100A  | Manual     | CONSTANT bus<br/>└→ 100A CB<br/>&nbsp;&nbsp;&nbsp;└→ BODY PDU                | ~54A max (radio 16A, USB 13A, camera 10A, seats 10A peak) | 185% of max load (future expansion)      |
-| **Fusion Apollo Amp**        | Blue Sea<br/>([187-series 40A][bs-100])           |  40A   | Manual     | CONSTANT bus<br/>└→ 40A CB<br/>&nbsp;&nbsp;&nbsp;└→ Fusion MS-AP61800        | Wiring + amp (40A per Fusion install guide; 125A internal fuse) | Mfr-specified external protection        |
+## Battery-Side CBs (Passenger Rear Wheel Well)
+
+Mounted inline on a bracket within 7" of AUX battery+ terminal. Protect the three protected feeds leaving the battery.
+
+| Circuit                              | Model                                            | Rating | Reset Type | Power Path                                                              | Max Load              | Sizing                         |
+| :----------------------------------- | :----------------------------------------------- | :----: | :--------- | :---------------------------------------------------------------------- | :-------------------- | :----------------------------- |
+| **Forward Feed (to Firewall Bus)**   | Mechanical Products<br/>([174-S2-300-2][mp-300]) |  300A  | Manual     | AUX battery+<br/>└→ 300A CB<br/>&nbsp;&nbsp;&nbsp;└→ Firewall CONSTANT Bus | ~152A combined max (SP + BODY PDU) | 197% of combined load (Fusion relocated to direct AUX feed) |
+| **SafetyHub 150 (Recovery)**         | Mechanical Products<br/>([174-S2-150-2][mp-150]) |  150A  | Manual     | AUX battery+<br/>└→ 150A CB<br/>&nbsp;&nbsp;&nbsp;└→ SafetyHub 150        | ~100A (ARB 90A + Winch Trigger 10A) | 150% of max load (future-proofed) |
+| **Fusion Apollo Amp**                | Blue Sea<br/>([187-100A][bs-100])                |  100A  | Manual     | AUX battery+<br/>└→ 100A CB<br/>&nbsp;&nbsp;&nbsp;└→ Fusion MS-AP61800 (under rear seat) | 78A max | 128% of max load — relocated from firewall bank when amp moved under rear seat |
+
+## Firewall-Side CBs (Co-located with Firewall CONSTANT Bus)
+
+Mounted within 7" of [Firewall CONSTANT Bus][constant-bus]. Protect each downstream controller.
+
+| Circuit                      | Model                                            | Rating | Reset Type | Power Path                                                                         | Max Load                                                  | Sizing                              |
+| :--------------------------- | :----------------------------------------------- | :----: | :--------- | :--------------------------------------------------------------------------------- | :-------------------------------------------------------- | :---------------------------------- |
+| **SwitchPros RCR-Force 12**  | Mechanical Products<br/>([174-S2-150-2][mp-150]) |  150A  | Manual     | Firewall CONSTANT Bus<br/>└→ 150A CB<br/>&nbsp;&nbsp;&nbsp;└→ SwitchPros           | ~100A (all lighting outputs on)                           | 150% of max load                    |
+| **BODY PDU**                 | Mechanical Products<br/>([174-S2-100-2][mp-100]) |  100A  | Manual     | Firewall CONSTANT Bus<br/>└→ 100A CB<br/>&nbsp;&nbsp;&nbsp;└→ BODY PDU             | ~54A max (radio 16A, USB 13A, camera 10A, seats 10A peak) | 185% of max load (future expansion) |
 
 !!! info "Wire Sizing for CB Protection"
-CONSTANT bus outputs use 2 AWG (130A @ 20°C) for SwitchPros, SafetyHub, and BODY PDU. Fusion Amp uses 4 AWG (95A @ 20°C) per the Fusion install guide (40A external breaker).
+Forward feed uses 2/0 AWG (300A @ 20°C) for the 13-ft run to the firewall bus (now carries only SP+BODY, ~152A max; 2/0 retained for upgrade headroom). Firewall-side outputs use 2 AWG (130A @ 20°C) for SwitchPros and BODY PDU. Fusion uses 4 AWG (95A @ 20°C) for the short ~3-4 ft run from AUX battery to under-seat amp location.
 
-**Mechanical Products Series 17 (3 units):**
+**Mechanical Products Series 17 (4 units):**
 
 - Type: Surface mount
 - Reset: Manual (Type III - push to reset)
@@ -31,7 +44,7 @@ CONSTANT bus outputs use 2 AWG (130A @ 20°C) for SwitchPros, SafetyHub, and BOD
 - Dimensions: 3.39" L × 1.9" W (per unit)
 - Ratings: 48V DC (20-150A), 30V DC (175-200A), 14V DC (225-300A)
 - Standards: Marine-rated (SAE J1171, ABYC E-11, UL1500, IP67, MIL-STD-202)
-- Mounting: Rear wheel well near battery
+- Mounting: 2 at passenger rear wheel well (battery side: 300A + 150A), 2 at firewall (bus side: 150A SP + 100A BODY)
 
 **Blue Sea 187-Series (1 unit - Fusion Amp):**
 
@@ -41,22 +54,28 @@ CONSTANT bus outputs use 2 AWG (130A @ 20°C) for SwitchPros, SafetyHub, and BOD
 - Dimensions: 3.44" H × 2.32" W × 1.8" D
 - Rating: 5000A interrupt @ 12V DC
 - Standards: Ignition protected, waterproof
+- Mounting: Passenger rear wheel well (battery side, stacked with MP CBs on bracket)
 
-**Space Requirements:** 4 CBs in 2×2 arrangement with wiring clearance for 2-4 AWG cables: ~8" × 10" (~80 sq in)
+**Space Requirements:**
+
+- **Battery-side bracket:** 3 CBs stacked (300A + 150A + 100A Fusion) — ~10" × 2" (~20 sq in) on wheel well bracket
+- **Firewall-side cluster:** 2 CBs in a row with wiring clearance — ~7" × 4" (~28 sq in) near bus
 
 ## Related Documentation
 
 - [AUX battery Distribution Overview][rear-battery]
+- [Firewall CONSTANT Bus][constant-bus] - Downstream distribution
 - [SwitchPros][switchpros] - Load details for SwitchPros circuit
 - [SafetyHub 150][safetyhub] - Load details for SafetyHub circuit (ARB compressor, winch trigger)
 - [BODY PDU][body-rtmr] - Load details for BODY PDU circuit
 - [Fusion Apollo Amp][audio] - Load details for amplifier circuit
 
+[mp-300]: https://www.waytekwire.com/item/49081/
 [mp-150]: https://www.waytekwire.com/item/49079/
-[mp-150b]: https://www.waytekwire.com/item/49079/
 [mp-100]: https://www.waytekwire.com/item/49077/
-[bs-100]: https://www.bluesea.com/category/8/Circuit_Protection/187-Series_Circuit_Breakers
+[bs-100]: https://www.bluesea.com/products/187-100A/187_Series_Thermal_Circuit_Breaker_100A
 [rear-battery]: index.md
+[constant-bus]: 02-constant-bus.md
 [switchpros]: ../../05-control-interfaces/02-switchpros-sp1200.md
 [safetyhub]: 04-safetyhub.md
 [body-rtmr]: 03-body-pdu.md

--- a/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/02-constant-bus.md
+++ b/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/02-constant-bus.md
@@ -7,66 +7,89 @@ tags:
   - bus-bar
 ---
 
-# 1.3.2 AUX battery CONSTANT Bus Bar {#rear-constant-bus}
+# 1.3.2 Firewall CONSTANT Bus Bar {#firewall-constant-bus}
 
 /// html | div.product-info
-![Blue Sea 2107 PowerBar](../../images/blue-sea-2107-powerbar.jpg){ loading=lazy }
+![Blue Sea 2105 MaxiBus](../../images/blue-sea-2105-maxibus.jpg){ loading=lazy }
 
 **Type:** Bus Bar
 
-**Model:** Blue Sea 2107 PowerBar
+**Model:** Blue Sea 2105 MaxiBus (250A) or 2107 PowerBar (600A)
 
 **Manufacturer:** Blue Sea Systems
 
-**Product Page:** [PowerBar 600A BusBar][product-link]
+**Product Page:** [MaxiBus 250A][product-link]
 
 ///
 
 ## Overview
 
-Provides organized distribution for accessory circuits in the rear wheel well compartment.
+Forward distribution bus mounted on the firewall (passenger cabin side). Receives a single protected feed from the AUX battery and fans out to the cabin/firewall-mounted accessory controllers.
 
-**Location:** Rear wheel well compartment (near battery)
+**Location:** Firewall (cabin side, passenger area), co-located with SwitchPros power module, BODY PDU, and Fusion Apollo amplifier.
+
+!!! info "Two-Stage Distribution Architecture"
+The AUX battery has no local CONSTANT bus. Loads are distributed in two stages:
+
+    1. **AUX battery+ → inline CBs → 2 protected feeds** (forward to this firewall bus, local to SafetyHub)
+    2. **Firewall CONSTANT bus → per-load CBs → 3 distribution controllers**
+
+    The firewall bus is fed by a 2/0 AWG cable through a 300A master CB at the AUX battery (within 7" of battery terminal). This places power distribution *near the loads* (most SwitchPros outputs are forward, BODY PDU is at firewall, Fusion is behind dash) and keeps the cabin trunk to a single heavy cable instead of multiple medium-gauge feeds.
 
 ## Specifications
 
-- **Rating:** 600A continuous
-- **Terminals:** 8× 3/8"-16 studs
-- **Wire Range:** Up to 4/0 AWG
+- **Rating:** 250A continuous (Blue Sea 2105) or 600A (2107 if oversized for future expansion)
+- **Terminals:** 14× 1/4"-20 studs (2105) or 8× 3/8"-16 studs (2107)
+- **Wire Range:** Up to 2/0 AWG (2105) or 4/0 AWG (2107)
 - **Features:** Tin-plated copper, corrosion resistant
-- **Full Specs:** [Blue Sea 2107][product-link]
+- **Recommendation:** 2105 is sufficient for ~232A combined load; 2107 if future expansion is anticipated
 
-!!! info "Circuit Protection"
-No circuit breaker between battery and CONSTANT bus. Each load has individual CB protection: SwitchPros (150A), SafetyHub (150A), BODY PDU (100A), Fusion Amp (40A). See [Circuit Breakers][circuit-breakers].
+## Input Feed (from AUX battery)
+
+| From                    | Cable     | Distance | Protection                | Voltage Drop @ 200A | Notes                                          |
+| :---------------------- | :-------- | :------- | :------------------------ | :------------------ | :--------------------------------------------- |
+| **AUX battery+**        | 2/0 AWG   | ~13 ft   | 300A CB at battery (<7") | ~2.0% @ 20°C        | Routed via cabin trunk (path TBD)              |
 
 ## Load Distribution
 
-| Stud | Connection                 | Wire Gauge | Distance | Voltage Drop | Protection | Load      | Notes                           |
-| :--- | :------------------------- | :--------- | :------- | :----------- | :--------- | :-------- | :------------------------------ |
-| 1    | **AUX battery+ (INPUT)**   | 1/0 AWG    | ~3 ft    | 0.9% @ 20°C  | None       | ~332A max | See [AUX battery][rear-battery] |
-| 2    | [SwitchPros][switchpros]   | 2 AWG      | ~2 ft    | 0.4% @ 20°C  | 150A CB    | ~100A max | Auxiliary lighting              |
-| 3    | [SafetyHub 150][safetyhub] | 2 AWG      | ~2 ft    | 0.4% @ 20°C  | 150A CB    | ~100A max | ARB compressor, winch trigger   |
-| 4    | [BODY PDU][body-rtmr]      | 2 AWG      | ~12 ft   | 1.2% @ 20°C  | 100A CB    | ~54A max  | Cabin circuits                  |
-| 5    | [Fusion Apollo Amp][audio] | 4 AWG      | TBD      | TBD          | 40A CB     | 78A theo. | 6-channel amplifier; 40A per mfr (8-15A musical) |
-| 6-8  | _(Available)_              | -          | -        | -            | -          | -         | Future expansion                |
+| Connection                 | Wire Gauge | Distance | Voltage Drop  | Protection | Load      | Notes                           |
+| :------------------------- | :--------- | :------- | :------------ | :--------- | :-------- | :------------------------------ |
+| **Feed INPUT**             | 2/0 AWG    | ~13 ft   | 2.0% @ 20°C   | 300A CB (at battery) | ~232A max | From AUX battery via cabin trunk |
+| [SwitchPros][switchpros]   | 2 AWG      | ~2 ft    | <0.5% @ 20°C  | 150A CB    | ~100A max | Auxiliary lighting              |
+| [BODY PDU][body-rtmr]      | 2 AWG      | ~2 ft    | <0.5% @ 20°C  | 100A CB    | ~54A max  | Cabin circuits                  |
+| [Fusion Apollo Amp][audio] | 4 AWG      | ~3 ft    | <0.5% @ 20°C  | 100A CB    | 78A max   | 6-channel amplifier             |
 
-**Stud Utilization:** 5 of 8 used (3 available)
+**Combined max realistic load:** ~232A (well within 250A bus rating, comfortable in 600A bus)
+
+**Stud utilization:** 4 of 14 used on 2105 (10 available), or 4 of 8 on 2107 (4 available)
+
+## Circuit Breakers (co-located with bus)
+
+All three per-load CBs mount within 7" of the bus on a small bracket near the cluster:
+
+| Load | CB Rating | Model | Notes |
+|:-----|:---------:|:------|:------|
+| SwitchPros | 150A | Mechanical Products 174-S2-150-2 | 150% of max load |
+| BODY PDU | 100A | Mechanical Products 174-S2-100-2 | 185% of max load |
+| Fusion Amp | 100A | Blue Sea 187-100A | 128% of max load |
+
+See [Circuit Breakers][circuit-breakers] for full specs.
 
 ## Related Documentation
 
 **Power Systems:**
 
-- [AUX battery Distribution][rear-battery] - Complete overview
-- [Circuit Breakers][circuit-breakers] - CB specifications
+- [AUX battery Distribution][rear-battery] - Battery terminal connections and inline CBs
+- [Circuit Breakers][circuit-breakers] - Full CB list (battery side + firewall side)
 
 **Connected Systems:**
 
-- [SwitchPros RCR-Force 12][switchpros] - Auxiliary lighting controller
-- [SafetyHub 150][safetyhub] - ARB compressor and winch trigger
+- [SwitchPros RCR-Force 12][switchpros] - Auxiliary lighting controller (power module at firewall)
 - [BODY PDU][body-rtmr] - Cabin convenience circuits
+- [Fusion Apollo Amp][audio] - 6-channel amplifier
 - [Installation Checklist][installation] - Bus bar mounting procedure
 
-[product-link]: https://www.bluesea.com/products/2107/PowerBar_600A_BusBar_-_Eight_3_8in-16_Studs__
+[product-link]: https://www.bluesea.com/products/2105/MaxiBus_Insulating_Base_-_Four_1_4in-20_Studs
 [rear-battery]: index.md
 [circuit-breakers]: 01-circuit-breakers.md
 [switchpros]: ../../05-control-interfaces/02-switchpros-sp1200.md

--- a/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/03-body-pdu.md
+++ b/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/03-body-pdu.md
@@ -26,7 +26,7 @@ tags:
 
 **Mounting:** Firewall - body side (cabin), passenger side
 
-**Power Source:** CONSTANT power from AUX battery via 2 AWG feed
+**Power Source:** Firewall CONSTANT bus via 100A CB (2 AWG, ~2 ft local — bus is fed from AUX battery through 300A master CB and 2/0 AWG forward feed)
 
 **Ground:** [Firewall Stud Bus][firewall-stud-bus] Terminal 3 (14 AWG) - relay coil/logic reference only
 
@@ -53,8 +53,8 @@ tags:
 | CB39        | TRLR BO STOP            | WolfBox Camera/Mirror       | 10A  | 16AWG | ~10A                  | -     | Dash cam + backup camera                    |
 | CB45        | IGNITION                | Driver Heated Seat          | 15A  | 14AWG | 5A peak, 2A sustained | K21   | Manual switch → relay K21 → seat element    |
 | CB42        | 2WAY INTRCM             | Passenger Heated Seat       | 20A  | 14AWG | 5A peak, 2A sustained | K22   | Manual switch → relay K22 → seat element    |
-| CB20        | RADIO                   | Cargo Lights                | 10A  | 16AWG | 4A                    | -     | Switch on wheel well top                    |
-| CB43        | TRANS ECU               | Winch Control (dash rocker) | 10A  | 18AWG | ~2A                   | -     | Dash rocker + remote parallel control       |
+| CB20        | RADIO                   | Cargo Lights                | 10A  | 16AWG | 4A                    | -     | Switch on rear wheel well top               |
+| CB43        | TRANS ECU               | Winch Control (CH4X4 dual-push) | 10A  | 18AWG | ~3A peak per direction | -    | CH4X4-TOY-D-WINIO dual-momentary push at dash → HDP24 pins 16/17 → contactor; Warn remote parallel at contactor |
 | CB44        | TRLR LIGHT              | **\[Available\]**             | -    | -     | -                     | -     | Future expansion                            |
 
 **Circuit Breaker Utilization:** 7 of 8 used (1 available)
@@ -95,7 +95,7 @@ G1 GMRS Radio and STX Intercom are powered from [SafetyHub 150][safetyhub] (STAR
 
 ## Related Documentation
 
-- [AUX battery Distribution][house-battery] - Power source and circuit breaker (passenger wheel well)
+- [AUX battery Distribution][house-battery] - Power source and circuit breaker (passenger rear wheel well)
 - [Circuit Breakers][circuit-breakers] - 100A CB protection for LR-2 power feed
 - [Dashboard Controls][dashboard] - Physical switch panel layout
 - [Audio Systems][audio] - Fusion radio specifications

--- a/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/04-safetyhub.md
+++ b/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/04-safetyhub.md
@@ -26,9 +26,9 @@ tags:
 
 Provides fused distribution for recovery and auxiliary systems powered by the AUX battery.
 
-**Location:** Passenger wheel well (co-located with AUX battery and circuit breakers)
+**Location:** Passenger rear wheel well (co-located with AUX battery and circuit breakers)
 
-**Power Source:** CONSTANT bus via 150A CB - see [Circuit Breakers][circuit-breakers]
+**Power Source:** AUX battery+ via inline 150A CB (~2 ft, local in rear wheel well) - see [Circuit Breakers][circuit-breakers]
 
 **Note:** Communications systems (GMRS, Intercom) are powered via PMU outputs - see [PMU Outputs][pmu-outputs]
 
@@ -47,15 +47,15 @@ Wire and CB sized for full 150A SafetyHub capacity (current load 100A). Provides
 
 | Slot   | Fuse | Circuit                              | Wire Gauge | Distance | Voltage @ Load | Load | Notes                                               |
 | :----- | :--- | :----------------------------------- | :--------- | :------- | :------------- | :--- | :-------------------------------------------------- |
-| MIDI-1 | 60A  | [ARB Compressor][air-system] Motor 1 | 6 AWG ✓    | ~12 ft   | 11.56V (3.6%)  | 45A  | Passenger wheel well → cargo → under passenger seat |
-| MIDI-2 | 60A  | [ARB Compressor][air-system] Motor 2 | 6 AWG ✓    | ~12 ft   | 11.56V (3.6%)  | 45A  | Passenger wheel well → cargo → under passenger seat |
+| MIDI-1 | 60A  | [ARB Compressor][air-system] Motor 1 | 6 AWG ✓    | ~12 ft   | 11.56V (3.6%)  | 45A  | Passenger rear wheel well → cargo → under passenger seat |
+| MIDI-2 | 60A  | [ARB Compressor][air-system] Motor 2 | 6 AWG ✓    | ~12 ft   | 11.56V (3.6%)  | 45A  | Passenger rear wheel well → cargo → under passenger seat |
 | MIDI-3 | -    | **\[Available\]**                      | -          | -        | -              | -    | -                                                   |
-| ATC-1  | 15A  | Winch Contactor Trigger              | 14 AWG ✓   | ~13 ft   | 13.70V (0.8%)  | 10A  | Passenger wheel well → front bumper via frame rail  |
+| ATC-1  | -    | **\[Available\]**                      | -          | -        | -              | -    | (Was Winch Contactor Trigger - reallocated 2026-05-30 to BODY PDU CB43 for shorter routing; see [Winch][recovery-systems] and [Dashboard Controls][dashboard-controls]) |
 | ATC-2  | -    | **\[Available\]**                      | -          | -        | -              | -    | -                                                   |
 | ATC-3  | -    | **\[Available\]**                      | -          | -        | -              | -    | -                                                   |
 | ATC-4  | -    | **\[Available\]**                      | -          | -        | -              | -    | -                                                   |
 
-**Slot Utilization:** 3 of 7 used (2 MIDI + 1 ATC, 4 available)
+**Slot Utilization:** 2 of 7 used (2 MIDI, 5 available — ATC-1 freed after winch trigger reallocated to BODY PDU CB43)
 
 **Total Load:** 100A maximum (ARB 90A + Winch Trigger 10A)
 
@@ -87,3 +87,4 @@ Winch motor power (400A peak) connects directly to AUX battery positive terminal
 [aux-battery]: index.md
 [pmu-outputs]: ../04-pmu/03-pmu-outputs.md
 [standards-exceptions]: ../STANDARDS-EXCEPTIONS.md
+[dashboard-controls]: ../../05-control-interfaces/05-dashboard-controls.md

--- a/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/CLAUDE.md
+++ b/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/CLAUDE.md
@@ -2,7 +2,7 @@
 
 ## What's Here
 
-Documents wheel well power distribution from the AUX battery (Dakota Lithium 135Ah LiFePO4).
+Documents rear wheel well power distribution from the AUX battery (Dakota Lithium 135Ah LiFePO4).
 
 ## Files
 
@@ -18,11 +18,13 @@ Documents wheel well power distribution from the AUX battery (Dakota Lithium 135
 
 **Use when:** Finding circuit breaker size for SwitchPros, BODY PDU, or other loads
 
-### `02-constant-bus.md` - CONSTANT Bus Bar
+### `02-constant-bus.md` - Firewall CONSTANT Bus Bar
 
-**Contains:** Blue Sea 2104 PowerBar specifications, stud assignments, load distribution
+**Contains:** Blue Sea 2105 MaxiBus specifications, stud assignments, load distribution at firewall
 
-**Use when:** Finding CONSTANT bus bar capacity, available studs, or what connects to the bus
+**Use when:** Finding firewall CONSTANT bus capacity, available studs, or what connects to the bus
+
+Note: AUX battery itself has NO local CONSTANT bus. Battery has 4 stacked terminal lugs + 2 inline CBs (300A master forward feed + 150A SafetyHub local).
 
 ### `03-body-pdu.md` - BODY PDU
 

--- a/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/index.md
+++ b/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/index.md
@@ -3,45 +3,52 @@ hide:
   - toc
 ---
 
-# 1.3 AUX battery Distribution (Passenger Wheel Well) {#aux-battery-distribution}
+# 1.3 AUX battery Distribution (Passenger Rear Wheel Well) {#aux-battery-distribution}
 
 ## Overview
 
-The AUX battery ([Dakota Lithium 135Ah LiFePO4][batteries]) in the passenger wheel well provides power for high-current accessories and cabin systems:
+The AUX battery ([Dakota Lithium 135Ah LiFePO4][batteries]) in the passenger rear wheel well provides power for high-current accessories and cabin systems via five direct terminal connections:
 
 1. **Direct high-current** → Winch (recovery system, no CB per manufacturer spec)
-2. **CONSTANT Bus Bar** (Blue Sea 2107 PowerBar, 600A) - Feeds SwitchPros, SafetyHub 150, BODY PDU, Fusion Amp
-3. **Direct charging input** → BCDC Alpha 50 output
+2. **Direct charging input** → BCDC Alpha 50 output (no CB - charging path)
+3. **Inline 300A CB** → 2/0 AWG forward feed → [Firewall CONSTANT Bus][constant-bus] (SwitchPros, BODY PDU)
+4. **Inline 150A CB** → 2 AWG short feed → [SafetyHub 150][aux-safetyhub] (local in rear wheel well)
+5. **Inline 100A CB** → 4 AWG short feed → [Fusion Apollo Amp][audio] (mounted under rear seat)
 
-See [CONSTANT Bus Bar][constant-bus] for complete bus bar specifications, [SafetyHub][aux-safetyhub] for fused distribution, and [Circuit Breakers][circuit-breakers] for CB details.
+!!! info "Two-Stage Distribution Architecture"
+The AUX battery has **no local CONSTANT bus** — protected feeds run from inline CBs at the battery to two distribution points: the firewall CONSTANT bus (most loads) and SafetyHub (local). This places distribution near the loads, minimizes the cabin trunk to a single heavy cable, and keeps the rear wheel well compartment uncluttered.
+
+See [Firewall CONSTANT Bus][constant-bus] for downstream distribution, [SafetyHub][aux-safetyhub] for fused recovery circuits, and [Circuit Breakers][circuit-breakers] for full CB list.
 
 !!! info "Single Source of Truth"
 This page is the authoritative source for all AUX battery wire specs (gauge, distance, voltage drop). Component pages reference here. For battery specs see [Section 1.1][batteries]. For ground bus bars see [Section 1.5][grounding].
 
-## AUX battery Positive Terminal (3 connections)
+## AUX battery Positive Terminal (5 stacked ring lugs)
 
-| Circuit                          | Destination  | Wire Gauge | Distance | Current  | Voltage Drop    | Protection               |
-| :------------------------------- | :----------- | :--------- | :------- | :------- | :-------------- | :----------------------- |
-| [BCDC Alpha 50][bcdc]            | Local        | 4 AWG      | Short    | 50A      | Negligible      | None                     |
-| [CONSTANT Bus Bar][constant-bus] | Local        | 1/0 AWG    | ~3 ft    | 254A max | 0.9% @ 20°C     | None                     |
-| [Winch][recovery]                | Front bumper | 1/0 AWG    | 13 ft    | 250A typ, 409A peak | 4.9-7.9% @ 20°C | [None][winch-protection] |
+| Circuit                              | Destination                       | Wire Gauge | Distance | Current             | Voltage Drop    | Protection               |
+| :----------------------------------- | :-------------------------------- | :--------- | :------- | :------------------ | :-------------- | :----------------------- |
+| [BCDC Alpha 50 output][bcdc]         | Local (rear wheel well)           | 4 AWG      | Short    | 50A                 | Negligible      | None (charging)          |
+| [Firewall CONSTANT Bus][constant-bus] | Firewall (cabin side, passenger) | 2/0 AWG    | ~13 ft   | ~152A max           | 1.3% @ 20°C     | 300A CB at battery (<7") |
+| [SafetyHub 150][aux-safetyhub]       | Local (rear wheel well)           | 2 AWG      | ~2 ft    | ~100A max           | <0.5% @ 20°C    | 150A CB at battery (<7") |
+| [Fusion Apollo Amp][audio]           | Under rear seat                   | 4 AWG      | ~3-4 ft  | 78A max             | <0.5% @ 20°C    | 100A CB at battery (<7") |
+| [Winch][recovery]                    | Front bumper                      | 1/0 AWG    | 13 ft    | 250A typ, 409A peak | 4.9-7.9% @ 20°C | [None][winch-protection] |
 
 ## AUX battery Negative Terminal (5 connections)
 
-| Circuit                          | Destination       | Wire Gauge | Distance | Current   | Voltage Drop    |
-| :------------------------------- | :---------------- | :--------- | :------- | :-------- | :-------------- |
-| Rear Frame Rail                  | Local (chassis)   | 2/0 AWG    | ~3 ft    | 654A peak | <0.1V @ 20°C    |
-| [BCDC Alpha 50][bcdc]            | Local             | 4 AWG      | Short    | 50A       | Negligible      |
-| [Fusion Apollo Amp][audio]       | Cab firewall      | 4 AWG      | ~8-10 ft | 78A max   | 1.2% @ 30°C     |
-| [START Battery][starter-battery] | Driver wheel well | 1/0 AWG    | 5-6 ft   | 75A max   | <0.05V @ 20°C   |
-| [Winch][recovery]                | Front bumper      | 1/0 AWG    | 13 ft    | 250A typ, 409A peak  | 4.9-7.9% @ 20°C |
+| Circuit                          | Destination            | Wire Gauge | Distance | Current             | Voltage Drop  |
+| :------------------------------- | :--------------------- | :--------- | :------- | :------------------ | :------------ |
+| Rear Frame Rail                  | Local (chassis)        | 2/0 AWG    | ~3 ft    | 654A peak           | <0.1V @ 20°C  |
+| [BCDC Alpha 50][bcdc]            | Local                  | 4 AWG      | Short    | 50A                 | Negligible    |
+| [Fusion Apollo Amp][audio]       | Under rear seat        | 4 AWG      | ~3-4 ft  | 78A max             | <0.5% @ 30°C  |
+| [START Battery][starter-battery] | Driver rear wheel well | 1/0 AWG    | 5-6 ft   | 75A max             | <0.05V @ 20°C |
+| [Winch][recovery]                | Front bumper           | 1/0 AWG    | 13 ft    | 250A typ, 409A peak | 4.9-7.9% @ 20°C |
 
 ## Related Documentation
 
-- [CONSTANT Bus Bar][constant-bus] - Stud assignments and loads
-- [SafetyHub 150][aux-safetyhub] - ARB compressor, winch trigger
-- [BODY PDU][body-rtmr] - Cabin convenience circuits
-- [Circuit Breakers][circuit-breakers] - CB specifications
+- [Firewall CONSTANT Bus][constant-bus] - Forward distribution at firewall
+- [SafetyHub 150][aux-safetyhub] - Local recovery distribution (rear wheel well)
+- [BODY PDU][body-rtmr] - Cabin convenience circuits (fed from firewall bus)
+- [Circuit Breakers][circuit-breakers] - Full CB specs (battery side + firewall side)
 - [Grounding Architecture][grounding] - Ground bus bars
 - [START battery Distribution][starter-battery] - BCDC input source
 - [Recovery Systems][recovery] - Winch specifications

--- a/docs/jeep_lj/01-power-systems/05-grounding/03-switchpros-ground-bus.md
+++ b/docs/jeep_lj/01-power-systems/05-grounding/03-switchpros-ground-bus.md
@@ -27,7 +27,7 @@ tags:
 
 - **Capacity:** 250A AC/DC continuous, 300V AC / 48V DC max
 - **Terminals:** 12x #10-24 screws, 2x 5/16"-18 studs
-- **Location:** Near SwitchPros controller (engine bay or rear cabin area)
+- **Location:** Firewall (passenger cabin side), co-located with SwitchPros power module
 - **Full Specs:** [Blue Sea 2105][bluesea-2105]
 
 ## Stud/Terminal Assignment
@@ -52,11 +52,11 @@ tags:
 
 ## Installation
 
-**Mounting:** Near SwitchPros controller (rear cabin area)
+**Mounting:** Firewall (cabin side, passenger area), bolted near SwitchPros power module so all load returns terminate locally
 
-**Ground Path:** Bus → chassis ground (1/0 AWG, handles ~100A total lighting load) → frame rail → START battery negative bus
+**Ground Path:** Bus → chassis ground (1/0 AWG, handles ~100A total lighting load) at firewall chassis point → main grounding network
 
-**Critical:** Clean metal-to-metal connection to chassis, accessible for lighting ground wires
+**Critical:** Clean metal-to-metal connection to chassis at firewall, accessible for lighting ground wires
 
 ## Related Documentation
 

--- a/docs/jeep_lj/01-power-systems/05-grounding/index.md
+++ b/docs/jeep_lj/01-power-systems/05-grounding/index.md
@@ -11,8 +11,8 @@ Multi-point grounding strategy with high-current grounds to frame rails and low-
 
 | Ground Point              | Type                   | Location                   | Capacity            | Notes                                              |
 | :------------------------ | :--------------------- | :------------------------- | :------------------ | :------------------------------------------------- |
-| **START battery (-)**     | Battery Terminal       | Driver wheel well          | 7 connections       | See [START Battery Distribution][starter-battery]  |
-| **AUX battery (-)**       | Battery Terminal       | Passenger wheel well       | 5 connections       | See [AUX Battery Distribution][aux-battery]        |
+| **START battery (-)**     | Battery Terminal       | Driver rear wheel well     | 7 connections       | See [START Battery Distribution][starter-battery]  |
+| **AUX battery (-)**       | Battery Terminal       | Passenger rear wheel well  | 5 connections       | See [AUX Battery Distribution][aux-battery]        |
 | **Engine Bay Ground Bus** | Blue Sea 2107 PowerBar | Firewall (engine bay)      | 8 studs (600A)      | See [Engine Bay Ground Bus][engine-bay-ground-bus] |
 | **Firewall Stud Bus**     | Blue Sea 2105 MaxiBus  | Firewall (cabin side)      | 14 terminals (250A) | See [Firewall Stud Bus][firewall-stud-bus]         |
 | **SwitchPros Ground Bus** | Blue Sea 2105 MaxiBus  | Near SwitchPros controller | 14 terminals (250A) | See [SwitchPros Ground Bus][switchpros-ground-bus] |

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/02-firewall-ingress.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/02-firewall-ingress.md
@@ -26,19 +26,21 @@ Single weatherproof bulkhead connector for all custom wiring through firewall.
 
 | Component | Part Number | Description |
 |:----------|:------------|:------------|
-| **Receptacle** | HDP24-24-21PE-L015 | 21-pin bulkhead receptacle, flange mount (engine side) |
-| **Plug** | HDP26-24-21SE | 21-pin plug (cabin side) |
+| **Receptacle** | HDP24-24-29PE-L015 | 29-pin bulkhead receptacle, flange mount (engine side) |
+| **Plug** | HDP26-24-29SE | 29-pin plug (cabin side) |
 
-**Insert Arrangement 24-21:** 4× size 12 + 17× size 16 contacts
+**Insert Arrangement 24-29:** 29× size 16 contacts
 
-- Size 12 contacts: 12-14 AWG, 25A (4 available, 0 used - reserved for future)[^deutsch-contacts]
-- Size 16 contacts: 14-20 AWG, 13A (17 available, 17 used)[^deutsch-contacts]
+- Size 16 contacts: 14-20 AWG, 13A (29 available, ~16 used after PBS-I keyless, ~13 future headroom — exact used-count pending final pin-map recount, see [TBD Tracker][tbd-tracker])
 
-[^deutsch-contacts]: TE Connectivity / Deutsch HD30 & HDP20 series contact ratings: **size 12 = 25A**, **size 16 = 13A** (solid contacts) — confirmed against TE HDP24-24-21 datasheet and the Deutsch Common Contact System spec (checked 2026-05-30).
-
-**Mounting:** Single 1.5" diameter hole in firewall
+**Mounting:** Single 1.5" diameter hole in firewall (same as previous 24-21 - shell size unchanged)
 
 **Sealing:** IP67/IP68, bayonet quick-connect coupling
+
+**Purpose:** Non-SwitchPros circuits — PMU outputs, CT4 outputs, cabin switches to PMU, winch control, ignition signal, keyless ignition. SwitchPros forward-going outputs use a separate dedicated bulkhead (see [SwitchPros Firewall Bulkhead](#switchpros-firewall-bulkhead)).
+
+!!! info "Upsize from HDP24-24-21 → HDP24-24-29 (2026-05-30)"
+The original 24-21 insert (17 size-16 + 4 size-12) was at 16/17 size-16 capacity. Architectural changes (SwitchPros moved to firewall, keyless ignition) added new circuits. Upsized to 24-29 (all size-16) for headroom. SwitchPros forward outputs were split out to a dedicated SP bulkhead for modularity and noise isolation, freeing more pins.
 
 ### Why Single Connector
 
@@ -48,7 +50,7 @@ RF interference analysis determined that with ferrite chokes on radio power lead
 
 ## Pin Assignment
 
-### Engine Bay → Cabin (5 wires)
+### Engine Bay → Cabin (6 wires)
 
 | Pin | Circuit | Gauge | Source | Destination | Contact |
 |:---:|:--------|:-----:|:-------|:------------|:-------:|
@@ -58,8 +60,11 @@ RF interference analysis determined that with ferrite chokes on radio power lead
 | 4 | Brake lights | 16 AWG | PMU OUT21 | Rear tail lights | #16 |
 | 5 | Reverse lights | 16 AWG | PMU OUT22 | Rear tail lights | #16 |
 | 6 | DRL/Parking | 16 AWG | PMU OUT23 | Rear tail lights | #16 |
+| 12 | PBS-I PINK IGN (ignition signal) | 14 AWG | PBS-I ICM | Ignition bus (cabin) | #16 |
 
-### Cabin → Engine Bay (11 wires)
+### Cabin → Engine Bay (10 wires)
+
+Pin 12 carries the PBS-I PINK IGN ignition signal; the keyswitch was removed when the PBS-I self-contained keyless system was adopted.
 
 | Pin | Circuit | Gauge | Source | Destination | Contact |
 |:---:|:--------|:-----:|:-------|:------------|:-------:|
@@ -68,20 +73,82 @@ RF interference analysis determined that with ferrite chokes on radio power lead
 | 9 | Low beam headlights | 14 AWG | CT4 SW3 | LP6 Pin 1 (both) | #16 |
 | 10 | High beam headlights | 14 AWG | CT4 SW4 | LP6 Pin 4 (both) | #16 |
 | 11 | Horn button trigger | 18 AWG | Steering wheel button | PMU In 1 | #16 |
-| 12 | Ignition signal (outbound) | 14 AWG | Ignition signal bus bar Stud 2 (cabin) | ECM 12V supply + PMU Pin 7 (engine bay) | #16 |
 | 13 | Brake switch | 18 AWG | Brake pedal switch | PMU In 2 | #16 |
 | 14 | A/C request | 18 AWG | HVAC controls | PMU In 9 | #16 |
-| 15 | WAIT-gated PURPLE START | 16 AWG | WAIT-gate relay NC contact (cabin) | Cole Hersee 24213 coil+ | #16 |
+| 15 | WAIT-gated PURPLE START | 16 AWG | PBS-I via WAIT-gate relay | Cole Hersee 24213 coil | #16 |
 | 16 | Winch control IN | 18 AWG | Dash rocker switch | Winch contactor | #16 |
 | 17 | Winch control OUT | 18 AWG | Dash rocker switch | Winch contactor | #16 |
 
-### Reserved (4 pins)
+### Available (13 spare pins)
 
-| Pin | Contact | Notes |
-|:---:|:-------:|:------|
-| A-D | #12 | Size 12 cavities — available for future expansion (e.g., higher-current circuits requiring size 12 contacts) |
+Pins 18-29 + pin 2 (legacy spare) reserved for future non-SwitchPros circuits. The former Boomerang fob-present and gated-start pins were dropped when the PBS-I self-contained keyless system replaced the Boomerang/PMU keyless approach — PBS-I needs no firewall pins beyond PINK IGN (pin 12) and WAIT-gated PURPLE START (pin 15).
 
-Connector is fully populated on size-16 contacts (17/17 used). Size-12 cavities remain available.
+---
+
+## SwitchPros Firewall Bulkhead {#switchpros-firewall-bulkhead}
+
+Dedicated bulkhead for SwitchPros forward-going outputs. Separate from main HDP24 for harness modularity, noise isolation (PWM-capable outputs kept away from signal wires), and future expansion headroom.
+
+### Connector Specification
+
+| Component | Part Number | Description |
+|:----------|:------------|:------------|
+| **Receptacle** | HDP24-18-14PE-L015 | 14-pin bulkhead receptacle, flange mount (engine side) |
+| **Plug** | HDP26-18-14SE | 14-pin plug (cabin side) |
+
+**Insert Arrangement 18-14:** 14× size 16 contacts
+
+- Size 16 contacts: 14-20 AWG, 13A (14 available, 6 used today, 8 future headroom)
+
+**Mounting:** Single 1.25" diameter hole in firewall (shell size 18, smaller than main HDP24-24)
+
+**Sealing:** IP67/IP68, bayonet quick-connect coupling
+
+**Location:** Adjacent to main HDP24 on firewall, passenger side cabin/EB transition (near SwitchPros power module)
+
+### Pin Assignment
+
+Each SwitchPros output uses **2 pins** (power out + ground return) — load grounds return to SwitchPros Ground Bus at firewall (cabin side) for clean SP-native architecture.
+
+| Pin | Circuit | Gauge | Direction | Source | Destination |
+|:---:|:--------|:-----:|:----------|:-------|:------------|
+| 1 | OUT-3 fog light (+) | 14 AWG | Cabin → EB | SP output | BD S8 fog (front bumper) |
+| 2 | OUT-3 fog light (−) | 14 AWG | EB → Cabin | Light ground | SP Ground Bus |
+| 3 | OUT-6 front rocks (+) | 14 AWG | Cabin → EB | SP output | Front bumper rock + 2× front wheel well rocks (splice in EB) |
+| 4 | OUT-6 front rocks (−) | 14 AWG | EB → Cabin | Lights ground | SP Ground Bus |
+| 5 | OUT-17 front locker (+) | 18 AWG | Cabin → EB | SP low-side output | Front ARB solenoid |
+| 6 | OUT-17 front locker (−) | 18 AWG | EB → Cabin | Solenoid ground | SP Ground Bus |
+
+### Available (8 spare pins)
+
+Pins 7-14 reserved for future SwitchPros forward outputs. Likely candidates:
+
+- OUT-2 ditch lights (2 pins) — if routed through firewall instead of A-pillar
+- OUT-1 roof lights (2 pins) — if routed through firewall instead of A-pillar (10 AWG fits size-16)
+- Additional front-mounted accessories (2 pins each)
+
+### Why Dedicated SP Bulkhead
+
+| Benefit | Detail |
+|:--------|:-------|
+| **Modularity** | SwitchPros harness is fully Delphi-native end-to-end; no inline crimps at HDP24. R&R the entire SP harness without touching CT4/PMU wiring. |
+| **Noise isolation** | PWM-capable lighting outputs kept on a separate connector from low-level signal wires (PMU inputs, CT4 outputs, switch returns). |
+| **Future-proof** | 8 free pins accommodate up to 4 more SP forward outputs if A-pillar routing for ditch/roof lights becomes impractical. |
+| **Clean ground architecture** | SP outputs return ground to SP Ground Bus on cabin side via dedicated bulkhead pins, no reliance on chassis ground at forward loads. |
+
+### BOM
+
+| Part Number | Description | Qty | ~Price |
+|:------------|:------------|:---:|:------:|
+| HDP24-18-14PE-L015 | 14-pin receptacle | 1 | $30 |
+| HDP26-18-14SE | 14-pin plug | 1 | $25 |
+| 0460-202-16141 | Size 16 pin, solid, nickel | 6 | $0.50 ea |
+| 0462-201-16141 | Size 16 socket, solid, nickel | 6 | $0.55 ea |
+| 114018 | Sealing plug, size 16 cavity | 8 | $0.25 ea |
+
+**Estimated Total:** ~$65
+
+**Crimping Tool:** HDT-48-00 (shared with main HDP24)
 
 ---
 
@@ -105,36 +172,146 @@ Radio grounds do NOT go through firewall - they route through cab floor to START
 | GMRS Radio ground (-) | 14 AWG | Midland G1 | START battery negative |
 | STX Intercom ground (-) | 14 AWG | STX | START battery negative |
 
-**Routing:** Radios (cabin) → under seat/floor → frame rail → START battery negative (driver wheel well)
+**Routing:** Radios (cabin) → under seat/floor → START battery negative (driver rear wheel well) - exact path TBD (avoid exposed frame rail)
 
 ---
 
 ## Wire Count Summary
 
+### Main HDP24-24-29 (non-SwitchPros)
+
 | Gauge | Count | Circuits |
 |:------|:-----:|:---------|
 | 14 AWG | 7 | Radio power (2), CT4 outputs (4), PBS-I PINK IGN (1) |
 | 16 AWG | 4 | PMU lighting outputs (3), WAIT-gated PURPLE START (1) |
-| 18 AWG | 6 | Switch signals (4), winch control (2) |
-| **Main Connector** | **17** | HDP24-24-21 (1 spare cavity at pin 2 + 4 reserved size 12) |
-| 22 AWG | 2 | Temp probe (separate grommet) |
+| 18 AWG | 5 | Switch signals (3: horn, brake, A/C), winch control (2) |
+| **Main connector** | **16** | HDP24-24-29 (16 of 29 used, 13 spare; exact count pending final recount) |
+
+### SwitchPros HDP24-18-14 (forward SP outputs)
+
+| Gauge | Count | Circuits |
+|:------|:-----:|:---------|
+| 14 AWG | 4 | OUT-3 fog (power + ground), OUT-6 front rocks (power + ground) |
+| 18 AWG | 2 | OUT-17 front locker (power + ground) |
+| **SP connector** | **6** | HDP24-18-14 (6 of 14 used, 8 spare for future SP) |
+
+### Separate Routing (Not Through Bulkheads)
+
+| Gauge | Count | Circuits |
+|:------|:-----:|:---------|
+| 22 AWG | 2 | Temp probe (separate small grommet to grille) |
+| 14 AWG | 2 | Radio grounds (cabin floor → START battery, not through firewall) |
 
 ---
 
-## Connector Bill of Materials
+## Pin Budget Audit (Historical) {#pin-budget-audit}
+
+*This audit drove the decision to upsize to HDP24-24-29 + add dedicated SwitchPros HDP24-18-14. Final architecture documented above.*
+
+### HDP24-24-21 (original)
+
+Architectural changes (SwitchPros relocated to firewall, Firewall CONSTANT bus, keyless ignition) added new circuits that must penetrate the firewall. This section accounts for them against current connector capacity.
+
+### Current usage
+
+| Bank | Capacity | Used | Spare |
+|:-----|:--------:|:----:|:-----:|
+| Size 16 (14-20 AWG, 13A) | 17 | 16 | 1 (pin 2) |
+| Size 12 (12-14 AWG, 25A) | 4 | 0 | 4 (all reserved) |
+| **TOTAL** | **21** | **16** | **5** |
+
+### Pending additions
+
+| Circuit | Direction | Gauge | Pins | Source | Destination |
+|:--------|:----------|:-----:|:----:|:-------|:------------|
+| SwitchPros OUT-3 (fog light) | Cabin → EB → front bumper | 14 AWG | 1 (chassis ground at light) | SP at firewall | BD S8 fog |
+| SwitchPros OUT-17 (front locker, low-side) | Cabin → EB → front axle | 18 AWG | 1 (chassis ground at solenoid) | SP at firewall | Front ARB solenoid |
+| SwitchPros OUT-6 (front rocks subset) | Cabin → EB → front rocks | 14 AWG | 1 (chassis ground at lights) | SP at firewall | Front bumper rock + front wheel well rocks |
+| Boomerang fob present | Cabin → EB | 18 AWG | 1 | Bullet 230 (cabin) | PMU In 4 |
+| Gated start return | Cabin → EB | 18 AWG | 1 | Brake switch start tap | EB P/N relay |
+| **TOTAL NEW** | | | **5** | | |
+
+!!! note "Ground strategy for forward-going SwitchPros outputs"
+Each SwitchPros output normally pairs a power wire (SP → load) with a ground wire (load → SP Ground Bus). For loads forward of the firewall, this doubles the firewall pin count per output.
+
+    **Recommended:** Ground forward-mounted loads to chassis locally. The SwitchPros Ground Bus has a 1/0 AWG bond to chassis at the firewall, so chassis-grounded loads share the same reference. This halves the pin count for forward-going SP outputs (1 pin per output instead of 2).
+
+    Trade-off: relies on chassis ground continuity from front bumper / axle / wheel wells back to the firewall bond. Already required for engine and chassis safety, so no incremental risk.
+
+### Capacity analysis
+
+| Scenario | Size-16 pins used | Spare | Headroom |
+|:---------|:-----------------:|:-----:|:--------:|
+| **Today (no expansion)** | 16 of 17 | 1 | Minimal |
+| **After 5 new circuits (chassis-gnd strategy)** | 21 of 21 (filling pin 2 + 4 size-12 reduced) | 0 | **NONE** |
+| **After 8 new circuits (separate-gnd strategy for SP outputs)** | 24 of 21 | -3 | **OVER CAPACITY** |
+
+### Verdict
+
+**Current HDP24-24-21 will work but leaves zero future headroom.**
+
+- The 1 size-16 spare (pin 2) + 4 size-12 reserved cavities can accommodate all 5 new circuits *only* if size-12 cavities accept 18 AWG wires via reducer crimps or 12 AWG dummy wires
+- Any future expansion (additional sensors, accessories, telematics) will require a connector change anyway
+
+### Recommendation
+
+**Upsize to Deutsch HDP24-24-29** (same shell size, same firewall hole, 29 size-16 contacts).
+
+| Aspect | HDP24-24-21 (current) | HDP24-24-29 (proposed) |
+|:-------|:----------------------|:-----------------------|
+| Total contacts | 21 (17 size-16 + 4 size-12) | 29 (all size-16) |
+| Used after pending additions | 21 of 21 (full) | 21 of 29 |
+| Future headroom | 0 | 8 |
+| Firewall hole size | 1.5" diameter | 1.5" diameter (same) |
+| Approx connector cost | ~$60 (recpt + plug) | ~$80 (recpt + plug) |
+| Crimping tool | HDT-48-00 | HDT-48-00 (same) |
+
+**Net change:** ~$20 extra, same install procedure, same hole, 8 pins of future headroom.
+
+### Alternative: Split into two connectors
+
+Adding a small secondary connector (e.g., HDP20-9-4 with 4 size-20 contacts) for keyless signals only, keeping HDP24-24-21 for current loads. Two penetrations, two sealing surfaces, more work. Not recommended unless HDP24-24-29 is unavailable.
+
+### Implementation order
+
+1. Order HDP24-24-29 receptacle + plug + 12 additional size-16 contacts (8 extra cavities require 8 pins + 8 sockets)
+2. Build harness with original 16 circuits + the 5 new circuits
+3. Plug-seal remaining 8 cavities for moisture protection
+4. Document pin assignments (update the [Pin Assignment](#pin-assignment) section above)
+
+---
+
+## Combined Connector Bill of Materials
+
+### Main HDP24-24-29
 
 | Part Number | Description | Qty | ~Price |
 |:------------|:------------|:---:|:------:|
-| HDP24-24-21PE-L015 | 21-pin receptacle, flange mount | 1 | $35 |
-| HDP26-24-21SE | 21-pin plug | 1 | $25 |
-| 0460-202-16141 | Size 16 pin, solid, nickel | 16 | $0.50 ea |
-| 0462-201-16141 | Size 16 socket, solid, nickel | 16 | $0.55 ea |
-| 114017 | Sealing plug, size 12 cavity | 4 | $0.25 ea |
-| 114018 | Sealing plug, size 16 cavity | 5 | $0.25 ea |
+| HDP24-24-29PE-L015 | 29-pin receptacle, flange mount | 1 | $45 |
+| HDP26-24-29SE | 29-pin plug | 1 | $35 |
+| 0460-202-16141 | Size 16 pin, solid, nickel | 18 | $0.50 ea |
+| 0462-201-16141 | Size 16 socket, solid, nickel | 18 | $0.55 ea |
+| 114018 | Sealing plug, size 16 cavity | 11 | $0.25 ea |
 
-**Estimated Total:** ~$80
+**Subtotal:** ~$105
 
-**Crimping Tool:** HDT-48-00 (size 12-20 solid contacts)
+### SwitchPros HDP24-18-14
+
+| Part Number | Description | Qty | ~Price |
+|:------------|:------------|:---:|:------:|
+| HDP24-18-14PE-L015 | 14-pin receptacle, flange mount | 1 | $30 |
+| HDP26-18-14SE | 14-pin plug | 1 | $25 |
+| 0460-202-16141 | Size 16 pin, solid, nickel | 6 | $0.50 ea |
+| 0462-201-16141 | Size 16 socket, solid, nickel | 6 | $0.55 ea |
+| 114018 | Sealing plug, size 16 cavity | 8 | $0.25 ea |
+
+**Subtotal:** ~$65
+
+**Grand Total:** ~$170
+
+**Crimping Tool:** HDT-48-00 (size 12-20 solid contacts, used for both connectors)
+
+**Firewall preparation:** Drill **two** 1.5" + 1.25" diameter holes adjacent to each other (passenger side, near SwitchPros mounting location). Allow ~3" minimum spacing between hole centers for sealing clearance.
 
 ---
 
@@ -161,6 +338,7 @@ PMU In 7 receives the headlight status signal from this tap, enabling DRL auto-o
 - [Intercom][intercom] - STX power routing
 
 [wire-routing]: index.md
+[tbd-tracker]: ../../09-installation/00-tbd-tracker.md
 [keyless-ignition]: ../../05-control-interfaces/06-keyless-ignition.md
 [pmu-outputs]: ../04-pmu/03-pmu-outputs.md
 [pmu-inputs]: ../04-pmu/02-pmu-inputs.md

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/03-harness-inventory.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/03-harness-inventory.md
@@ -1,0 +1,453 @@
+---
+hide:
+  - toc
+---
+
+# 1.7.3 Harness Inventory {#harness-inventory}
+
+## Purpose
+
+Catalogs each fabricatable wire harness in the build. A "harness" here = a discrete bundle of wires with a defined start connector, end connector(s), routing path, and BOM — something you'd lay out on a workbench and tape together as a unit.
+
+**Use this doc to:**
+
+- Order connectors and lugs in correct quantities
+- Plan fabrication order (build harnesses bench-side, install in vehicle)
+- Identify reuse / consolidation opportunities
+- Define service-replaceable units (one harness fails → replace just that segment)
+
+**Bundling philosophy:** Each harness terminates at a connector at every transition point (firewall, body penetration, distribution box). This makes harnesses individually serviceable and lets you lay them out flat for fabrication. The cost is more connectors; the benefit is much easier R&R.
+
+---
+
+## Harness Map
+
+```text
+                  ┌──────────────────────────────────────────────────┐
+                  │                  ENGINE BAY                       │
+                  │                                                   │
+  H2 START trunk ─►──┐                                                │
+                     │ alt, starter, PMU feed, BCDC input             │
+                     │                                                │
+                     ▼                                                │
+                  ┌─────┐                                             │
+                  │ PMU │◄────── H5 SP front ◄──┐                     │
+                  └──┬──┘                       │                     │
+                     │                          │                     │
+  ═════════════════════════════════ FIREWALL ═════════════════════════│
+                     │                          │                     │
+                     ▼ HDP20                    │                     │
+                  ┌──────────────────────────────────┐                │
+                  │  FIREWALL CLUSTER (cabin side):  │                │
+                  │  SwitchPros + GND bus + BODY PDU │                │
+                  │  + Firewall CONSTANT bus + CBs   │                │
+                  │  + Fusion Amp                    │                │
+                  └────┬──────────────┬──────────────┘                │
+                       │              │                               │
+                       │      H6/7 Rear Cabin Trunk Bundle              │
+                       │      (SwitchPros rear + PMU rear, ~10 cond)    │
+                       │              │                                  │
+                       ▼              ▼                                  │
+                  ┌─────────────────────────────────────────┐         │
+                  │  CABIN TRUNK                            │         │
+                  │  Forward (passenger side): H1/4         │         │
+                  │  Forward (driver side): H2              │         │
+                  │  Rearward: H6/7 + CT4 turn + H8 signal  │         │
+                  │  Cross-cab: H3 (under rear bench)       │         │
+                  └────┬──────────────────────────┬─────────┘         │
+                       │                          │                   │
+                       ▼                          ▼                   │
+       ┌─────────────────────┐         ┌────────────────────┐         │
+       │ DRIVER REAR WELL    │         │ PASSENGER REAR WELL │         │
+       │ • START battery     │◄────────│ • AUX battery       │         │
+       │ • 250A + 80A CBs    │  H3     │ • 300A + 150A CBs   │         │
+       │                     │ BCDC    │ • SafetyHub         │         │
+       │                     │ cross   │ • BCDC              │         │
+       │  H2 ↑ (3× 2/0 AWG)  │ (under  │  H1/4 ↑ (3 cables)  │         │
+       │  driver floor/wall  │  rear   │  passenger          │         │
+       │  to engine bay      │  bench) │  floor/wall to      │         │
+       │                     │         │  3× bulkhead studs  │         │
+       └─────────────────────┘         │  at firewall;       │         │
+                                       │  winch portion      │         │
+                                       │  continues to       │         │
+                                       │  front bumper       │         │
+                                       │  H8 ARB compressor  │         │
+                                       │  → under pass seat  │         │
+                                       └──────┬──────────────┘         │
+                                              │                       │
+                                              ▼                       │
+       ┌─────────────────────────────────────────────────────────────┐
+       │  FRONT BUMPER (H1/4 winch portion terminates)               │
+       │  REAR CARGO BULKHEAD (H6/7 multi-pin breakout)              │
+       └─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## Harness Catalog
+
+### H1/4 — Passenger Rear Power Trunk (AUX Forward Feed + Winch)
+
+*Formerly two harnesses (H1 + H4) — merged 2026-05-30 since they share the entire passenger-side path. Fabricated and installed as a single bundled assembly.*
+
+**Route:** Passenger rear wheel well (AUX battery) → up inside passenger rear quarter sill → forward along **inside floor board / side wall** (passenger side) → A-pillar area → **3× bulkhead studs through firewall** → engine bay → forward along passenger inner fender → through grille area → front bumper (winch portion only)
+
+**Length:** ~13 ft to firewall (all 3 cables); ~13 ft additional for winch cables continuing to bumper
+
+**Contains:**
+
+| Wire | Gauge | Function | Termination at battery | Termination at firewall | Continues to |
+|:-----|:-----:|:---------|:----------------------|:------------------------|:-------------|
+| Forward feed (+) | 2/0 AWG | Powers SwitchPros + BODY PDU + Fusion via Firewall CONSTANT bus | Ring lug to 300A CB output stud | Ring lug to bulkhead stud | (terminates at firewall — bus input stud on engine bay side via short jumper) |
+| Winch power (+) | 1/0 AWG | AUX battery+ → winch contactor B+ | Ring lug to AUX battery+ stud | Ring lug to bulkhead stud | Lug to winch contactor B+ |
+| Winch ground (−) | 1/0 AWG | AUX battery- → winch contactor B− | Ring lug to AUX battery- stud | Ring lug to bulkhead stud | Lug to winch motor / chassis at front |
+
+**Firewall pass-through:** **Single sealed 2-piece rubber grommet** sized for the ~1.5" OD bundle (~1.75" firewall hole). Cables run continuously from rear wheel well to their respective destinations — no service break at the firewall. The grommet seals the firewall penetration only; the cables themselves are uninterrupted.
+
+**Why continuous cables + grommet (not inline connectors or bulkhead studs):**
+
+- WARN install documentation references this approach as standard for winch firewall pass-through
+- No amperage limit at the pass-through (the cable is the conductor; grommet just seals the hole)
+- Common feed-through marine bulkhead studs (Blue Sea 2203/2204, Cole Hersee 46211) max at 250A continuous — borderline for H1 (232A) and underrated for H4 winch peaks (400A)
+- Anderson SB175 is undersized for the winch leg (175A continuous); SBE320/SB350 would work but adds complexity
+- Service is rare in practice — when needed, pulling the entire cable end-to-end is acceptable
+- Steele Rubber or similar 2-piece grommet, ~$5–15
+
+**Protection:** Split loom + wrapped harness sleeve along entire cabin path. Heat sleeve where the winch cables enter engine bay. P-clamps every 12–18".
+
+**Notes:**
+
+- 3-cable bundle: ~1.5" OD final wrapped harness
+- Path is fully inside the body until firewall transition (no exposed frame rail)
+- Cables terminate as ring lugs at destinations (lug-to-stud at battery / CB / bus / contactor on each end). If a service break is ever desired, do it as a lug-to-lug junction inside the rear wheel well, not at the firewall.
+
+---
+
+### H2 — START Engine Bay Trunk
+
+**Route:** Driver rear wheel well (START battery) → up inside driver rear quarter sill → forward along **inside floor board / side wall** (driver side) → A-pillar area → driver firewall penetration → engine bay
+
+**Length:** 6–8 ft per cable
+
+**Contains:**
+
+| Wire | Gauge | Function | Termination at battery | Termination at engine bay |
+|:-----|:-----:|:---------|:----------------------|:--------------------------|
+| Alternator charging input | 2/0 AWG | Alternator → START battery+ | Lug to battery+ stud | Lug to alternator output stud |
+| Starter motor power | 2/0 AWG | START battery+ → starter | Lug to battery+ stud | Lug to starter B+ stud |
+| PMU24 main feed | 2/0 AWG | START battery+ → 250A CB → PMU24 | Lug to 250A CB output | Lug to PMU power stud |
+
+(BCDC input feed (4 AWG via 80A CB) takes the H3 cross-cab path instead — see H3.)
+
+**Connectors:** Lug terminations at both ends. Heat sleeve required where bundle enters engine bay (>12" from exhaust). Bundle 3 cables with looms; expect ~1.5" OD final bundle.
+
+**Protection:** Split loom + wrapped harness sleeve in cabin / sill. Heat sleeve in engine bay. P-clamps every 12–18".
+
+**Firewall penetration:** Driver-side grommet for high-current cables — separate from the HDP24 (HDP24 is passenger-side, signal-only). Three 2/0 AWG cables need a grommet sized for ~1.5" bundle OD.
+
+**Notes:**
+
+- All 3 high-current cables share the same driver-side floor / side wall path
+- Path is fully inside the body (no exposed frame rail)
+- Driver-side firewall grommet is a new firewall penetration — separate from existing passenger-side HDP24 and SwitchPros bulkheads
+
+---
+
+### H3 — BCDC Cross-Cab
+
+**Route:** Driver rear wheel well (START battery) → **under the rear bench seat cushion** → passenger rear wheel well (BCDC + AUX battery)
+
+**Length:** ~5–6 ft (straight cross-cab run under bench)
+
+**Contains:**
+
+| Wire | Gauge | Function | Termination at driver well | Termination at passenger well |
+|:-----|:-----:|:---------|:--------------------------|:------------------------------|
+| BCDC input | 4 AWG | START battery+ via 80A CB → BCDC input terminal | Lug to 80A CB output | Lug to BCDC input red terminal (M8) |
+| Cross-ground reference | 1/0 AWG | START battery- → AUX battery- (critical for BCDC operation) | Lug to START battery- | Lug to AUX battery- |
+
+**Connectors:** Lug terminations both ends. No inline connectors needed for short run.
+
+**Protection:** Split loom along the run. Bench cushion provides physical shielding from above; floor pan shields from below. P-clamps to body cross-member at 1–2 points.
+
+**Notes:**
+
+- Under-bench routing is short, dry, accessible, and physically protected (bench cushion above, floor pan below)
+- No frame rail exposure; no need to share the longer floor / side wall paths used by H1/H2/H4
+- BCDC sensor cable (~6 ft, 2-pin) is included with BCDC unit, runs to AUX battery+ terminal at the same wheel well — short, stays passenger-side, not part of this harness
+- Path is independent of cabin trunk runs (H1/H4 passenger side, H2 driver side), so no cabin trunk congestion impact
+
+---
+
+### H4 — Winch Feed *(merged into H1/4 — see above)*
+
+**Status:** Merged into **H1/4 Passenger Rear Power Trunk** on 2026-05-30. The two harnesses share the entire passenger-side path from AUX battery to firewall, so they are now fabricated as a single 3-cable bundle. The 2× 1/0 AWG winch cables continue past the firewall to the front bumper. See [H1/4 above](#h14--passenger-rear-power-trunk-aux-forward-feed--winch).
+
+---
+
+### H5 — SwitchPros Front Bundle
+
+**Route:** SwitchPros (firewall, cabin side) → **dedicated SwitchPros HDP24-18-14 firewall bulkhead** → engine bay → grille / front bumper / front axle
+
+**Length:** 4–8 ft (depending on destination)
+
+**Contains:**
+
+| SwitchPros output | Gauge | Function | Destination | SP bulkhead pins |
+|:-----------------:|:-----:|:---------|:------------|:----------------:|
+| OUT-3 (35A circuit) | 14 AWG | Fog light | Front bumper (BD S8 amber) | 1 (+) / 2 (−) |
+| OUT-6 (front rocks subset, 15A circuit, shared with rear) | 14 AWG | Front bumper rock light + 2x front wheel well rock lights | Splice at front for 3 lights | 3 (+) / 4 (−) |
+| OUT-17 (low-side 2A) | 18 AWG | Front ARB locker solenoid | Front axle (~12 ft from SP) | 5 (+) / 6 (−) |
+
+**Connectors:** Custom 2-pin Delphi at SwitchPros output side (per SP harness convention); harness terminates at HDP24-18-14 cabin-side plug at firewall. Engine-bay side picks up at HDP24-18-14 receptacle and re-terminates as 2-pin Delphi at each light/solenoid.
+
+**Ground strategy:** Each output's load ground returns through the SP bulkhead (pins 2, 4, 6) to the SwitchPros Ground Bus on cabin side. Clean SP-native architecture; no reliance on chassis ground at forward loads.
+
+**Notes:**
+
+- 3 forward-going SwitchPros circuits in this bundle, 6 pins through dedicated SP bulkhead (HDP24-18-14)
+- Front locker wire (18 AWG) is the longest run — passes through front fender well and along front axle
+- Front rock lights (4 in front wheel wells + 1 front bumper) all share OUT-6 with rear rocks
+- Could be split into "front bumper sub-harness" (fog + front rock + front bumper) and "front axle sub-harness" (front locker) if those routings diverge
+- **8 spare pins** on SP bulkhead accommodate future ditch/roof additions if A-pillar routing becomes impractical
+
+See [SwitchPros Firewall Bulkhead][firewall-ingress] for connector spec and pinout.
+
+---
+
+### H6/7 — Rear Cabin Trunk Bundle (SwitchPros Rear + PMU Rear)
+
+*Formerly two harnesses (H6 + H7) — merged 2026-05-30 since they share the firewall-to-rear cabin trunk path. Fabricated as a single multi-conductor bundle with a rear cargo bulkhead breakout connector.*
+
+**Route:** SwitchPros (firewall, cabin side) + PMU24 outputs (via HDP24 pins 4/5/6 from engine bay) → converge at firewall → cabin trunk (trans tunnel) → rear cargo bulkhead breakout → fans out to rear destinations
+
+**Length:** 8–14 ft (depending on destination; PMU portion is ~11–16 ft total including engine bay leg)
+
+**Contains:**
+
+| Source | Output / Function | Gauge | Destination |
+|:-------|:------------------|:-----:|:------------|
+| **SwitchPros** OUT-6 (shared with front) | Rear rocks (rear bumper + 2× rear wheel well) | 14 AWG | Splice at rear for 3 lights |
+| **SwitchPros** OUT-7 | Chase light (BD RTL-S 30") | 14 AWG | Rear bumper |
+| **SwitchPros** OUT-10 | Rear ARB locker solenoid | 14 AWG | Rear axle |
+| **SwitchPros** OUT-12 | Rear work lights (2× BD S1) | 14 AWG | Above license plate |
+| **SwitchPros** OUT-13 | Cargo lights (2× flush in rear wheel wells) | 14 AWG | Triggered by rear cargo rocker |
+| **SwitchPros** TRIGGER-2 | Cargo rocker switch return | 18 AWG | Rear cargo rocker (rear wheel well top) |
+| **PMU** OUT-21 | Brake signal | 16 AWG | Tail clusters (L+R) + 3rd brake |
+| **PMU** OUT-22 | Reverse signal | 16 AWG | Tail clusters (L+R) |
+| **PMU** OUT-23 | Running/parking signal | 16 AWG | Tail clusters (L+R) + license plate |
+| **PMU** ground return | Common tail cluster ground | 16 AWG | SwitchPros GND bus at firewall |
+
+**Connectors:**
+
+- **Firewall (cabin side):** SwitchPros outputs originate as Delphi 2-pin pigtails at SP module; PMU outputs enter the cabin via HDP24 pins 4/5/6. Both join the trunk wrap aft of firewall.
+- **Rear cargo bulkhead breakout:** Single multi-pin connector — **Deutsch DT15-XX (15-pin)** or **AMP CPC ~15-pin**. All ~10 conductors mate at this single service point.
+- **Rear-side pigtails:** Short individual harnesses from breakout to each destination (chase, work, cargo, rocks, locker, tail clusters).
+
+**Protection:** Split loom + wrapped harness sleeve through cabin trunk. P-clamps every 12–18".
+
+**Notes:**
+
+- ~10 conductors in the cabin trunk bundle (mostly 14 AWG + a few 16/18 AWG)
+- **Service model:** R&R any rear light by swapping its pigtail at the rear bulkhead breakout. The cabin trunk pull stays in place.
+- Splices needed for the tail clusters: each PMU output feeds both driver and passenger sides + 3rd brake/license — can be done at the breakout or with Y-splices closer to lights
+- CT4 rear turn signals could also join this bundle through the cabin trunk; tracked separately because they originate at CT4 (steering column) not firewall
+
+---
+
+### H7 — PMU Rear Lighting *(merged into H6/7 — see above)*
+
+**Status:** Merged into **H6/7 Rear Cabin Trunk Bundle** on 2026-05-30. PMU rear outputs share the cabin trunk path with SwitchPros rear outputs after exiting HDP24, so they are now fabricated as a single multi-conductor bundle with shared rear bulkhead breakout. See [H6/7 above](#h67--rear-cabin-trunk-bundle-switchpros-rear--pmu-rear).
+
+---
+
+### H8 — ARB Compressor Bundle
+
+**Route:** SafetyHub (passenger rear wheel well) → under cargo / under rear bench → under passenger seat (compressor mount)
+
+**Length:** ~10 ft
+
+**Contains:**
+
+| Wire | Gauge | Function | Termination at SafetyHub | Termination at compressor |
+|:-----|:-----:|:---------|:-------------------------|:--------------------------|
+| Motor 1 power | 6 AWG | SafetyHub MIDI-1 (60A) → compressor motor 1 | Lug to MIDI-1 output | Compressor motor terminal |
+| Motor 2 power | 6 AWG | SafetyHub MIDI-2 (60A) → compressor motor 2 | Lug to MIDI-2 output | Compressor motor terminal |
+| Control signal | 14 AWG | SwitchPros OUT-11 → compressor control terminal | (Comes from SwitchPros at firewall, not SafetyHub — runs separately or joins this bundle along common path) | Compressor control terminal |
+| Pressure switch | 18 AWG | ARB pressure switch (on manifold under passenger seat) → SwitchPros TRIGGER-3 | (At firewall, not SafetyHub) | Pressure switch normally-open contact |
+
+**Connectors:** Lug at SafetyHub side, ring/spade at compressor. ARB compressor manifold typically has a pigtail with its own connector.
+
+**Notes:**
+
+- Motor 1 + motor 2 are 6 AWG (high current, brief peaks) — bundle as a pair
+- Control + pressure switch wires originate at SwitchPros at firewall, NOT SafetyHub — they run from firewall through cabin to under passenger seat
+- Could be merged into H8 if they share routing, or kept separate as "H8b ARB signal"
+
+**Optimization opportunity:** Run the SwitchPros control + pressure switch wires through the cabin trunk to under passenger seat as part of H6 SwitchPros rear bundle (they're SP wires anyway), and split off at the compressor. Saves a separate harness — the only ARB-specific harness is the 2x 6 AWG motor cables from SafetyHub.
+
+---
+
+### H9 — Winch Trigger Control (small wire)
+
+**Route:** BODY PDU (firewall, cabin side) → dash switch ([CH4X4 dual-momentary push][ch4x4-winch]) → HDP24 firewall pins 16/17 → winch contactor at front bumper
+
+**Length:** ~3 ft (BODY PDU → dash) + ~13 ft (dash → contactor via engine bay)
+
+**Contains:**
+
+| Wire | Gauge | Function | Termination |
+|:-----|:-----:|:---------|:------------|
+| Switch +12V supply | 18 AWG | BODY PDU CB43 (10A) → CH4X4 switch common | Spade at BODY PDU, included pigtail at switch |
+| IN trigger | 18 AWG | CH4X4 IN button → HDP24 pin 16 → contactor IN trigger | Included pigtail at switch, HDP24 socket, ring/spade at contactor |
+| OUT trigger | 18 AWG | CH4X4 OUT button → HDP24 pin 17 → contactor OUT trigger | Included pigtail at switch, HDP24 socket, ring/spade at contactor |
+| Illumination supply | 18 AWG | Dash illumination circuit | Included pigtail at switch |
+| Switch ground | 18 AWG | Switch common ground | Chassis ground at dash |
+
+**Connectors:** CH4X4 includes its own connector + cable kit. HDP24-24-29 at firewall penetration. Ring/spade terminals at contactor.
+
+**Notes:**
+
+- BODY PDU CB43 (10A, ~3 ft to dash) replaces the previously-planned SafetyHub ATC-1 (15A, ~13 ft from rear wheel well). The 18 AWG wire is properly sized for the ~3A trigger current; the prior 14 AWG / 15A spec was over-built and routed wastefully.
+- Switch is dual-momentary push (not a polarity-reversing rocker) — the WARN ZEON 10-S contactor handles polarity internally
+- Warn handheld remote wires in parallel at the contactor trigger terminals
+- SafetyHub ATC-1 slot freed for future use (recovery accessories etc.)
+
+[ch4x4-winch]: https://ch4x4.com/product/ch4x4-momentary-dual-push-switch-for-toyota-winch-in-out-symbol/
+
+---
+
+### H10 — Kilduff Shifter to TCU
+
+**Route:** Kilduff shifter in **center console** → straight down through trans tunnel → Turbolamik TCU **mounted on 8HP70 mechatronic** (transmission valve body)
+
+**Length:** ~3–5 ft
+
+**Contains:**
+
+| Wire | Gauge | Function | Termination at shifter | Termination at TCU |
+|:-----|:-----:|:---------|:----------------------|:-------------------|
+| Shifter harness | Proprietary multi-conductor (factory 8HP70 connector) | All shifter signals (P/R/N/D, manual +/−, button states, illumination) | Kilduff-supplied connector at shifter base | Factory 8HP70 connector at TCU |
+
+**Connectors:**
+
+- Kilduff supplies the shifter end of the harness with their shifter kit
+- TCU end uses the factory 8HP70 mechatronic connector (Turbolamik TCU 2.0 mates to this)
+
+**Protection:** Split loom through trans tunnel. The trans tunnel keeps the cable away from cabin contents and provides a clean straight run.
+
+**Notes:**
+
+- TCU is **mounted on the 8HP70 mechatronic** (the trans valve body), not in cabin or engine bay — so this is a very short pull
+- No firewall penetration
+- No other H-series harnesses share this path — it's a single-purpose, self-contained run
+- Kilduff includes the wiring harness with the shifter kit — no separate fabrication required
+
+See [Transmission][transmission] for shifter and TCU specs.
+
+---
+
+### H11 — TCU to Engine Bay
+
+**Route:** Turbolamik TCU on 8HP70 mechatronic → up through trans tunnel forward → engine bay (PMU + J1939 tap + starter P/N relay)
+
+**Length:** 3–4 ft
+
+**Contains:**
+
+| Wire | Gauge | Function | Source | Destination |
+|:-----|:-----:|:---------|:-------|:------------|
+| TCU power feed | 14 AWG | PMU OUT16 (CONSTANT, 15A) → TCU power input | PMU OUT16 (engine bay) | TCU power terminal |
+| J1939 CAN High | Twisted pair | Shared J1939 bus tap (same tap as PMU, Dakota Digital BIM-01-2) | CAN bus tap point | TCU CAN-H |
+| J1939 CAN Low | Twisted pair (paired with CAN High) | Shared J1939 bus tap | CAN bus tap point | TCU CAN-L |
+| Aux out (Reverse) | 18 AWG | TCU aux output: 12V when shifter in R → PMU In 3 (drives PMU OUT22 reverse lights) | TCU aux Reverse pin | PMU In 3 |
+| Aux out (P/N) | 18 AWG | TCU aux output: 12V when shifter in P or N → starter P/N interlock relay coil | TCU aux P/N pin | Starter P/N interlock relay coil+ |
+| TCU ground | 14 AWG | TCU ground return | TCU ground terminal | Engine bay ground bus |
+
+**Connectors:**
+
+- TCU end: Turbolamik TCU's connector (depends on TCU model — 2.0 typically uses a small Deutsch DT or similar)
+- Engine bay ends: Each wire terminates at its destination (PMU spade/screw terminal, J1939 splice, relay coil terminal, ground bus stud)
+
+**Protection:** Split loom from TCU through trans tunnel up to engine bay. Heat sleeve where it enters engine bay zone (>12" from exhaust).
+
+**Notes:**
+
+- All endpoints are in engine bay — no firewall penetration needed
+- J1939 CAN tap is shared with PMU and Dakota Digital BIM-01-2 — the TCU is a third node on the same bus (just adds a splice at the existing tap point)
+- The brake switch input to TCU (for unlock-from-Park) is sourced from the cabin brake pedal switch (which already feeds PMU In 2 via HDP24 pin 13) — could share routing or take a separate tap; routing TBD
+- TCU is one of three controllers tightly coupled to the engine bay: PMU24 (mounted on firewall), Dakota Digital BIM modules (on HDPE panel cabin side), and TCU (mounted on transmission). All share the J1939 CAN bus.
+
+See [Transmission][transmission] and [PMU Outputs][pmu-outputs] for related details.
+
+[transmission]: ../../10-drivetrain/01-transmission.md
+
+---
+
+## Cabin Trunk Bundle Summary
+
+The **cabin trunk** (trans tunnel / sill, firewall ↔ rear wheel wells) carries multiple harnesses in parallel. Total bundle inventory:
+
+| Direction | Harness | Cable count | Largest gauge | Path side |
+|:----------|:--------|:-----------:|:-------------:|:---------:|
+| Forward (rear → firewall) | **H1/4** Passenger Rear Power Trunk (AUX fwd + winch power+gnd) | 3 | 2/0 AWG | Passenger sill/floor |
+| Cross-cab | H3 (BCDC inter-battery + cross-gnd) | 2 | 1/0 AWG | Under rear bench |
+| Forward (driver rear → engine bay) | H2 (alt, starter, PMU feed) | 3 | 2/0 AWG | Driver sill/floor |
+| Rearward (firewall → rear) | **H6/7** Rear Cabin Trunk Bundle (SP rear outputs + PMU rear lighting) | ~10 | 14 AWG | Trans tunnel |
+| Rearward (firewall → rear) | CT4 rear turn signals | 2 | 14 AWG | Trans tunnel (could merge into H6/7) |
+| Rearward (firewall → under pass seat) | SwitchPros control + pressure (ARB) | 2 | 14–18 AWG | Trans tunnel (per H8 optimization) |
+
+**Passenger sill/floor (H1/4):** ~3 cables, ~1.5" OD bundle, terminates at 3× bulkhead studs at firewall
+
+**Driver sill/floor (H2):** ~3 cables, ~1.5" OD bundle, terminates at heavy power grommet at firewall
+
+**Trans tunnel rearward (H6/7 + CT4 + ARB signal):** ~14 conductors of small wire (14–18 AWG)
+
+**Suggested trunk wrap:** 1.5"–2" split loom or wrapped harness sleeve per side. P-clamp every 12–18".
+
+---
+
+## Bundle Optimization Opportunities (Summary)
+
+These were noted inline above; consolidated here for review:
+
+1. ~~H4 + H1 share rear-well → firewall path~~ **Resolved (2026-05-30):** Merged into single **H1/4 Passenger Rear Power Trunk**. Firewall transition uses a **single sealed 2-piece rubber grommet** (e.g., Steele Rubber) — cables run continuously, no service break. Bulkhead studs (Blue Sea 2203/2204) max at 250A and were underrated for the H4 winch peaks (400A); Anderson SB175 was also undersized. Continuous-cable + grommet is WARN's documented standard for high-current firewall pass-through.
+2. ~~H6 + H7 + CT4 rear turn + H8 SP signal wires share cabin trunk → rear~~ **Partially resolved (2026-05-30):** H6 + H7 merged into **H6/7 Rear Cabin Trunk Bundle** with single multi-pin breakout (Deutsch DT15 or AMP CPC ~15-pin) at rear cargo bulkhead. CT4 rear turn signals and ARB control wires *could* still join — pending decision.
+3. **H6/7 sub-harness (firewall → rear breakout) is a single straight pull;** R&R of any individual rear light becomes a pigtail swap.
+4. **H8 motor cables only.** Move control/pressure wires into H6/7 since they originate at SwitchPros.
+5. **Front lockers + rock lights + fog in one bundle** through SwitchPros firewall bulkhead to engine bay → grille area. Splice/breakout at front for fan-out.
+6. ~~HDP20 firewall connector pin budget~~ **Resolved (2026-05-30):** Split into two dedicated bulkheads — HDP24-24-29 for non-SP traffic (18/29 used, 11 spare) + HDP24-18-14 for SwitchPros forward outputs (6/14 used, 8 spare). SP harness stays Delphi-native end-to-end. See [Pin Budget Audit][firewall-ingress].
+
+---
+
+## Outstanding Items
+
+- [ ] Decide front bumper breakout connector style (Deutsch DT, AMP CPC, etc.)
+- [ ] Decide rear cargo bulkhead breakout connector style and pin count
+- [x] ~~Calculate HDP20 firewall pin budget — fits or needs upsize?~~ → **Resolved:** Upsized to HDP24-24-29 (29 size-16 contacts, 21 used + 8 future headroom). See [Pin Budget Audit][firewall-ingress] for full pin assignment. Forward-going SP loads use chassis ground locally (1 pin per output instead of 2).
+- [ ] Confirm SwitchPros front locker wire routing (front axle access)
+- [ ] Decide if ARB control wires merge into H6 (recommended) or run as H8 signal pair
+- [ ] Source connector + lug + heat shrink BOM totals
+- [ ] Determine harness sleeve / wrap material (split loom vs braided sleeving) per zone
+
+## Related Documentation
+
+- [Wire Routing][wire-routing] - Zone-based routing reference
+- [Firewall Ingress][firewall-ingress] - HDP20 pinout and penetrations
+- [AUX Battery Distribution][aux-battery] - H1 and H4 source
+- [START Battery Distribution][start-battery] - H2 and H3 source
+- [SwitchPros SP-1200][switchpros] - H5, H6 source controller
+- [PMU24 Outputs][pmu-outputs] - H7 source
+- [SafetyHub 150][safetyhub] - H8, H9 source
+- [Recovery Systems / Winch][recovery] - H4 destination
+- [Air Compressor][air-compressor] - H8 destination
+
+[wire-routing]: index.md
+[firewall-ingress]: 02-firewall-ingress.md
+[aux-battery]: ../03-aux-battery-distribution/index.md
+[start-battery]: ../02-starter-battery-distribution/index.md
+[switchpros]: ../../05-control-interfaces/02-switchpros-sp1200.md
+[pmu-outputs]: ../04-pmu/03-pmu-outputs.md
+[safetyhub]: ../03-aux-battery-distribution/04-safetyhub.md
+[recovery]: ../../08-exterior-systems/01-winch.md
+[air-compressor]: ../../08-exterior-systems/02-air-compressor.md

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/index.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/index.md
@@ -44,53 +44,73 @@ All wire runs require appropriate protection based on location and environment:
 
 ---
 
-## 🔧 Driver Wheel Well (START Battery)
+## 🔧 Driver Rear Wheel Well (START Battery)
 
 **High-current power distribution from START battery:**
 
-| Circuit                       | Wire Gauge | Distance | Destination                    | Current        | Notes                                                |
-| :---------------------------- | :--------- | :------- | :----------------------------- | :------------- | :--------------------------------------------------- |
-| **Alternator charging input** | 2/0 AWG    | 8 ft     | FROM Alternator (engine)       | 270A           | Charges START battery - see [Alternator][alternator] |
-| **Starter motor power**       | 2/0 AWG    | 6 ft     | TO Starter motor               | 400-600A       | Brief cranking load - see [Starter][starter]         |
-| **PMU24 power feed**          | 2/0 AWG    | 7 ft     | TO PMU24 (engine bay)          | 220A max       | Via 250A CB - see [PMU][pmu]                         |
-| **BCDC input feed**           | 4 AWG      | 5-6 ft   | TO BCDC (passenger wheel well) | 50-55A         | Via 80A CB - see [BCDC][bcdc]                        |
-| **Primary ground**            | 2/0 AWG    | 8 ft     | TO Engine bay ground bus       | 600A+ peak     | Primary return path                                  |
-| **Battery cross-ground**      | 1/0 AWG    | 5-6 ft   | TO AUX battery- (passenger)    | BCDC reference | Critical for BCDC operation                          |
+| Circuit                       | Wire Gauge | Distance | Destination                         | Current        | Notes                                                |
+| :---------------------------- | :--------- | :------- | :---------------------------------- | :------------- | :--------------------------------------------------- |
+| **Alternator charging input** | 2/0 AWG    | 8 ft     | FROM Alternator (engine bay)        | 270A           | Charges START battery - see [Alternator][alternator] |
+| **Starter motor power**       | 2/0 AWG    | 6 ft     | TO Starter motor (engine bay)       | 400-600A       | Brief cranking load - see [Starter][starter]         |
+| **PMU24 power feed**          | 2/0 AWG    | 7 ft     | TO PMU24 (engine bay)               | 220A max       | Via 250A CB - see [PMU][pmu]                         |
+| **BCDC input feed**           | 4 AWG      | 5-6 ft   | TO BCDC (passenger rear wheel well) | 50-55A         | Via 80A CB - see [BCDC][bcdc]                        |
+| **Primary ground**            | 2/0 AWG    | 3 ft     | TO Rear frame rail                  | 600A+ peak     | Primary return path                                  |
+| **Battery cross-ground**      | 1/0 AWG    | 5-6 ft   | TO AUX battery- (passenger)         | BCDC reference | Critical for BCDC operation                          |
 
-**Routing:** Frame rail along driver side, through wheel well to engine bay and firewall
+**Routing:** Driver rear wheel well → up inside driver rear quarter sill → forward along **inside floor board / side wall (driver side)** → driver A-pillar area → driver-side firewall grommet → engine bay. Path is fully inside the body (no exposed frame rail). BCDC input (4 AWG) takes the H3 cross-cab path instead (under rear bench seat to passenger side).
 
 ---
 
-## 🔋 Passenger Wheel Well (AUX Battery)
+## 🔋 Passenger Rear Wheel Well (AUX Battery)
 
 **Power distribution from AUX battery:**
 
-| Circuit                           | Wire Gauge | Distance | Destination                            | Current             | Notes                                                                |
-| :-------------------------------- | :--------- | :------- | :------------------------------------- | :------------------ | :------------------------------------------------------------------- |
-| **Warn ZEON 10-S Winch power**  | 1/0 AWG    | 13 ft    | TO Front bumper winch                  | 250A typ, 409A peak | Direct connection (no CB) - see [Recovery Systems][recovery-systems] |
-| **Warn ZEON 10-S Winch ground** | 1/0 AWG    | 13 ft    | TO Winch motor ground                  | 250A typ, 409A peak | Return path via frame rail                                           |
-| **CONSTANT bus bar**              | 1/0 AWG    | 3 ft     | TO CONSTANT bus (passenger wheel well) | 254A max            | Feeds SwitchPros, SafetyHub, BODY PDU                                |
-| **BCDC output**                   | 4 AWG      | Short    | FROM BCDC (passenger wheel well)       | 50A                 | Charging input to AUX battery                                        |
-| **SwitchPros outputs**            | Various    | TBD      | TO Engine bay/front                    | ~100A               | Offroad lighting power - routing TBD                                 |
-| **Primary ground**                | 2/0 AWG    | 3 ft     | TO Rear frame rail                     | 569A peak           | Winch + accessories return                                           |
-| **Cross-ground reference**        | 1/0 AWG    | 5-6 ft   | FROM START battery- (driver)           | BCDC reference      | Critical for BCDC operation                                          |
+| Circuit                                | Wire Gauge | Distance | Destination                                       | Current             | Notes                                                                |
+| :------------------------------------- | :--------- | :------- | :------------------------------------------------ | :------------------ | :------------------------------------------------------------------- |
+| **Warn ZEON 10-S Winch power**       | 1/0 AWG    | 13 ft    | TO Front bumper winch                             | 250A typ, 409A peak | Direct connection (no CB) - see [Recovery Systems][recovery-systems] |
+| **Warn ZEON 10-S Winch ground**      | 1/0 AWG    | 13 ft    | TO Winch motor ground                             | 250A typ, 409A peak | Return path - routing TBD                                            |
+| **Forward feed (Firewall CONSTANT bus)** | 2/0 AWG  | ~13 ft   | TO Firewall CONSTANT Bus (cabin trunk)            | ~232A max           | Protected by 300A CB at battery - feeds SwitchPros, BODY PDU, Fusion |
+| **SafetyHub local feed**               | 2 AWG      | ~2 ft    | TO SafetyHub 150 (local in wheel well)            | ~100A max           | Protected by 150A CB at battery                                      |
+| **BCDC output**                        | 4 AWG      | Short    | FROM BCDC (local in wheel well)                   | 50A                 | Charging input to AUX battery                                        |
+| **Primary ground**                     | 2/0 AWG    | 3 ft     | TO Rear frame rail                                | 569A peak           | Winch + accessories return                                           |
+| **Cross-ground reference**             | 1/0 AWG    | 5-6 ft   | FROM START battery- (driver)                      | BCDC reference      | Critical for BCDC operation                                          |
 
-**Routing:** Frame rail from passenger wheel well to front bumper (winch), rear to cargo, TBD to engine bay
+**Routing:**
+
+- **Forward feed (2/0 AWG) + Winch power/ground (2× 1/0 AWG) (H1 + H4):** Passenger rear wheel well → up inside passenger rear quarter sill → forward along **inside floor board / side wall (passenger side)** → A-pillar area → through passenger firewall (H1 terminates at Firewall CONSTANT bus; H4 continues to engine bay → grille → front bumper). Three heavy cables bundled together. Fully inside body, no exposed frame rail.
+- **BCDC input + cross-ground reference (H3):** **Under the rear bench seat** cushion → passenger rear wheel well. Short, dry, physically protected.
+- **SafetyHub local feed (2 AWG):** ~2 ft local in wheel well, no routing concern.
 
 ---
 
-## ⚙️ Engine Bay & CONSTANT Bus
+## ⚙️ Engine Bay
 
 **Engine compartment wiring:**
 
 | Circuit                   | Wire Gauge | Distance | Source                | Destination           | Current    | Notes                         |
 | :------------------------ | :--------- | :------- | :-------------------- | :-------------------- | :--------- | :---------------------------- |
-| **Alternator to battery** | 2/0 AWG    | 8 ft     | Alternator            | START battery+        | 270A       | See Driver Wheel Well section |
-| **Starter motor**         | 2/0 AWG    | 6 ft     | START battery+        | Starter motor         | 400-600A   | See Driver Wheel Well section |
+| **Alternator to battery** | 2/0 AWG    | 8 ft     | Alternator            | START battery+        | 270A       | See Driver Rear Wheel Well section |
+| **Starter motor**         | 2/0 AWG    | 6 ft     | START battery+        | Starter motor         | 400-600A   | See Driver Rear Wheel Well section |
 | **Engine block ground**   | 2/0 AWG    | 8 ft     | Engine block          | Engine bay ground bus | 600A+ peak | Starter/alternator return     |
 | **Frame ground**          | 2/0 AWG    | 3 ft     | Engine bay ground bus | Front frame rail      | 600A+ peak | Chassis ground point          |
 
-**BCDC Location:** Passenger wheel well (near AUX battery) - charges AUX battery from START battery/alternator
+**BCDC Location:** Passenger rear wheel well (near AUX battery) - charges AUX battery from START battery/alternator
+
+---
+
+## 🏠 Firewall Cluster (Cabin Side, Passenger Area)
+
+**Cabin distribution cluster mounted on the firewall** - co-located components fed by the 2/0 AWG forward feed from AUX battery:
+
+| Component                              | Wire Gauge | Distance | Source/Destination                         | Notes                                           |
+| :------------------------------------- | :--------- | :------- | :----------------------------------------- | :---------------------------------------------- |
+| **Firewall CONSTANT Bus (input)**      | 2/0 AWG    | ~13 ft   | FROM AUX battery+ via 300A master CB       | Heavy feed through cabin trunk - routing TBD    |
+| **Bus → SwitchPros**                   | 2 AWG      | ~2 ft    | TO SwitchPros power module                 | Via 150A CB                                     |
+| **Bus → BODY PDU**                     | 2 AWG      | ~2 ft    | TO BODY PDU                                | Via 100A CB                                     |
+| **Bus → Fusion Apollo Amp**            | 4 AWG      | ~3 ft    | TO Fusion amp (behind dash radio)          | Via 100A CB                                     |
+| **SwitchPros Ground Bus**              | 1 AWG      | ~3 ft    | TO chassis ground at firewall              | Lighting/aux load returns                       |
+| **SwitchPros control cable**           | Multi-pin  | ~5 ft    | TO SwitchPros panel on dash                | Standard SwitchPros cable                       |
+| **SwitchPros outputs (12 circuits)**   | Various    | TBD      | TO various loads (front/cabin/rear/roof)   | Mostly short forward fan-out from firewall      |
 
 ---
 
@@ -141,8 +161,8 @@ J1939 CAN High/Low wires tap into Cummins harness at firewall punch-through, the
 
 | Routing Path                     | Circuits                         | Method         | Notes                         |
 | :------------------------------- | :------------------------------- | :------------- | :---------------------------- |
-| **Cab → Cargo**                  | Rear lights, compressor, lockers | TBD            | Under seats or floor channels |
-| **Passenger wheel well → Cargo** | SwitchPros rear outputs          | Via frame rail | Rear auxiliary power          |
+| **Cab → Cargo**                       | Rear lights, compressor, lockers | TBD | Under seats or floor channels |
+| **Passenger rear wheel well → Cargo** | SwitchPros rear outputs          | TBD | Rear auxiliary power (avoid exposed frame rail) |
 
 ---
 
@@ -164,8 +184,8 @@ J1939 CAN High/Low wires tap into Cummins harness at firewall punch-through, the
 
 | Location                      | Ground Bus            | Wire Gauge | Connections                                           | Notes                     |
 | :---------------------------- | :-------------------- | :--------- | :---------------------------------------------------- | :------------------------ |
-| 🔧 **Driver wheel well**      | Engine bay ground bus | 2/0 AWG    | START battery-, engine block, frame rail, AUX battery | Primary ground hub        |
-| 🔋 **Passenger wheel well**   | Rear frame rail       | 2/0 AWG    | AUX battery-                                          | AUX battery ground point  |
+| 🔧 **Driver rear wheel well**      | Engine bay ground bus | 2/0 AWG    | START battery-, engine block, frame rail, AUX battery | Primary ground hub        |
+| 🔋 **Passenger rear wheel well**   | Rear frame rail       | 2/0 AWG    | AUX battery-                                          | AUX battery ground point  |
 | 🏠 **Firewall (cabin side)**  | Firewall stud bus     | 4 AWG max  | Body electronics, sensors                             | Cabin electronics ground  |
 | ⚙️ **Firewall (engine side)** | Engine bay ground bus | Various    | PMU, controllers, accessories                         | Engine bay ground hub     |
 | 🌐 **SwitchPros controller**  | SwitchPros ground bus | 1 AWG      | Lighting/aux loads                                    | Dedicated lighting ground |
@@ -174,9 +194,10 @@ J1939 CAN High/Low wires tap into Cummins harness at firewall punch-through, the
 
 ## Related Documentation
 
+- [Harness Inventory][harness-inventory] - Fabricatable harness BOMs (H1–H9) with connectors and bundle optimization notes
 - [Grounding Architecture][grounding] - Complete grounding system design
-- [START battery Distribution][starter-battery] - Driver wheel well power
-- [AUX battery Distribution][aux-battery] - Passenger wheel well power
+- [START battery Distribution][starter-battery] - Driver rear wheel well power
+- [AUX battery Distribution][aux-battery] - Passenger rear wheel well power
 - [PMU][pmu] - Power management unit
 - [SafetyHub][safetyhub] - Fused distribution
 - [BCDC][bcdc] - DC-DC charger
@@ -184,6 +205,8 @@ J1939 CAN High/Low wires tap into Cummins harness at firewall punch-through, the
 - [Starter][starter] - Starter motor routing
 - [Firewall Ingress][firewall-ingress] - Detailed firewall penetrations and grommet specifications
 - [Recovery Systems][recovery-systems] - Winch installation and wiring
+
+[harness-inventory]: 03-harness-inventory.md
 
 [grounding]: ../05-grounding/index.md
 [starter-battery]: ../02-starter-battery-distribution/index.md

--- a/docs/jeep_lj/01-power-systems/08-load-analysis/03-aux-battery.md
+++ b/docs/jeep_lj/01-power-systems/08-load-analysis/03-aux-battery.md
@@ -54,7 +54,7 @@ All circuits powered by AUX battery (charged by BCDC at 50A max):
 
 - **Capacity:** 135Ah nominal
 - **Usable capacity:** 108Ah (80% DOD safe for LiFePO4)
-- **Heated BMS:** Enables charging down to -4°F (critical for wheel well mount)
+- **Heated BMS:** Enables charging down to -4°F (critical for rear wheel well mount)
 - **Recovery rate:** At 50A charging, recovers 108Ah in ~2.2 hours
 
 ## Scenario Analysis

--- a/docs/jeep_lj/01-power-systems/08-load-analysis/index.md
+++ b/docs/jeep_lj/01-power-systems/08-load-analysis/index.md
@@ -13,8 +13,8 @@ The Jeep LJ uses a dual battery architecture with isolated power domains:
 
 | Battery   | Location             | Charging                | Primary Loads                   |
 | :-------- | :------------------- | :---------------------- | :------------------------------ |
-| **START** | Driver wheel well    | Alternator (270A)       | PMU, engine systems, BCDC       |
-| **AUX**   | Passenger wheel well | BCDC (50A) + Solar (6A) | SwitchPros, SafetyHub, BODY PDU |
+| **START** | Driver rear wheel well    | Alternator (270A)       | PMU, engine systems, BCDC       |
+| **AUX**   | Passenger rear wheel well | BCDC (50A) + Solar (6A) | SwitchPros, SafetyHub, BODY PDU |
 
 **Key Principle:** The BCDC is the only connection between batteries during normal operation. AUX battery loads do NOT draw from the alternator directly.
 

--- a/docs/jeep_lj/01-power-systems/CLAUDE.md
+++ b/docs/jeep_lj/01-power-systems/CLAUDE.md
@@ -14,11 +14,11 @@ Batteries, alternator, BCDC charger, solar panel
 
 ### 1.2 START Battery Distribution (`02-starter-battery-distribution/`)
 
-Engine bay power distribution, circuit breakers, SafetyHub
+Driver rear wheel well power distribution, circuit breakers, SafetyHub
 
 ### 1.3 AUX Battery Distribution (`03-aux-battery-distribution/`)
 
-Wheel well power distribution, BODY PDU, SwitchPros power source
+Passenger rear wheel well power distribution, BODY PDU, SwitchPros power source
 
 ### 1.4 PMU (`04-pmu/`)
 

--- a/docs/jeep_lj/01-power-systems/index.md
+++ b/docs/jeep_lj/01-power-systems/index.md
@@ -11,19 +11,19 @@ The Jeep LJ uses a dual-battery electrical system with intelligent power distrib
 
 ### Power Generation & Storage
 
-- **START battery:** Odyssey PC1500 (850 CCA, 68 Ah) in driver wheel well - critical systems only
-- **AUX battery:** Dakota Lithium 135Ah LiFePO4 (108 Ah usable, heated BMS) in passenger wheel well - accessories, winch (jump start capable)
+- **START battery:** Odyssey PC1500 (850 CCA, 68 Ah) in driver rear wheel well - critical systems only
+- **AUX battery:** Dakota Lithium 135Ah LiFePO4 (108 Ah usable, heated BMS) in passenger rear wheel well - accessories, winch (jump start capable)
 - **RedArc BCDC Alpha 50:** DC-DC charger/isolator - batteries operate independently when isolated
-- **270A Alternator:** Charges START battery, BCDC charges AUX battery from front
+- **270A Alternator:** Charges START battery, BCDC charges AUX battery
 
 See [Power Generation](01-power-generation/index.md) for complete details on batteries, alternator, BCDC, and solar charging.
 
 ### Power Distribution
 
-Both batteries use CONSTANT bus bars for organized distribution with individual circuit breaker protection:
+Each battery uses a different distribution strategy:
 
-- **[START battery Distribution](02-starter-battery-distribution/index.md):** CONSTANT bus (Blue Sea 2107, 600A) feeds PMU, SafetyHub, BCDC
-- **[AUX battery Distribution](03-aux-battery-distribution/index.md):** CONSTANT bus (Blue Sea 2104, 225A) feeds SwitchPros, BODY PDU
+- **[START battery Distribution](02-starter-battery-distribution/index.md):** Inline CBs at battery (250A for PMU, 80A for BCDC input) — no local bus, direct stacked terminal lugs
+- **[AUX battery Distribution](03-aux-battery-distribution/index.md):** Inline CBs at battery (300A master forward feed + 150A SafetyHub local) → [Firewall CONSTANT Bus](03-aux-battery-distribution/02-constant-bus.md) (Blue Sea 2105, 250A) feeds SwitchPros, BODY PDU, Fusion Amp at the firewall cluster
 
 The system replaces the factory TIPM with modular programmable controllers:
 
@@ -48,7 +48,7 @@ Ground distribution architecture:
 | **Loom** | Split loom or braided sleeving | Abrasion protection where routed against metal |
 | **Grommets** | Rubber with sealant | All firewall and body penetrations |
 | **Temp derating** | 60°C for engine bay | Ampacity calculations must use derated values |
-| **Temp derating** | 30°C for cabin/wheel well | Standard ampacity values acceptable |
+| **Temp derating** | 30°C for cabin/rear wheel well | Standard ampacity values acceptable |
 
 See [Wire Distance Reference][wire-distance] for routing distances and gauge specifications.
 

--- a/docs/jeep_lj/02-engine-systems/05-horn.md
+++ b/docs/jeep_lj/02-engine-systems/05-horn.md
@@ -54,7 +54,7 @@ START battery CONSTANT → PMU → Out 18 → PIAA Horns (5.4A) → Chassis Grou
 
 **Power Flow:**
 
-1. START battery+ → CONSTANT bus → PMU
+1. START battery+ → 250A inline CB → PMU
 2. Horn button (steering wheel) → PMU In 1 (trigger signal)
 3. PMU Out 18 activated when In 1 closes
 4. PMU Out 18 → PIAA horns (5.4A) → chassis ground (engine bay)
@@ -73,7 +73,7 @@ None - design complete. See [installation checklist][install-checklist] for buil
 ## Related Documentation
 
 - [PMU Outputs][pmu-outputs] - PMU Out 18 circuit and programming
-- [START Battery Distribution][starter-battery-distribution] - CONSTANT bus bar
+- [START Battery Distribution][starter-battery-distribution] - Inline CBs (250A PMU, 80A BCDC)
 - [Firewall Ingress][firewall-ingress] - Horn button trigger wire routing
 
 [piaa-horns]: https://www.piaa.com/product/85115/

--- a/docs/jeep_lj/04-offroad-lighting/07-cargo-lights.md
+++ b/docs/jeep_lj/04-offroad-lighting/07-cargo-lights.md
@@ -27,7 +27,7 @@ Interior cargo area lighting controlled by physical switch (Baja Designs Zone 7)
 
 **Quantity:** 2 pods
 
-**Mounting:** Flush mount inset on wheel well
+**Mounting:** Flush mount inset on rear wheel well (cargo area)
 
 **Power Source:** BODY PDU (via physical switch)
 
@@ -45,7 +45,7 @@ Interior cargo area lighting controlled by physical switch (Baja Designs Zone 7)
 
 **Controller:** [Blue Sea 4160 Push Button Switch][switch-link]
 
-**Switch Location:** Top of wheel well (accessible from tailgate)
+**Switch Location:** Top of rear wheel well (accessible from tailgate)
 
 **Wiring:** BODY PDU CB20 (10A) → Switch → Cargo lights → Ground
 

--- a/docs/jeep_lj/05-control-interfaces/01-overview.md
+++ b/docs/jeep_lj/05-control-interfaces/01-overview.md
@@ -12,7 +12,7 @@ This section documents all control interfaces in the Jeep LJ build - the switche
 - **[SwitchPros SP-1200][switchpros-sp-1200-rcr-force-12]** - Main lighting and accessory controller
   - 12-button control panel with Bluetooth app
   - 17 total outputs (12 main + 5 low-side drivers)
-  - 150A total capacity on CONSTANT bus
+  - 150A capacity, fed by Firewall CONSTANT Bus (via 150A CB)
   - Controls all auxiliary lighting and accessories
 
 - **[Command Touch CT4][command-touch-ct4]** - Steering column turn signal and headlight controller
@@ -37,8 +37,8 @@ This section documents all control interfaces in the Jeep LJ build - the switche
 
 All control interfaces integrate with the dual-battery electrical system:
 
-- **SwitchPros SP-1200:** Powered by CONSTANT bus (AUX battery)
-- **Command Touch CT4:** Powered by START battery CONSTANT, integrates with PMU
+- **SwitchPros SP-1200:** Powered by Firewall CONSTANT Bus (sourced from AUX battery via 300A master CB + 2/0 AWG forward feed)
+- **Command Touch CT4:** Powered by PMU OUT 13 (15A CONSTANT, sourced from START battery), integrates with PMU
 - **Dashboard switches:** Various power sources depending on function
 
 ## Related Documentation

--- a/docs/jeep_lj/05-control-interfaces/02-switchpros-sp1200.md
+++ b/docs/jeep_lj/05-control-interfaces/02-switchpros-sp1200.md
@@ -16,17 +16,17 @@ tags:
 
 **Manual:** <https://www.switchpros.com/wp-content/uploads/RCR-force-12-installation-guide-REV-1.9.pdf>
 
-**Power Source:** 150A breaker from CONSTANT bus (AUX battery)
+**Power Source:** 150A breaker from [Firewall CONSTANT Bus][firewall-bus] (fed from AUX battery via 300A master CB + 2/0 AWG forward feed)
 
-**Power Wire:** 1/0 AWG, ~2 ft (AUX battery to power module in same wheel well) — deliberate upsize over the supplied 30" cable[^sp-gauge]
+**Power Wire:** 2 AWG, ~2 ft (Firewall CONSTANT Bus to power module — both at firewall cluster)
 
-**Power Module Location:** Passenger rear wheel well (with AUX battery, rated to 125°C, IP67)
+**Power Module Location:** Firewall (cabin side, passenger area) — co-located with BODY PDU and Firewall CONSTANT Bus. Module is IP67 / 125°C-rated so wheel well placement is also valid, but firewall mounting minimizes total output wire length since most loads are forward/upper (~58% of outputs).
 
 **Control Panel Location:** Dash mount (4" L x 3" W x 0.375" H)
 
-**Control Cable:** Standard 10.5 ft (available in 1, 5, 10.5, 15, 20, 25, 30, 35 ft lengths)
+**Control Cable:** Standard 5 ft cable (was 10.5 ft when module was rear-mounted — moving to firewall shortens this significantly)
 
-**Ground:** 4 AWG to chassis (reference ground only, not load return)[^sp-gauge]
+**Ground:** 4 AWG to chassis (per manufacturer spec - reference ground only, not load return)
 
 !!! note "Load Ground Path"
     The 4 AWG controller ground is for logic/reference only. Load return current flows through individual output grounds to the [SwitchPros Ground Bus][switchpros-ground-bus] (1/0 AWG to chassis).
@@ -114,10 +114,11 @@ The SwitchPros SP-1200 is the main lighting and accessory controller for the Jee
 
 ## Power and Ground Connections
 
-See [AUX Battery Distribution][aux-battery] for power specifications.
+See [AUX Battery Distribution][aux-battery] for source battery and [Firewall CONSTANT Bus][firewall-bus] for downstream distribution.
 
-- **Power:** CONSTANT bus (AUX battery) → 150A breaker → SwitchPros power module
-- **Ground:** 4 AWG wire from SwitchPros power module → Front frame rail or START battery negative (direct battery ground per manufacturer spec)
+- **Power:** AUX battery+ → 300A master CB → 2/0 AWG forward (~13 ft) → Firewall CONSTANT Bus → 150A CB → SwitchPros power module
+- **Ground (logic reference):** 4 AWG wire from SwitchPros power module → chassis ground at firewall (short run, per manufacturer spec)
+- **Load returns:** Each output's ground wire returns to the [SwitchPros Ground Bus][switchpros-ground-bus] (Blue Sea 2105 MaxiBus), co-located with the power module at the firewall
 
 ## Trigger Input Assignments
 
@@ -135,8 +136,8 @@ Factory Passenger Door Plunger (NO)─┘
 ```
 
 **Wire Routing:**
-- Driver door: Door jamb → under dash → rear wheel well (via existing harness path)
-- Passenger door: Door jamb → under dash → rear wheel well (via existing harness path)
+- Driver door: Door jamb → under dash → firewall SwitchPros (short run)
+- Passenger door: Door jamb → under dash → firewall SwitchPros (short run)
 - Wire gauge: 18 AWG (trigger signal only, no current load)
 
 **Configuration:**
@@ -195,7 +196,7 @@ Program TRIGGER-3 to activate compressor when tank pressure drops below 135 PSI:
 
 - ARB Pressure Switch model 180901 (cut-in: 135 PSI, cut-out: 150 PSI)
 - Mounted on air manifold under passenger seat
-- Low current signal wire (18 AWG from manifold to SwitchPros TRIGGER-3)
+- Low current signal wire (18 AWG from manifold under passenger seat to SwitchPros TRIGGER-3 at firewall — short run)
 
 **Benefits:**
 
@@ -211,17 +212,14 @@ Program TRIGGER-3 to activate compressor when tank pressure drops below 135 PSI:
 
 ## Outstanding Items
 
-- [ ] Determine exact SwitchPros power module mounting location in engine bay
-  - IP67 rated, 125°C temperature rating suitable for engine bay
-  - Locate near CONSTANT bus or START battery for short power/ground runs
+- [ ] Determine exact SwitchPros power module mounting location at firewall (passenger cabin side, near BODY PDU)
 - [ ] Determine SwitchPros control panel mounting location on dash
-- [ ] Route 4 AWG ground wire from SwitchPros power module to front frame rail or START battery negative
-  - Short run in engine bay, per manufacturer spec for direct battery ground
+- [ ] Route 4 AWG logic ground wire from SwitchPros power module to chassis ground at firewall (short run, per manufacturer spec)
+- [ ] Mount [SwitchPros Ground Bus][switchpros-ground-bus] (Blue Sea 2105 MaxiBus) at firewall near SwitchPros power module for output load returns
 - [ ] Connect ignition signal from ignition switch RUN terminal to SwitchPros Pin 3 (IGNITION - LT BLUE)
   - 18 AWG wire, splits from main ignition signal distribution (see [PMU24][pmu-inputs])
 - [ ] Determine parking lights signal source for SwitchPros Pin 4 (LIGHTS - WHITE) for DRL integration
-- [ ] Plan control panel cable routing from rear wheel well power module to dash (~10-15 ft)
-  - Order 15 ft cable if standard 10.5 ft is insufficient
+- [ ] Order 5 ft control panel cable (firewall power module to dash panel - short run)
 - [ ] Wire driver door switch + passenger door switch in parallel to TRIGGER-1 (Pin 7, PINK)
 - [ ] Configure Button 4 programming: OUTPUT-4 OR TRIGGER-1 activates dome lights
 - [ ] Install rear cargo rocker switch and wire to TRIGGER-2 (Pin 8, PINK)
@@ -243,9 +241,8 @@ Program TRIGGER-3 to activate compressor when tank pressure drops below 135 PSI:
 - [Air System][air-system-arb-compressor-lockers] - ARB locker and compressor wiring details
 - [AUX Battery Distribution][aux-battery] - Power feed specifications for SwitchPros
 
-[^sp-gauge]: Switch-Pros does not publish a required wire gauge — the RCR-Force 12 ships with a **30" battery cable** and its [install guide](https://www.switchpros.com/wp-content/uploads/RCR-force-12-installation-guide-REV-1.9.pdf) only specifies output-side gauge (14 AWG harness; up to 12/10 AWG for long high-current runs). Our **1/0 AWG** power feed is a deliberate upsize over the supplied cable, sized for the 150A module capacity on a short (~2 ft) run. The **4 AWG controller ground is adequate** because it carries logic/reference current only — per Switch-Pros' design, load-return current flows through each output's own ground back to the [SwitchPros Ground Bus][switchpros-ground-bus] (1/0 AWG to chassis), not through the controller ground. Confirmed design choice, 2026-05-30.
-
 [aux-battery]: ../01-power-systems/03-aux-battery-distribution/index.md
+[firewall-bus]: ../01-power-systems/03-aux-battery-distribution/02-constant-bus.md
 [air-system-arb-compressor-lockers]: ../08-exterior-systems/02-air-compressor.md
 [pmu-inputs]: ../01-power-systems/04-pmu/02-pmu-inputs.md
 [control-interfaces-overview]: 01-overview.md

--- a/docs/jeep_lj/05-control-interfaces/05-dashboard-controls.md
+++ b/docs/jeep_lj/05-control-interfaces/05-dashboard-controls.md
@@ -7,48 +7,91 @@ hide:
 
 This section documents physical switches mounted in the dashboard area (separate from the SwitchPros control panel).
 
-## Winch Control Rocker Switch
+## Dash Switch Panel Standard
+
+All dash-mounted physical switches use the **Toyota OEM cutout standard: 1.54" × 0.83" (39 mm × 21 mm)**. This is the de facto "Toyota-style" switch dimension used by Tacoma / 4Runner / FJ Cruiser / Tundra OEM, and supported by multiple aftermarket switch vendors (CH4X4, STEDI, sPOD, etc.).
+
+**Why this standard:**
+
+- Single consistent dash cutout dimension across all custom switches
+- Wide vendor selection at this size (better than custom Carling Contura cutouts)
+- LED-backlit OEM-look aesthetic
+- Switches snap-lock into their own cutout — no fascia/bezel required
+
+**Mounting:** Cutouts machined directly into the existing **Genright dash** at chosen positions — no separate fascia panel. Each switch snap-locks into its 1.54" × 0.83" rectangular cutout.
+
+---
+
+## Identified Dash Switches
+
+| # | Switch | Status | Function | Power | Notes |
+|:-:|:-------|:-------|:---------|:------|:------|
+| 1 | **Winch IN/OUT** | ✓ Selected: CH4X4-TOY-D-WINIO | Dual-momentary push, IN and OUT | BODY PDU CB43 (10A) | See [Winch Control Switch](#winch-control-switch) below |
+| 2 | **Drive mode select** (transmission) | 🔴 TBD | 3-position mode select (Street / Default / Offroad) — exact action depends on TCU spec | TBD (likely BODY PDU) | Verify TCU input requirements before sourcing |
+| 3 | **Driver heated seat** | 🔴 TBD | ON/OFF latching (or momentary for Hi/Lo if available) | BODY PDU CB45 via relay K21 | Toyota-style equivalent needed |
+| 4 | **Passenger heated seat** | 🔴 TBD | ON/OFF latching | BODY PDU CB42 via relay K22 | Toyota-style equivalent needed |
+
+**Excluded from this panel** (different aesthetic/form factor by design):
+
+- Keyless ignition push button — round illuminated momentary (Otto/Apem 19-22mm), separate dash location
+- Hidden bypass toggle — under-dash, intentionally not visible
+- AMOT runaway shutoff T-handle — mechanical push-pull cable handle, dash bezel mount
+
+---
+
+## Winch Control Switch
 
 !!! info "Winch System Documentation"
 For complete winch specifications, wiring details, and recovery system information, see [Recovery Systems][recovery-systems].
 
-**Type:** Center-off momentary rocker switch (SPDT or DPDT)
-**Location:** Dashboard physical switch panel
-**Function:** In-cab winch control (works in parallel with handheld remote)
+**Selected part:** [CH4X4 Momentary Dual Push Switch for Toyota — Winch IN/OUT][ch4x4-winch]
 
-### Switch Positions
+| Spec | Value |
+|:-----|:------|
+| SKU | CH4X4-TOY-D-WINIO |
+| Type | Dual independent momentary push buttons in one housing |
+| Cutout | 1.54" × 0.83" (Toyota OEM standard) |
+| Per-circuit rating | 3A @ 12V |
+| Illumination | Dual-color LED (blue = OFF, green = ON) |
+| Includes | Switch + connector + cable + wiring diagram |
+| Price | ~$24 |
 
-- **UP (momentary):** Winch OUT (let out cable)
-- **CENTER:** Off (spring return to center)
-- **DOWN (momentary):** Winch IN (pull in cable)
+**Function:** In-cab winch control (works in parallel with handheld remote).
 
-**Dual Control:** Dash rocker switch + handheld remote work simultaneously in parallel
+### How It Works
+
+The CH4X4 has **two independent momentary push circuits** (not a polarity-reversing rocker). Each press sends a momentary +12V signal:
+
+- **Top button (IN symbol):** momentary +12V → winch contactor IN trigger
+- **Bottom button (OUT symbol):** momentary +12V → winch contactor OUT trigger
+
+This is the **correct** design for the Warn ZEON 10-S contactor, which has separate IN and OUT trigger inputs that internally handle the motor polarity reversal. Two discrete push buttons are safer than a single rocker (can't accidentally activate both directions at once).
+
+**Dual Control:** Dash push switch + handheld remote work simultaneously in parallel (both wired to the contactor's same trigger inputs).
 
 ### Wiring
 
-**Power Source:**
+| Connection | Wire | Source | Destination |
+|:-----------|:-----|:-------|:------------|
+| Switch +12V supply | 1× 18 AWG | BODY PDU CB43 (10A) | Switch common terminal |
+| IN signal | 1× 18 AWG | Switch IN button output | HDP24 pin 16 → winch contactor IN trigger |
+| OUT signal | 1× 18 AWG | Switch OUT button output | HDP24 pin 17 → winch contactor OUT trigger |
+| Illumination supply | 1× 18 AWG | Dash illumination circuit | Switch LED+ |
+| Switch ground | 1× 18 AWG | Switch LED−/common | Chassis ground at dash |
 
-- **BODY PDU:** Available circuit breaker slot (10A fuse)
-- **System:** AUX battery powered (matches winch main power source)
+**Routing:** BODY PDU (firewall, cabin side) → ~3 ft 18 AWG to dash switch → out through HDP24 pins 16/17 → engine bay → winch contactor (front bumper).
 
-**Control Circuit:**
-
-- **Power:** BODY PDU (10A CB) → Dash rocker switch
-- **Outputs:** Rocker UP/DOWN → Winch contactor IN/OUT signals
-- **Wire Gauge:** 16-18 AWG (low-current control signals, ~2A max)
-- **Routing:** BODY PDU (cabin) → dash rocker → through firewall → winch contactor (front bumper)
-
-**Parallel Remote:**
-
-- Handheld remote (wireless or wired) connects in parallel at winch contactor
-- Both dash rocker AND remote can trigger IN/OUT independently
+**Parallel Remote:** Handheld remote (wireless or wired) connects in parallel at winch contactor trigger terminals. Both dash switch and remote can trigger IN/OUT independently.
 
 ### Winch Control Outstanding Items
 
-- [ ] Source center-off momentary rocker switch (SPDT or DPDT, 10A rated)
-- [ ] Assign BODY PDU circuit breaker slot for winch control (10A)
-- [ ] Determine firewall grommet routing for control wires
-- [ ] Verify winch contactor IN/OUT terminal connections for parallel wiring
+- [x] ~~Source center-off momentary rocker switch~~ → **Resolved 2026-05-30:** CH4X4-TOY-D-WINIO selected (dual-momentary push, not rocker; matches WARN contactor architecture)
+- [x] ~~Assign BODY PDU circuit breaker slot~~ → **Resolved:** CB43 (10A) already allocated
+- [ ] Verify winch contactor IN/OUT terminal connections for parallel wiring (with handheld remote)
+- [ ] Order CH4X4 switch
+- [ ] Mark and machine 1.54" × 0.83" cutouts in Genright dash at chosen positions for winch + future switches
+
+[ch4x4-winch]: https://ch4x4.com/product/ch4x4-momentary-dual-push-switch-for-toyota-winch-in-out-symbol/
 
 ## Rear Seat Switch
 

--- a/docs/jeep_lj/06-audio-systems/02-amplifier.md
+++ b/docs/jeep_lj/06-audio-systems/02-amplifier.md
@@ -26,11 +26,9 @@ tags:
 
 **Manual:** [Installation Manual][manual-link]
 
-**Mounting:** Cab side firewall (behind radio)
+**Mounting:** Under rear seat (mounting plate w/ clearance for Class-D thermals)
 
-**Power Source:** CONSTANT bus via 40A breaker (per Fusion install guide)[^amp-fuse]
-
-[^amp-fuse]: External protection set to **40A** per Garmin/Fusion's MS-AP61800 install guide (owner decision, 2026-05-30) — supersedes the earlier 100A breaker, which was oversized for this amp. The install guide specifies a 40A external inline fuse/breaker with 4 AWG (max 2 AWG) power/ground; our 4 AWG matches. The amp's own **125A internal electronic fuse** handles amp-side faults; the 40A external device protects the wiring. The previously documented "78A max" is a theoretical all-channels-full-sine figure, not a sustained load — realistic musical draw is ~8-15A (see [AUX Battery Load Analysis][aux-load-analysis]). Source: [Fusion Apollo Multichannel Amplifiers install guide](https://static.garmin.com/pumac/Fusion_Apollo_Multichannel_Amplifiers_Install_EN-US.pdf) (checked 2026-05-30).
+**Power Source:** AUX battery+ direct via 100A inline CB (~3-4 ft, short feed)
 
 ///
 
@@ -54,7 +52,7 @@ tags:
 
 | Channel | Mode    |   Output | Load        |
 | :------ | :------ | -------: | :---------- |
-| Ch 1+2  | Bridged | 580W RMS | Subwoofer   |
+| Ch 1+2  | Bridged @ 8Ω | ~290W RMS | 2× M6-8IB subs wired in **series** (4Ω + 4Ω = 8Ω) |
 | Ch 3    | Stereo  | 150W RMS | Front Left  |
 | Ch 4    | Stereo  | 150W RMS | Front Right |
 | Ch 5    | Stereo  | 150W RMS | Rear Left   |
@@ -80,29 +78,31 @@ Fusion includes bridge adapters with built-in magnets:
 
 | Connection | Wire     | Source          | Notes                    |
 | :--------- | :------- | :-------------- | :----------------------- |
-| Power (+)  | 4 AWG    | CONSTANT bus    | Via 40A Blue Sea breaker |
-| Ground (−) | 4 AWG    | AUX battery (−) | Direct to terminal       |
-| Remote     | 18 AWG   | MS-RA670        | Turn-on signal           |
-| RCA Zone 1 | Shielded | MS-RA670        | Ch 3+4 (front)           |
-| RCA Zone 2 | Shielded | MS-RA670        | Ch 5+6 (rear)            |
-| RCA Sub    | Shielded | MS-RA670        | Ch 1+2 (bridged)         |
+| Power (+)  | 4 AWG    | AUX battery+ direct | Via 100A inline CB at battery (~3-4 ft) |
+| Ground (−) | 4 AWG    | AUX battery (−) | Direct to terminal (~3-4 ft)       |
+| Remote     | 18 AWG   | MS-RA670        | Turn-on signal, bundled w/ RCA through trans tunnel |
+| RCA Zone 1 | Shielded | MS-RA670        | Ch 3+4 (front), ~10-12 ft — use high-quality shielded |
+| RCA Zone 2 | Shielded | MS-RA670        | Ch 5+6 (rear), ~10-12 ft |
+| RCA Sub    | Shielded | MS-RA670        | Ch 1+2 (bridged), ~10-12 ft |
 
 ## Circuit Protection
 
-Amplifier has 125A internal electronic fuse (no replacement necessary). External protection at CONSTANT bus:
+Amplifier has 125A internal electronic fuse (no replacement necessary). External protection at AUX battery:
 
-- **Breaker:** Blue Sea 187-series 40A thermal circuit breaker (per Fusion install guide)
-- Protects 4 AWG wiring (rated 95A continuous)
-- Mount at CONSTANT bus in passenger wheel well
+- **Breaker:** Blue Sea 187-100A (100A) thermal circuit breaker
+- Protects 4 AWG wiring (rated 95A continuous, 100A with short runs)
+- Mount inline within 7" of AUX battery+ terminal (5th stacked lug)
 
 ## Mounting Location
 
-**Cab side firewall (behind radio)**
+**Under rear seat (driver side or center, mounted to floor with clearance for Class-D thermals)**
 
-- Shortest RCA runs from head unit
-- Central location for speaker wire routing
-- Power/ground run ~8-10 ft to AUX battery in passenger wheel well
-- Adequate ventilation for Class-D efficiency
+- Power feed ~3-4 ft direct from AUX battery+ (much shorter than firewall route)
+- Ground return ~3-4 ft to AUX battery− (shorter = less noise risk)
+- Centroid to all 4 speakers + 2 subs — optimizes speaker wire routing
+- RCA + remote bundled together from head unit through trans tunnel (~10-12 ft, high-quality shielded RCA required to avoid alternator whine)
+- Mounting plate with airflow gap underneath for Class-D thermals (Fusion rated 32-122°F operating)
+- Removes Fusion 100A CB from firewall-side bank (firewall CONSTANT bus now feeds only SwitchPros + BODY PDU)
 
 ## Related Documentation
 
@@ -117,6 +117,5 @@ Amplifier has 125A internal electronic fuse (no replacement necessary). External
 [speakers]: 03-speakers.md
 [subwoofer]: 04-subwoofer.md
 [aux-distribution]: ../01-power-systems/03-aux-battery-distribution/index.md
-[aux-load-analysis]: ../01-power-systems/08-load-analysis/03-aux-battery.md
 [product-link]: https://www.garmin.com/en-US/p/677280/pn/010-02284-60/
 [manual-link]: https://static.garmin.com/pumac/Fusion_Apollo_Multichannel_Amplifiers_Install_EN-US.pdf

--- a/docs/jeep_lj/06-audio-systems/04-subwoofer.md
+++ b/docs/jeep_lj/06-audio-systems/04-subwoofer.md
@@ -7,63 +7,67 @@ tags:
   - jl-audio
 ---
 
-# 6.4 Subwoofer {#subwoofer}
+# 6.4 Subwoofers {#subwoofer}
 
-12" infinite baffle marine subwoofer with RGB LED lighting, designed for large air volume installations.
+Pair of 8" infinite baffle marine subwoofers with RGB LED lighting, mounted symmetrically in the rear quarter panels.
 
 /// html | div.product-info
-![JL Audio M7-12IB-S-GmTi-i-4](../images/jl-audio-m7-12ib-s-gmti-i-4.jpg){ loading=lazy }
+![JL Audio M6-8IB-S-GmTi-i-4](../images/jl-audio-m6-8ib-s-gmti-i-4.jpg){ loading=lazy }
 
-**Type:** 12" Infinite Baffle Marine Subwoofer
+**Type:** 8" Infinite Baffle Marine Subwoofer
 
-**Model:** M7-12IB-S-GmTi-i-4
-
-**Part Number:** 010-03288-00
+**Model:** M6-8IB-S-GmTi-i-4
 
 **Manufacturer:** JL Audio
 
-**Product Page:** [M7-12IB-S-GmTi-i-4][product-link]
+**Product Page:** [M6-8IB-S-GmTi-i-4][product-link]
 
-**Quantity:** 1
+**Quantity:** 2 (pair)
 
-**Mounting:** Cargo area wall (infinite baffle)
+**Mounting:** Rear quarter panels (one per side, above wheel wells, firing inward)
 
-**Power Source:** Amplifier Channels 1+2 (bridged)
+**Power Source:** Amplifier Channels 1+2 (bridged), wired **in series** across both subs
 
 ///
 
-## Specifications
+## Specifications (per sub)
 
 | Spec               |                Value |
 | :----------------- | -------------------: |
-| Power Handling     |        600W RMS @ 4Ω |
-| Amplifier Output   | 580W RMS (97% match) |
-| Impedance          |                   4Ω |
-| Sensitivity        |      86.7 dB @ 1W/1m |
-| Free Air Resonance |             35.34 Hz |
-| Sealed -3dB        |             35.52 Hz |
-| Ported -3dB        |             20.96 Hz |
-| Voice Coil         |           4" (102mm) |
-| Weight             |            25.35 lbs |
+| Power Handling     |        200W RMS @ 4Ω |
+| Impedance          |              4Ω SVC |
+| Sensitivity        |        ~85 dB @ 1W/1m |
+| Voice Coil         |                  2" |
+| Overall Diameter   |              ~9.5" |
+| Mounting Depth     |              ~4.25" |
+| Weight             |             ~7 lbs |
 | Warranty           |              3 years |
 
-## Dimensions
+## Wiring Configuration {#wiring}
 
-| Measurement       |            Value |
-| :---------------- | ---------------: |
-| Overall Diameter  |      14" (356mm) |
-| Overall Depth     |       9.39-9.42" |
-| Mounting Depth    |    7.94" (202mm) |
-| Cutout Diameter   | 12.0625" (306mm) |
-| Bolt Hole Circle  |  12.813" (325mm) |
-| Grille Protrusion |       1.45-1.48" |
+Both subs wired **in series** to the Fusion amp bridged Ch1+2 output. This is the only safe configuration with this amp/sub combination:
+
+| Wiring | Total Z | Fusion AP61800 Output | Per Sub | Safe? |
+| :----- | :-----: | :------------------: | :-----: | :----: |
+| Parallel | 2Ω | n/a — below 4Ω bridged minimum | n/a | ❌ Damages amp |
+| **Series** | **8Ω** | ~290W | ~145W | ✅ 72% of RMS rating |
+
+**Series wiring path:**
+
+```
+Amp Ch1+2 (+) → Sub A (+)
+              Sub A (−) → Sub B (+)
+                          Sub B (−) → Amp Ch1+2 (−)
+```
+
+Total amp output ~290W into the pair (~145W per sub) — well-controlled, headroom for transients, no risk of over-excursion at sane gain settings.
 
 ## Infinite Baffle Requirements
 
-- **Minimum air volume:** 3 cu. ft. (84.95 liters) behind mounting surface
+- **Minimum air volume:** 0.75 cu ft per sub (1.5 cu ft pair)
 - **Installation type:** No dedicated enclosure required
-- **Ideal locations:** Cargo area wall, rear seat/tub wall
-- **Jeep LJ cargo area:** Provides ideal infinite baffle environment
+- **Ideal location:** Rear quarter panels above wheel wells, firing inward into cabin
+- **IB chamber:** Rear cargo area / behind quarter trim (effectively unlimited volume in an LJ)
 
 ## Features
 
@@ -77,15 +81,27 @@ tags:
 
 | Connection  | Wire   | Notes                   |
 | :---------- | :----- | :---------------------- |
-| Speaker (+) | 12 AWG | From amp Ch 1+2 bridged |
-| Speaker (−) | 12 AWG | From amp Ch 1+2 bridged |
-| LED         | 20 AWG    | RGB from MLC-RW         |
+| Speaker (+) | 14 AWG | From amp Ch 1+2 bridged to Sub A (+) |
+| Sub A (−) → Sub B (+) | 14 AWG | Series jumper between subs |
+| Speaker (−) | 14 AWG | From Sub B (−) back to amp Ch 1+2 bridged (−) |
+| LED         | 20 AWG | RGB from MLC-RW (one tap per sub) |
 
 Standard speaker wire (no XM-WHTMFC needed for subwoofer audio).
 
+## Why Two 8" vs Single 12"
+
+The single 12" M7-12IB option (600W RMS, 14" overall diameter, 7.94" mounting depth, requires 3+ cu ft IB chamber) was ruled out for LJ-specific install reasons:
+
+- **Mounting depth:** 7.94" of basket depth makes most LJ panels impractical — cage tubes, wheel wells, and tailgate clearance all conflict.
+- **Single-sub asymmetry:** harder to integrate cosmetically vs symmetric L/R 8" pair.
+- **No matching 12" M6:** JL doesn't make a 12" M6-IB (M6 IB line tops at 10"), so the pair option doesn't exist at 12".
+
+**Tradeoff accepted:** total sub output drops from 580W (single M7-12IB @ 4Ω bridged) to ~290W (2× M6-8IB @ 8Ω bridged), about half. Acceptable for a soft-top Jeep where wind noise dominates at highway speed anyway, and the symmetric placement + easier install win out.
+
 ## Outstanding Items
 
-- [ ] Determine subwoofer mounting location and orientation
+- [ ] Confirm exact mounting locations in rear quarter panels (clear of cage tubes and rear seatbelts)
+- [ ] Verify quarter panel material can support sub weight + mounting torque (may need backing plate)
 
 ## Related Documentation
 
@@ -96,4 +112,4 @@ Standard speaker wire (no XM-WHTMFC needed for subwoofer audio).
 [audio-overview]: index.md
 [amplifier]: 02-amplifier.md
 [led-controller]: 05-led-controller.md
-[product-link]: https://www.jlaudio.com/products/m7-12ib-s-gmti-i-4-marine-audio-subwoofer-drivers-93723
+[product-link]: https://www.garmin.com/en-US/p/1851253/

--- a/docs/jeep_lj/06-audio-systems/index.md
+++ b/docs/jeep_lj/06-audio-systems/index.md
@@ -14,10 +14,10 @@ Marine-grade audio system with multi-zone control and RGB LED lighting integrati
 | Component                        | Model                          | Power | Control            |
 | :------------------------------- | :----------------------------- | ----: | :----------------- |
 | [Head Unit][head-unit]           | Fusion MS-RA670                |   15A | BODY PDU F2        |
-| [Amplifier][amplifier]           | Fusion Apollo MS-AP61800       |   40A | CONSTANT bus CB    |
+| [Amplifier][amplifier]           | Fusion Apollo MS-AP61800       |   40A | AUX battery+ direct (100A inline CB) — mounted under rear seat |
 | [Front Speakers][speakers]       | JL Audio M6-650X-S-GmTi-i      |     — | Amp Ch 3+4         |
 | [Rear Speakers][speakers]        | JL Audio M6-650VEX-Mb-S-GmTi-i |     — | Amp Ch 5+6         |
-| [Subwoofer][subwoofer]           | JL Audio M7-12IB-S-GmTi-i-4    |     — | Amp Ch 1+2 bridged |
+| [Subwoofers][subwoofer]          | 2× JL Audio M6-8IB-S-GmTi-i-4 (series-wired) | — | Amp Ch 1+2 bridged @ 8Ω |
 | [LED Controller][led-controller] | JL Audio MLC-RW                |    5A | SwitchPros OUT-5   |
 
 **Total System Power:** ~60A peak (40A amp + 15A head unit + 5A LED)
@@ -29,7 +29,7 @@ MS-RA670 Head Unit
     │
     ├─► Zone 1 RCA ──► Amp Ch 3+4 ──► Front Dash Speakers
     ├─► Zone 2 RCA ──► Amp Ch 5+6 ──► Rear Roll Bar Speakers
-    ├─► Sub RCA ────► Amp Ch 1+2 (bridged) ──► Subwoofer
+    ├─► Sub RCA ────► Amp Ch 1+2 (bridged @ 8Ω) ──► 2× M6-8IB subs (series)
     └─► Remote Turn-On ──► Amplifier
 
 MLC-RW LED Controller
@@ -43,7 +43,7 @@ None - see individual component pages for specific items.
 
 ## Related Documentation
 
-- [AUX Battery Distribution][aux-distribution] - CONSTANT bus power source
+- [AUX Battery Distribution][aux-distribution] - Firewall CONSTANT Bus power source (via 300A master CB at AUX battery)
 - [BODY PDU][body-pdu] - Head unit and LED controller power
 - [Footwell Lights][footwell-lights] - RGB lights controlled by MLC-RW
 

--- a/docs/jeep_lj/07-communication-systems/02-intercom.md
+++ b/docs/jeep_lj/07-communication-systems/02-intercom.md
@@ -63,8 +63,8 @@ tags:
 | :----- | :-------------- | :--------------------- | :-------------- |
 | Port 1 | Driver          | STX unit (behind dash) | 6 ft (included) |
 | Port 2 | Front passenger | STX unit (behind dash) | 6 ft (included) |
-| Port 3 | Rear left       | Driver wheel well      | Extended        |
-| Port 4 | Rear right      | Passenger wheel well   | Extended        |
+| Port 3 | Rear left       | Driver rear wheel well      | Extended        |
+| Port 4 | Rear right      | Passenger rear wheel well   | Extended        |
 
 ## Wiring
 

--- a/docs/jeep_lj/08-exterior-systems/01-winch.md
+++ b/docs/jeep_lj/08-exterior-systems/01-winch.md
@@ -30,12 +30,12 @@ tags:
 
 - **Peak Amperage Draw:** 409A (at full load/stall - brief periods only)[^winch-model]
 - **Typical Operating Draw:** 80-250A (most recovery operations)
-- **Main Power Source:** AUX battery (passenger wheel well - direct connection, no fuse/breaker)
+- **Main Power Source:** AUX battery (passenger rear wheel well - direct connection, no fuse/breaker)
   - See [AUX Battery Distribution][aux-battery] for wire specs (gauge, length, routing, voltage drop calculations)
   - **System Voltage:** 13.8V (alternator charging - engine running during winch operations)
   - **Protection:** None - direct connection (see justification below)
 
-[^winch-model]: Model confirmed **WARN ZEON 10-S** (owner, 2026-05-30) — the earlier "VR EVO 10-S" naming was incorrect. WARN's published peak draw for the ZEON 10-S is **409A @ 10,000 lb** (pull table: 62/144/215/280/353/409A); the previously documented 450A (≈ ZEON Platinum) was conservative. 1/0 AWG cable and the integrated contactor retain margin above 409A; WARN service battery leads for the 10-S are **2 AWG** (our 1/0 AWG is a deliberate upsize). Source: [WARN ZEON 10-S (89611)](https://www.warn.com/products/zeon-10-s-89611) (checked 2026-05-30).
+[^winch-model]: Model confirmed **WARN ZEON 10-S** (owner, 2026-05-30) — the earlier "ZEON 10-S" naming was incorrect. WARN's published peak draw for the ZEON 10-S is **409A @ 10,000 lb** (pull table: 62/144/215/280/353/409A); the previously documented 450A (≈ ZEON Platinum) was conservative. 1/0 AWG cable and the integrated contactor retain margin above 409A; WARN service battery leads for the 10-S are **2 AWG** (our 1/0 AWG is a deliberate upsize). Source: [WARN ZEON 10-S (89611)](https://www.warn.com/products/zeon-10-s-89611) (checked 2026-05-30).
 
 ## Circuit Protection - Engineering Justification {#winch-circuit-protection}
 
@@ -121,19 +121,23 @@ See [AUX Battery Distribution][aux-battery] for wire specs (gauge, length, routi
 
 **Control Wiring:**
 
-- **Power Source:** SafetyHub ATC-1 (15A fuse) - AUX battery powered
-- **Dash Rocker:** SafetyHub ATC-1 → Dash rocker switch → Winch contactor IN/OUT signals
-- **Remote:** Wired in parallel with dash rocker (IN and OUT signals)
-- **Wire Gauge:** 14 AWG (low-current control signals only, ~2A max)
-- **Routing:** SafetyHub (wheel well) → dash switch → through firewall → winch contactor (front bumper)
-- **Remote Connection:** Paralleled at winch contactor terminals (IN/OUT)
+- **Power Source:** BODY PDU CB43 (10A fuse) - sourced from Firewall CONSTANT Bus (AUX battery)
+- **Dash Switch:** [CH4X4-TOY-D-WINIO][ch4x4-winch] dual-momentary push, Toyota-style (1.54" × 0.83" cutout) - see [Dashboard Controls][dashboard-controls]
+- **Signal Path:** BODY PDU CB43 → CH4X4 switch (push IN or OUT) → HDP24 pins 16/17 → winch contactor IN/OUT triggers
+- **Remote:** Wired in parallel with dash switch at contactor IN/OUT trigger terminals
+- **Wire Gauge:** 18 AWG (low-current trigger signals, ~2A max each direction)
+- **Routing:** BODY PDU (firewall cabin side) → ~3 ft to dash switch → out through HDP24 → engine bay → winch contactor (front bumper)
 
 | Circuit         | Source             | Protection            | Wire Gauge                                                 | Destination             | Function            |
 | --------------- | ------------------ | --------------------- | ---------------------------------------------------------- | ----------------------- | ------------------- |
 | Main Power (+)  | AUX battery+       | None (direct)         | See [AUX Battery Distribution][aux-battery] for wire specs | Winch Contactor → Motor | High-current power  |
 | Main Power (-)  | AUX battery-       | None                  | See [AUX Battery Distribution][aux-battery] for wire specs | Winch Motor Ground      | High-current return |
-| Control Trigger | Dash Rocker Switch | SafetyHub ATC-1 (15A) | 14 AWG                                                     | Winch Contactor         | Low-current trigger |
-| Remote Control  | Warn Remote        | Internal to winch     | Per Warn specs                                             | Winch Control Pack      | Directional control |
+| Trigger IN      | CH4X4 IN button    | BODY PDU CB43 (10A)   | 18 AWG                                                     | Winch Contactor IN trig | Low-current trigger |
+| Trigger OUT     | CH4X4 OUT button   | BODY PDU CB43 (10A)   | 18 AWG                                                     | Winch Contactor OUT trig| Low-current trigger |
+| Remote Control  | Warn Remote        | Internal to winch     | Per Warn specs                                             | Winch Control Pack      | Parallel to dash    |
+
+[ch4x4-winch]: https://ch4x4.com/product/ch4x4-momentary-dual-push-switch-for-toyota-winch-in-out-symbol/
+[dashboard-controls]: ../05-control-interfaces/05-dashboard-controls.md
 
 ## Installation
 
@@ -141,9 +145,9 @@ See [AUX Battery Distribution][aux-battery] for wire specs (gauge, length, routi
 
 See [AUX Battery Distribution][aux-battery] for cable specs and routing path.
 
-- **Route:** Passenger wheel well → along frame rail → front bumper (13 ft)
+- **Route:** Passenger rear wheel well → front bumper (~13 ft, exact path TBD - avoid exposed frame rail per offroad protection requirement)
 - **Protection:** Split loom over entire run
-- **Securing:** P-clamps every 18" along frame rail
+- **Securing:** P-clamps every 18" along the chosen path
 - **Grommets:** Rubber grommets with sealant at body penetrations
 - **Heat:** Route away from exhaust components (minimum 6" clearance)
 
@@ -181,7 +185,7 @@ None - all specifications determined.
 
 ## Related Documentation
 
-- [AUX Battery Distribution][aux-battery] - Winch power source (passenger wheel well)
+- [AUX Battery Distribution][aux-battery] - Winch power source (passenger rear wheel well)
 - [Wire Distance Reference][wire-distance] - Winch to battery routing distance (13 ft one-way, 26 ft circuit)
 - [SafetyHub][safetyhub] - Winch contactor trigger circuit protection
 - [Air Compressor][air-compressor] - ARB compressor for tire inflation

--- a/docs/jeep_lj/08-exterior-systems/02-air-compressor.md
+++ b/docs/jeep_lj/08-exterior-systems/02-air-compressor.md
@@ -74,8 +74,8 @@ ARB Twin Compressor system with air tank and automatic pressure management for l
 
 **Wiring Summary:**
 
-1. **Motor 1 Power (+):** CONSTANT bus → SafetyHub (150A breaker) → SafetyHub MIDI-1 (60A) → 6 AWG → compressor motor 1
-2. **Motor 2 Power (+):** CONSTANT bus → SafetyHub (150A breaker) → SafetyHub MIDI-2 (60A) → 6 AWG → compressor motor 2
+1. **Motor 1 Power (+):** AUX battery+ → 150A inline CB → SafetyHub → SafetyHub MIDI-1 (60A) → 6 AWG → compressor motor 1
+2. **Motor 2 Power (+):** AUX battery+ → 150A inline CB → SafetyHub → SafetyHub MIDI-2 (60A) → 6 AWG → compressor motor 2
 3. **Ground (-):** Compressor negative terminal → 6 AWG → AUX battery negative
 4. **Control (Automatic):** Pressure switch (ARB 180901) → SwitchPros TRIGGER-3 (Pin 17) → OUTPUT-11 → compressor control
 5. **Control (Manual Override):** SwitchPros Button 11 → OUTPUT-11 → compressor control

--- a/docs/jeep_lj/08-exterior-systems/03-air-lockers.md
+++ b/docs/jeep_lj/08-exterior-systems/03-air-lockers.md
@@ -48,15 +48,15 @@ ARB RD116 air-operated locking differentials for front and rear Dana 44 axles.
 
 | Locker | SwitchPros Output | Wire   | Route                                               |
 | ------ | ----------------- | ------ | --------------------------------------------------- |
-| Front  | OUTPUT-17         | 18 AWG | Wheel well → driver frame rail → front axle (~12 ft) |
-| Rear   | OUTPUT-10         | 18 AWG | Wheel well → rear axle (~6 ft)                      |
+| Front  | OUTPUT-17         | 18 AWG | Passenger rear wheel well → front axle (~12 ft, routing TBD) |
+| Rear   | OUTPUT-10         | 18 AWG | Passenger rear wheel well → rear axle (~6 ft)                |
 
 ### Wire Routing
 
-- **Front Locker (OUTPUT-17):** SwitchPros (wheel well) → along driver frame rail → to front axle solenoid (~12 ft)
+- **Front Locker (OUTPUT-17):** SwitchPros (passenger rear wheel well) → along driver frame rail → to front axle solenoid (~12 ft)
   - Wire: 18 AWG (2A load, low-side driver output)
   - Protection: Split loom, P-clamps every 18", secure to frame rail
-- **Rear Locker (OUTPUT-10):** SwitchPros (wheel well) → to rear axle solenoid (~6 ft)
+- **Rear Locker (OUTPUT-10):** SwitchPros (passenger rear wheel well) → to rear axle solenoid (~6 ft)
   - Wire: 18 AWG (2A load)
   - Protection: Split loom where exposed, secure to axle housing
 

--- a/docs/jeep_lj/09-installation/00-tbd-tracker.md
+++ b/docs/jeep_lj/09-installation/00-tbd-tracker.md
@@ -9,7 +9,7 @@ hide:
 
 **Last Updated:** 2026-05-31
 
-**Total Open Items:** 63 (+10 from the 2026-05-30 critical-spec verification audit)
+**Total Open Items:** 58
 
 ---
 
@@ -19,8 +19,7 @@ Items that prevent build completion or system operation.
 
 | Item                                   | Description | File | Priority |
 | :------------------------------------- | :---------- | :--- | :------- |
-| iBooster Backing Plate DXF Redesign    | Re-cut `lj-ibooster-backing-plate.dxf` from 72×72mm square to confirmed 60×80mm rectangular hole pattern (±30mm H / ±40mm V, 80mm vertical) before ordering SendCutSend steel. Vendor revised pattern 2026-05-30. | [iBooster][ibooster] | 🔴 Critical |
-| MC Bore — ✅ resolved                  | **1.00" → Wilwood 260-15542** (2026-05-30). Sized from brake hardware: TJ Rubicon front calipers (2.595" piston) + rear disc + standard/light pedal feel. Factory-matched (Mopar's TJ 1.00" bore was built around these calipers), gives lighter pedal effort, and agrees with the already-confirmed adapter fitment. MC ready to order. | [iBooster][ibooster] | ✅ Done |
+| _(None - all critical items resolved)_ |             |      |          |
 
 ---
 
@@ -33,23 +32,22 @@ Items needed before installation begins but not system-critical.
 | Dakota Digital Panel Mounting     | HDPE sheet dimensions and location                              | [Wire Routing][wire-routing]   | High     |
 | Turbolamik Aux: Reverse           | Confirm aux output channel + pinout configured for Reverse signal → PMU In 3 | [Transmission][transmission]   | High     |
 | Turbolamik Aux: P/N               | Confirm aux output channel + pinout configured for P/N (start interlock) | [Transmission][transmission]   | High     |
-| PBS-I Order                       | Order Digital Guard Dawg PBS-I kit (ICM, 2 iTag fobs, Start Button, Programming Button, Bypass Card, harnesses) | [Keyless Ignition][keyless]   | High     |
-| WAIT-Gate Relay                   | Select SPST 30A automotive relay (NC contacts in start path; coil driven by ECM WAIT signal) | [Keyless Ignition][keyless]   | High     |
-| PBS-I Mounting Location           | Cabin under-dash position; module is ~5.5"×3"×1.25"; away from heat/water; do NOT engine-bay mount | [Keyless Ignition][keyless]   | High     |
-| Start Button Mounting Location    | Dash position within easy reach (button + 36" harness included in PBS-I kit)                  | [Keyless Ignition][keyless]   | High     |
-| Programming Button Storage        | Hidden but accessible location (under dash or in trunk) for fob-learn and emergency bypass PIN entry | [Keyless Ignition][keyless] | Medium   |
-| PBS-I Quiescent Current           | Measure or vendor-confirm standby draw to add to START battery parasitic budget               | [Keyless Ignition][keyless]   | Medium   |
+| Dash Push-Button (Keyless)        | Select 19/22mm illuminated momentary NO push-button for keyless start/stop | [Keyless Ignition][keyless]   | High     |
+| Boomerang Bullet 230              | Order RFID receiver + fob; mounting location under dash         | [Keyless Ignition][keyless]   | High     |
+| Boomerang Mounting Location       | Under-dash position near driver (3-6 ft range to driver seat)   | [Keyless Ignition][keyless]   | High     |
+| ECM Ignition Relay                | Select Hella/Bosch SPST 30-40A automotive relay                 | [Keyless Ignition][keyless]   | High     |
+| P/N Interlock Relay               | Select SPST 30A automotive relay (Turbolamik P/N → coil)        | [Keyless Ignition][keyless]   | High     |
+| Engine-Running Lockout Relay      | Select SPST 30A automotive relay with NC contacts               | [Keyless Ignition][keyless]   | High     |
+| Engine-Running Voltage Filter     | Design diode + zener + resistor filter on alternator B+ tap for lockout coil drive | [Keyless Ignition][keyless]   | High     |
+| Keyless Firewall Pin Assignments  | Assign 3 new HDP24 pins (fob, OUT24 supply, gated start return); current connector is full | [Firewall Ingress][firewall-ingress] | High     |
+| Hidden Bypass Toggle              | Select part + mounting location for emergency get-home bypass   | [Keyless Ignition][keyless]   | High     |
+| PMU Output Strategy (Keyless)     | Decide: OUT24-only + engine-running lockout (current plan) vs. free OUT15 winch trigger for dedicated crank output | [Keyless Ignition][keyless]   | High     |
+| PMU24 Keyless State Machine       | Program ECUMaster Light Client logic for OFF/RUN/CRANK transitions, fob detection, kill behavior | [PMU Programming][pmu-programming]   | High     |
 | R2.8 Turbo Inlet OD               | Measure turbo inlet tube outside diameter to confirm AMOT 4261M-02 (2.8" body) fitment and select intake-side adapter | [Runaway Protection][runaway-protection] | High     |
 | AMOT-to-Intake Adapters           | Source NPT-to-hose fittings sized to match measured turbo inlet OD                                | [Runaway Protection][runaway-protection] | High     |
 | AMOT T-Handle Mounting Location   | Select dash mounting position for Midwest Control 30-144-TTL-BH-3 (reachable belted, away from accidental contact) | [Runaway Protection][runaway-protection] | High     |
 | AMOT Cable Firewall Grommet       | Assign dedicated firewall grommet for AMOT push-pull cable pass-through (must not share with other cables) | [Runaway Protection][runaway-protection] | High     |
 | Catch Can Mounting Bracket Point  | Select engine bracketry attachment point for Mishimoto MMOCC-UB universal bracket                  | [Runaway Protection][runaway-protection] | High     |
-| iBooster Donor Sourcing           | Source 2018-2023 Honda Accord Hybrid iBooster + MC pull (eBay/LKQ/Car-Part.com)                   | [iBooster][ibooster] | High |
-| iBooster Wiring Harness Selection | Choose between Tulay's Wire Werks Gen 2 universal vs EVcreate Gen 2 connector kit                  | [iBooster][ibooster] | High |
-| LJ Firewall Mount Strategy        | Primary: direct mount via booster's integral 4-stud flange + SendCutSend cabin-side backing plate (drill new firewall holes 60×80mm M8, 80mm vertical + 62mm center). Fallback: SendCutSend custom one-off, then Back Bay commission (only if LJ trial-fit available) | [iBooster][ibooster] | High |
-| Reservoir Standoff Design         | Design firewall standoff to mount 250-16393 dual bracket 4-6" above MC flange                      | [iBooster][ibooster] | High |
-| Auto Brake Pedal Sourcing         | Source 03-06 TJ/LJ automatic brake pedal assembly + stop-lamp switch (Mopar 56045043AB if needed) | [iBooster][ibooster] | High |
-| Clutch MC Firewall Hole Plug      | Block-off plate or weld closure for ~1.25" CMC pass-through (manual-to-auto pedal swap)            | [iBooster][ibooster] | High |
 
 ---
 
@@ -60,7 +58,6 @@ Items that improve the design but don't block installation.
 | Item                                   | Description                                                                      | File                                 | Priority |
 | :------------------------------------- | :------------------------------------------------------------------------------- | :----------------------------------- | :------- |
 | Firewall Grommet Circuits              | Complete wire bundle lists                                                       | [Wire Routing][wire-routing]         | Medium   |
-| Passenger Wheel Well Routing           | SwitchPros outputs path                                                          | [Wire Routing][wire-routing]         | Medium   |
 | Dash to Console Routing                | Switch panels, USB, radio                                                        | [Wire Routing][wire-routing]         | Medium   |
 | Cab to Cargo Routing                   | Rear lights, compressor, lockers                                                 | [Wire Routing][wire-routing]         | Medium   |
 | Roof/Roll Bar Routing                  | Light bars, dome lights                                                          | [Wire Routing][wire-routing]         | Medium   |
@@ -71,11 +68,18 @@ Items that improve the design but don't block installation.
 | Alternator Voltage Regulator Set Point | Verify 14.2-14.4V for AGM batteries                                              | [Alternator][alternator]             | Medium   |
 | BODY PDU Metri-Pack Pinout             | J301-J306 connector pinout (military TM or reverse engineering)                  | [BODY PDU][body-rtmr]                | Medium   |
 | BODY PDU 12V Relay Part Numbers        | Replacement part numbers for K40, K42, K53 (currently 24V coils)                 | [BODY PDU][body-rtmr]                | Medium   |
-| Winch Control Wire Routing             | Routing path from dash to bumper (~15-20 ft through multiple zones)              | [Dashboard Controls][dash-controls]  | Medium   |
-| Winch Rocker Switch Sourcing           | Center-off momentary rocker switch (SPDT or DPDT, 10A rated)                     | [Dashboard Controls][dash-controls]  | Medium   |
+| Winch Control Wire Routing             | Routing path from dash to bumper via HDP24 (~3 ft BODY PDU→dash + ~13 ft dash→contactor)              | [Dashboard Controls][dash-controls]  | Medium   |
+| Drive Mode Switch (transmission)       | Source 3-position Toyota-style switch (1.54"×0.83" cutout) once TCU selected. Verify TCU input requirements (ground-switched vs +12V switched, # of modes). | [Dashboard Controls][dash-controls]  | Medium   |
+| Heated Seat Switches                   | Source 2× Toyota-style ON/OFF switches (1.54"×0.83" cutout) for driver + passenger heated seats. Wire to BODY PDU CB45/CB42 via K21/K22 relays. | [Dashboard Controls][dash-controls]  | Medium   |
+| Driver-side Firewall Heavy Power Grommet | Source rubber grommet sized for ~1.5" OD bundle (3× 2/0 AWG H2 cables). New firewall penetration on driver side. | [Firewall Ingress][firewall-ingress] | High |
+| Passenger-side Firewall Grommet (H1/4) | Source **single sealed 2-piece rubber grommet** (Steele Rubber or equivalent) sized for ~1.5" OD H1/4 cable bundle (~1.75" firewall hole). Cables run continuously through — no service break. Standard winch firewall pass-through per WARN install guidance. Bulkhead studs (Blue Sea 2203/2204) and Anderson SB175 were both underrated for the winch peak current. | [Firewall Ingress][firewall-ingress] | High |
+| Dash Switch Cutout Layout              | Mark and machine 1.54"×0.83" cutouts directly into Genright dash for winch + future switches. Decide cluster location and spacing (e.g., row of 4 beside HDX cluster). | [Dashboard Controls][dash-controls]  | Medium   |
 | Rear Seat Switch Mounting Location     | Physical mounting location for Blue Sea 4160 push button (rear roll bar lights)  | [Dashboard Controls][dash-controls]  | Medium   |
-| Fusion Apollo Amp Distance & Drop      | Wire distance and resulting voltage drop for MS-AP61800 (CONSTANT bus stud 5)    | [Constant Bus][constant-bus]         | Medium   |
-| iBooster Reservoir Flexline Length     | Confirm Wilwood 220-12xxx length after firewall mockup (8"/10"/12" available)    | [iBooster][ibooster]                 | Medium   |
+| Subwoofer Mount Locations              | Mark and cut quarter panel openings for 2× JL M6-8IB (8" cutout, 4.25" depth) above wheel wells. Verify clearance from cage tubes and rear seatbelts. May need backing plate. | [Subwoofer][subwoofer]               | Medium   |
+| Fusion Amp Under-Seat Mounting Plate   | Fab mounting plate under driver-side rear seat with airflow gap (Class-D thermals). 11.69" × 7.06" footprint. Verify clearance from seat slider rails. | [Amplifier][amplifier]               | Medium   |
+| Winch Trigger Control Routing          | Path for 14 AWG control wire (~13 ft) from SafetyHub ATC-1 (passenger rear wheel well) to winch contactor (front bumper) | [Recovery Systems][recovery-systems] | Medium   |
+| Front Air Locker Solenoid Routing      | Path for 18 AWG (~12 ft) from SwitchPros OUTPUT-17 (passenger rear wheel well) to front axle solenoid - cross-cab + forward | [Air Lockers][air-lockers] | Medium   |
+| Radio Ground Routing                   | Path for 14 AWG ground wires from GMRS / Intercom (dashboard) to START battery negative (driver rear wheel well) - direct grounds required for RF noise isolation | [Firewall Ingress][firewall-ingress] | Medium   |
 
 ---
 
@@ -96,42 +100,7 @@ Items that are estimated and need actual product specs to confirm.
 
 | Item                | Description                                                                                     | File                       | Action Needed      |
 | :------------------ | :---------------------------------------------------------------------------------------------- | :------------------------- | :----------------- |
-| Grid Heater Current | Design value 80A - verify via element resistance measurement during installation (~0.15Ω @ 12V); Cummins publishes no current figure for 5467024 | [Grid Heater][grid-heater] | Measure resistance |
-
----
-
-## 🔬 CRITICAL-SPEC VERIFICATION AUDIT (2026-05-30)
-
-Findings from a source-validation pass over critical fab/order/wiring specs (per CLAUDE.md Imperative #7). Each is footnoted at its source page. **Confirmed** specs need no action; **mismatch/unverified** items below need a decision or measurement before fabrication/order.
-
-| Item | Finding | File | Action Needed | Issue |
-| :--- | :------ | :--- | :------------ | :---- |
-| Fusion amp external fuse | ✅ **Resolved (2026-05-30):** external protection set to **40A** per Fusion install guide (owner decision); 100A was oversized. 78A is theoretical sine-max, not sustained; musical draw ~8-15A. 4 AWG retained; 125A internal fuse covers amp-side faults. | [Amplifier][amplifier] | ✅ Done — 40A | [PR #15][pr15] |
-| Winch model + peak draw | ✅ **Resolved (2026-05-30):** model confirmed **WARN ZEON 10-S** (owner); VR EVO naming removed. Peak draw corrected to **409A** (WARN spec) throughout; 1/0 AWG retains margin. | [Winch][winch] | ✅ Done — Zeon 10-S / 409A | [PR #15][pr15] |
-| MC bore recalc | ✅ **Resolved (2026-05-30):** **1.00" / Wilwood 260-15542**, sized to TJ Rubicon front calipers + rear disc + standard/light pedal feel (factory-matched; agrees with confirmed adapter fitment). | [iBooster][ibooster] | ✅ Done — 260-15542 | [#16][i16] |
-| iBooster firewall torque | ✅ **Resolved (2026-05-30):** corrected **16.5 → 13 Nm (115 in-lb)** — Honda's M8 power-brake-booster mounting-nut spec (consistent across Accord generations); M8 confirmed by EVcreate. Conservative direction into the firewall/backing plate. | [iBooster][ibooster] | ✅ Done — 13 Nm | [#18][i18] |
-| iBooster body-neck Ø | ⚠️ **Corroborated (2026-05-30):** ~62mm backed by **two** independent sources (Back Bay vendor + iBooster retrofit community). Not a Honda-published spec. On-arrival measurement folded into checklist [#29][i29] — only ~2mm clearance vs the 64mm backing-plate bore. | [iBooster][ibooster] | On arrival → [#29][i29] | [#19][i19] |
-| Ground bus stud torque | ✅ **Resolved (2026-05-30):** corrected **100-120 → 140 in-lb** — Blue Sea's published spec for the 2107's 3/8"-16 studs (the 120 in-lb was the 5/16"-18 value, undertorquing these). Cited to bluesea.com. | [Ground Bus][ground-bus] | ✅ Done — 140 in-lb | [#22][i22] |
-| MC port threads | ✅ **Outlet resolved (2026-05-30):** confirmed **1/2-20 IF** per Wilwood datasheet (corrects the old 11/16-20 flexline-adapter thread). Inlet/reservoir thread (bore fixed at 260-15542) folded into ordering checklist [#29][i29]. | [iBooster][ibooster] | Inlet → [#29][i29] | [#21][i21] |
-| Radiator fan current/CFM | **53A / 4188 CFM** unverifiable — GM/ACDelco publish no figures for 84100128; requires clamp-meter on the running vehicle. Folded into checklist [#29][i29]. | [Radiator Fan][radiator-fan] | On vehicle → [#29][i29] | [#23][i23] |
-| SwitchPros power/ground gauge | ✅ **Resolved (2026-05-30):** confirmed adequate. 1/0 AWG power is a deliberate upsize over the supplied 30" cable (150A module, ~2 ft run); 4 AWG ground carries reference/logic current only — load return flows via each output's ground to the 1/0 AWG SwitchPros ground bus, per Switch-Pros design. | [SwitchPros][switchpros] | ✅ Done — adequate | [#24][i24] |
-| iBooster donor year + part # | ✅ **Resolved (2026-05-30):** part #s **confirmed on the secured donor** (eBay listing #397546491129, offer accepted): OE/OEM `46680-T3Z-A00` + `01469-TWA-A58`, MC mfr # `46100-TWA-A550-M1`. Speculative model-year claim dropped — physical part is the fitment reference (Gen 2 Honda Accord). Final casting-# check on arrival. | [iBooster][ibooster] | ✅ Done — donor secured | [#20][i20] |
-
-> **GitHub tracking:** the audit items above are sub-issues of [#17 — Critical-spec verification audit][i17]. The MC bore ([#16][i16]) was tracked as a standalone blocker (now resolved). Items needing the physical part or running vehicle (body-neck measure, MC inlet thread, fan current) are consolidated into the on-arrival/on-bench checklist [#29][i29].
-
-[pr15]: https://github.com/sob/drawings/pull/15
-[i16]: https://github.com/sob/drawings/issues/16
-[i17]: https://github.com/sob/drawings/issues/17
-[i18]: https://github.com/sob/drawings/issues/18
-[i19]: https://github.com/sob/drawings/issues/19
-[i20]: https://github.com/sob/drawings/issues/20
-[i21]: https://github.com/sob/drawings/issues/21
-[i22]: https://github.com/sob/drawings/issues/22
-[i23]: https://github.com/sob/drawings/issues/23
-[i24]: https://github.com/sob/drawings/issues/24
-[i29]: https://github.com/sob/drawings/issues/29
-
-**Confirmed-correct (footnoted, no action):** Cole Hersee 24213 = 200A (was wrongly 85A — corrected); MC stroke 1.10"; reservoir 260-16392 4oz/-3AN; ARB CKBLTA12 90A total; SwitchPros RCR-Force 12 output ratings (4×35A/1×30A/11×15A/150A); CT4 10A/output (40A); Odyssey PC1500 68Ah/850CCA; Dakota Lithium 135Ah; Mechanical Products 174-S2 breakers (250/150/100/80A); Blue Sea 2107 (600A) / 2105 (250A); Deutsch HDP24 contacts (size-12 25A / size-16 13A); DB Electrical 410-52442 starter (2.7kW/10-tooth); WARN line pull 10,000 lb; iBooster firewall pattern 60×80mm M8.
+| Grid Heater Current | Design value 80A - verify via element resistance measurement during installation (~0.15Ω @ 12V) | [Grid Heater][grid-heater] | Measure resistance |
 
 ---
 
@@ -141,11 +110,13 @@ Mechanical drivetrain specifications, tracked separately from the electrical bui
 
 | Item                              | Description                                                                                  | File                              | Priority |
 | :-------------------------------- | :------------------------------------------------------------------------------------------- | :-------------------------------- | :------- |
-| Transmission Shifter Type         | Electronic shifter input - depends on shifter selection                                      | [Transmission][transmission]      | Medium   |
+| TCU Brake Switch Routing          | Brake pedal switch already feeds PMU In 2 via HDP24 pin 13. Decide: shared signal tap or dedicated wire to TCU? | [Harness Inventory][harness-inventory] | Medium |
 | Transmission Pilot Bearing        | If required by flywheel/crank combination                                                    | [Transmission][transmission]      | Medium   |
-| Transfer Case → 8HP70 Mating      | Input shaft/adapter to mate the NV241 GenII (stock 23-spline JK input) to the 8HP70 output; confirm low-range gears are stock 2.72:1. Output (32-spline), fluid (ATF+4), capacity (~1.6 L) now documented | [Transfer Case][transfer-case]    | Medium   |
+| Transfer Case Specs               | Output type, fluid type and capacity                                                         | [Transfer Case][transfer-case]    | Medium   |
 | Front Driveshaft Specs            | Type, length, U-joint selection                                                              | [Driveshafts][driveshafts]        | Medium   |
 | Rear Driveshaft Specs             | Type, length, U-joint selection                                                              | [Driveshafts][driveshafts]        | Medium   |
+| Front Axle Gearing & Manufacturer | Ratio and axle housing manufacturer                                                          | [Front Axle][front-axle]          | Medium   |
+| Rear Axle Gearing & Locker        | Ratio, manufacturer, and locker type                                                         | [Rear Axle][rear-axle]            | Medium   |
 | Front Suspension Components       | Coil rate, bypass valving, control arms, track bar, sway bar                                 | [Suspension][suspension]          | Medium   |
 | Rear Suspension Components        | Coil rate, bypass valving, control arms, track bar, sway bar                                 | [Suspension][suspension]          | Medium   |
 | Hydroboost Pump Specs             | Model, flow rate, pressure, drive type                                                       | [Steering][steering]              | Medium   |
@@ -161,24 +132,28 @@ Items completed since last update.
 
 | Item                          | Resolution                                                                                                                    | Date       |
 | :---------------------------- | :---------------------------------------------------------------------------------------------------------------------------- | :--------- |
-| Front Axle Shaft Part Number  | RCV Performance Ultimate Dana 44 CV set, P/N **CVJ44** ('03–'06 TJ/LJ Rubicon; 30-spline inner / 27 outer, unit bearing). rcvperformance.com | 2026-05-31 |
-| Rear Axle Shaft Spec          | **Ten Factory MG22135** — Dana 44 30-spline rear kit ('04–'06 TJ/LJ Rubicon), 4140 chromoly. Seller-confirmed                                  | 2026-05-31 |
-| Rear Brake Hardware           | Confirmed factory TJ **rear disc** with **PowerStop drilled & slotted rotors** (seller). Validates the rear-disc assumption behind the iBooster MC bore; rotor upgrade doesn't change bore basis | 2026-05-31 |
-| Transfer Case Identity + Specs | Corrected to **2012 JK Sport NV241 GenII Command-Trac, 2.72:1** (was wrongly NP241OR Rock-Trac 4:1). Rear output 32-spline, fluid ATF+4 ~1.6 L documented. Crawl ratio ≈66:1 with 8HP70 4.714 1st + 5.13 axles. 8HP70 mating remains open | 2026-05-31 |
-| Front & Rear Gear Ratio + R&P Brand | **5.13:1, Revolution Gear & Axle** (seller-confirmed). Non-factory — re-geared from 4.10. Supersedes earlier 4.56 owner estimate | 2026-05-31 |
-| ARB Locker Model              | **RD116** front and rear — 30-spline Dana 44, 3.92 & up. Confirmed applicable by the 5.13 ratio (RD117 is 3.73 & down). Same part both ends | 2026-05-31 |
-| Back Bay MC Adapter Compatibility | Vendor (Back Bay Customs / Adam) confirmed: adapter fits Wilwood 260-15542 (1.00" Tandem Compact — the selected bore), is Honda-Accord-iBooster-only (not Tesla), and the 2× remote Wilwood reservoirs are fine. Blocker cleared — Wilwood + adapter cleared to order. Note: vendor also revised the firewall pattern to 60×80mm (80mm vertical), see new backing-plate DXF redesign item. | 2026-05-30 |
-| Boomerang Bullet 230          | Removed from build — product was fabricated (does not exist). Replaced by Digital Guard Dawg PBS-I self-contained system     | 2026-05-30 |
-| Boomerang Mounting Location   | Obsolete — Boomerang not used; PBS-I includes its own RFID receiver in the ICM                                                | 2026-05-30 |
-| ECM Ignition Relay            | Obsolete — PBS-I PINK IGN (60A onboard relay) replaces the external ECM ignition relay                                        | 2026-05-30 |
-| P/N Interlock Relay           | Obsolete — interlock provided by 8HP70 + Turbolamik (transmission won't shift out of Park without brake); no external relay  | 2026-05-30 |
-| Engine-Running Lockout Relay  | Obsolete — relying on starter Bendix overrunning clutch + brake-required-to-crank UX; no external relay                       | 2026-05-30 |
-| Engine-Running Voltage Filter | Obsolete — no engine-running lockout relay; no filter needed                                                                  | 2026-05-30 |
-| Hidden Bypass Toggle          | Obsolete — PBS-I Emergency Bypass Card (4-digit PIN entered via Programming Button) replaces hardwired bypass                 | 2026-05-30 |
-| Dash Push-Button (Keyless)    | Resolved — Start Button included in PBS-I kit (pre-wired 36" harness to ICM)                                                  | 2026-05-30 |
-| PMU Output Strategy (Keyless) | Obsolete — PMU is no longer in the keyless logic path; OUT24 returned to Available                                            | 2026-05-30 |
-| PMU24 Keyless State Machine   | Obsolete — PBS-I is self-contained; no PMU state machine required                                                             | 2026-05-30 |
-| Keyless Firewall Pin Assignments | Resolved — Pin 12 reassigned to ignition signal outbound (cabin→EB), Pin 15 reassigned to WAIT-gated PURPLE START         | 2026-05-30 |
+| SwitchPros Power Module Location | **Architecture change:** Moved from passenger rear wheel well to firewall (cabin side, passenger area). Output fan-out is ~58% forward — placing module near loads minimizes total output wire. SwitchPros Ground Bus moves with controller. Input is 2 AWG, ~2 ft from Firewall CONSTANT Bus. Control cable shortens from 10.5 ft to ~5 ft. | 2026-05-30 |
+| AUX Battery CONSTANT Bus #1 (rear) | **Architecture change:** Removed. With SwitchPros, BODY PDU, and Fusion Amp moved to firewall distribution, only 2 CB-protected feeds + 2 direct connections leave the AUX battery. Replaced rear CONSTANT bus with 4 stacked ring lugs on battery + 2 inline CBs (300A master + 150A SafetyHub) on a wheel well bracket. | 2026-05-30 |
+| Firewall CONSTANT Bus (new)   | **Architecture change:** Added Blue Sea 2105 MaxiBus (250A) on firewall (passenger cabin side). Fed by 2/0 AWG forward feed from AUX battery via 300A master CB. Feeds SwitchPros (150A CB), BODY PDU (100A CB), Fusion Amp (100A CB). Places distribution near loads; collapses 3 forward feeds into 1 heavy cable through cabin trunk. | 2026-05-30 |
+| HDP24 Connector Upsize        | Upsized main firewall connector from HDP24-24-21 to HDP24-24-29 (29 size-16 contacts, 18 used after non-SP additions + 11 future headroom). Same shell size, same firewall hole. | 2026-05-30 |
+| Dedicated SwitchPros Firewall Bulkhead | Added second firewall connector (HDP24-18-14, 14 size-16 contacts, 1.25" hole) for SwitchPros forward-going outputs only. Keeps SP harness fully Delphi-native + modular, isolates PWM-capable lighting from signal wires, and reserves 8 spare pins for future SP additions (e.g., ditch/roof if A-pillar gets crowded). | 2026-05-30 |
+| SwitchPros Forward-Load Ground Strategy | Each forward SP output uses 2 pins on the dedicated SP bulkhead (power out + ground return). Load grounds return to SwitchPros Ground Bus at firewall cabin side via dedicated bulkhead pins. Clean SP-native architecture; no reliance on chassis ground at forward loads. | 2026-05-30 |
+| Winch Trigger Power Source              | Reallocated from SafetyHub ATC-1 (15A, ~13 ft from rear) to BODY PDU CB43 (10A, ~3 ft to dash). Properly sized for 3A trigger current. Saves ~10 ft of 14 AWG wire and frees SafetyHub ATC-1 slot for future use. | 2026-05-30 |
+| Winch Dash Switch Part                  | Selected **CH4X4-TOY-D-WINIO** ($24): dual-momentary push switch, Toyota OEM cutout (1.54"×0.83"), dual-color LED. Two independent 3A circuits feed contactor IN/OUT triggers directly — matches WARN ZEON 10-S contactor architecture (contactor handles polarity internally). Safer than single rocker (can't activate both directions simultaneously). | 2026-05-30 |
+| Dash Switch Cutout Standard             | All custom dash switches use **Toyota OEM cutout: 1.54"×0.83" (39mm×21mm)**. Wide vendor selection (CH4X4, STEDI, sPOD), pre-cut multi-position fascias available. Replaces ad-hoc Carling Contura cutouts. | 2026-05-30 |
+| Dash Switch Mounting Approach           | Cutouts machined directly into existing **Genright aftermarket dash** — no separate fascia panel. Switches snap-lock into their own cutouts. | 2026-05-30 |
+| H1 AUX Forward Feed Routing             | **Path: inside floor board / side wall (passenger side).** Passenger rear wheel well → up rear quarter sill → forward along inside floor/wall → A-pillar → firewall (CONSTANT bus). Fully inside body, bundled with H4 winch feed. | 2026-05-30 |
+| H2 START → Engine Bay Routing           | **Path: inside floor board / side wall (driver side).** Driver rear wheel well → up rear quarter sill → forward along inside floor/wall → driver A-pillar → driver-side firewall grommet → engine bay. 3× 2/0 AWG bundled (~1.5" OD). New driver-side firewall grommet required. | 2026-05-30 |
+| H3 BCDC Cross-Cab Routing               | **Path: under the rear bench seat cushion.** Driver rear wheel well → straight cross-cab under bench → passenger rear wheel well. Short, dry, physically protected by bench above and floor pan below. Independent of cabin trunk runs. | 2026-05-30 |
+| H4 Winch Feed Routing                   | **Path: inside floor board / side wall (passenger side, shared with H1).** Passenger rear wheel well → up rear quarter sill → forward along inside floor/wall (bundled with H1) → A-pillar → passenger firewall grommet → engine bay → inner fender forward → grille → front bumper. Anderson SB175 inline connector at firewall recommended for service. | 2026-05-30 |
+| Transmission Shifter Type               | Kilduff 8HP70 / 8 Speed ZF Shifter for Swaps — factory 8HP70 connector mates to Turbolamik TCU on mechatronic. Center console mount. Documented as H10 in harness inventory. | 2026-05-30 |
+| H10 Kilduff Shifter → TCU Harness       | Documented: shifter (center console) → trans tunnel down → TCU on 8HP70 mechatronic. Kilduff-supplied harness, factory 8HP70 connector, ~3-5 ft. No firewall penetration. | 2026-05-30 |
+| H11 TCU → Engine Bay Harness            | Documented: TCU power (PMU OUT16 14 AWG), J1939 CAN tap, Aux Reverse (PMU In 3), Aux P/N (starter relay coil), TCU ground (engine bay ground bus). All endpoints in engine bay. | 2026-05-30 |
+| H1+H4 Harness Collapse                  | Merged H1 (AUX forward feed) + H4 (winch feed) into single **H1/4 Passenger Rear Power Trunk** — share entire passenger-side path. Fabricated as 3-cable bundle (1× 2/0 + 2× 1/0 AWG), ~1.5" OD. | 2026-05-30 |
+| Subwoofer Configuration                 | **Architecture change:** Swapped single JL M7-12IB (12", 600W, 14" diameter, 7.94" mounting depth) → 2× JL M6-8IB (8", 200W each, ~9.5" diameter, 4.25" depth), wired **in series (8Ω) bridged to Fusion Ch1+2**. Symmetric L/R mounting in rear quarter panels above wheel wells. Tradeoff: total sub power drops from 580W → ~290W, but 12" depth made LJ panel mounting impractical. Series wiring keeps amp safe (8Ω is above 4Ω bridged minimum; parallel @ 2Ω would damage amp). | 2026-05-31 |
+| Fusion Amp Mounting Relocation          | **Architecture change:** Moved Fusion Apollo MS-AP61800 from behind-dash firewall → **under driver-side rear seat**. Power feed now 4 AWG ~3-4 ft direct from AUX battery+ via 100A inline CB (was ~3 ft from Firewall CONSTANT Bus via 100A CB). Ground also ~3-4 ft (was ~8-10 ft). RCAs + remote turn-on grow to ~10-12 ft through trans tunnel — requires high-quality shielded RCA. Removes 100A→Fusion CB from firewall bank (now 2 CBs there: SP + BODY only). Adds 5th stacked lug + 3rd inline CB at AUX battery+ bracket. | 2026-05-31 |
+| H6+H7 Harness Collapse                  | Merged H6 (SwitchPros rear) + H7 (PMU rear lighting) into single **H6/7 Rear Cabin Trunk Bundle** — share cabin trunk path. ~10 conductors with multi-pin breakout (Deutsch DT15 or AMP CPC ~15-pin) at rear cargo bulkhead. | 2026-05-30 |
+| H1/4 Firewall Pass-Through Hardware     | **Single sealed 2-piece rubber grommet** (Steele Rubber or equivalent), ~1.75" hole, ~1.5" cable bundle OD. Cables continuous through firewall — no service break. WARN's documented standard for winch firewall pass-through. Bulkhead studs (Blue Sea 2203/2204, Cole Hersee 46211) max at 250A continuous and are underrated for H4 winch peaks (400A). Anderson SB175 also undersized. ~$5-15. | 2026-05-30 |
 | Horn Relay Specs              | None required - PMU OUT 18 switches PIAA horns directly, no external relay                                                    | 2026-05-25 |
 | Horn Load                     | 5.4A (PIAA 2.7A × 2)                                                                                                          | 2026-05-25 |
 | Horn Circuit Protection       | None required - PMU OUT 18 has integrated electronic overcurrent/thermal protection                                           | 2026-05-25 |
@@ -202,22 +177,21 @@ Items completed since last update.
 | Speaker IPX Rating            | IP67                                                                                                                          | 2025-11-28 |
 | Hi-Lift Jack Mount            | Not needed                                                                                                                    | 2025-11-28 |
 | Recovery Board Storage        | Not needed                                                                                                                    | 2025-11-28 |
-| SwitchPros Control Cable      | 10.5 ft standard cable (wheel well to dash)                                                                                   | 2025-11-28 |
+| SwitchPros Control Cable      | 10.5 ft standard cable (passenger rear wheel well to dash)                                                                    | 2025-11-28 |
 | CT4 Power Source              | PMU Out 13 (15A CONSTANT) - ~9A actual load, allows hazards when ignition off                                                | 2025-11-26 |
-| SwitchPros Power Module Location | Passenger rear wheel well (with AUX battery), 1/0 AWG power wire ~2 ft                                                     | 2025-11-26 |
 | Rear Seat Switch              | Blue Sea 4160 (10A latching), 16 AWG, parallel with SwitchPros OUTPUT-4                                                      | 2025-11-26 |
 | Door Switch Routing           | Factory plunger switches retained, 18 AWG to SwitchPros TRIGGER-1                                                            | 2025-11-26 |
 | Turn Signal Distribution      | CT4 splice to front turn, Maxbilt rear, RTL-S amber (~0.9A per side)                                                         | 2025-11-26 |
 | Brake Light Distribution      | PMU Out 21 splice to Maxbilt, RTL-S brake (~4.5A total)                                                                      | 2025-11-26 |
 | Running Light Distribution    | PMU Out 23 splice to LP6 DRL, Maxbilt marker, RTL-S running (~2.6A total)                                                    | 2025-11-26 |
 | RTL-S Wiring Configuration    | 4-wire: black ground, red running (PMU Out 23), yellow brake (OEM), blue work (PMU Out 23); 2-wire: yellow/blue turn (SwitchPros OUTPUT-7) | 2025-11-25 |
-| Cargo Light Power Source      | BODY PDU CB20 (10A) with SPST switch on wheel well top; lights flush mounted in wheel well                                                   | 2025-11-26 |
+| Cargo Light Power Source      | BODY PDU CB20 (10A) with SPST switch on rear wheel well top; lights flush mounted in rear wheel well                                         | 2025-11-26 |
 | Rear Work Lights Position     | Above license plate, verified clear of WolfBox rear camera                                                                                   | 2025-11-26 |
 | Reverse Lights Mount          | Rear armor brackets                                                                                                                          | 2025-11-26 |
-| Cargo Light Switch            | Blue Sea 4160 (10A latching, 3/4" mount) on wheel well top                                                                                   | 2025-11-26 |
+| Cargo Light Switch            | Blue Sea 4160 (10A latching, 3/4" mount) on rear wheel well top                                                                              | 2025-11-26 |
 | Roof Lights OUTPUT-1 Overload | Corrected XL Sport specs (2.2A/pod, not 6A); 8 pods = 18A on single OUTPUT-1 (51% utilization)                               | 2025-11-25 |
 | Fusion Amp Current Draw       | 6-ch MS-AP61800: 1.32A idle, 78A max, 125A electronic fuse                                                                    | 2025-11-24 |
-| Fusion Amp CB Selection       | Blue Sea 187-series 40A breaker (per Fusion install guide; superseded earlier 100A), 4 AWG power/ground wiring, mount at CONSTANT bus       | 2026-05-30 |
+| Fusion Amp CB Selection       | Blue Sea 187-100A breaker, 4 AWG power/ground wiring, mount at CONSTANT bus                                                   | 2025-11-24 |
 | WolfBox Model                 | G900 TriPro selected                                                                                                          | 2025-11-24 |
 | WolfBox Power Source          | BODY PDU F5 (10A, CONSTANT)                                                                                                   | 2025-11-24 |
 | WolfBox Mounting              | Windshield mount (replaces factory rearview mirror)                                                                           | 2025-11-24 |
@@ -254,13 +228,13 @@ Items completed since last update.
 
 | Priority         | Count  |
 | :--------------- | :----- |
-| 🔴 Critical      | 1      |
-| High             | 20     |
-| 📋 Medium        | 19     |
+| 🔴 Critical      | 0      |
+| High             | 19     |
+| 📋 Medium        | 16     |
 | 📝 Low           | 2      |
 | 🔍 Verify        | 1      |
-| 🚙 Drivetrain    | 11     |
-| **TOTAL**        | **54** |
+| 🚙 Drivetrain    | 13     |
+| **TOTAL**        | **51** |
 
 ## Related Documentation
 
@@ -302,7 +276,8 @@ Items completed since last update.
 [pmu-programming]: ../01-power-systems/04-pmu/04-pmu-programming.md
 [firewall-ingress]: ../01-power-systems/07-wire-routing/02-firewall-ingress.md
 [runaway-protection]: ../02-engine-systems/11-runaway-protection.md
-[ibooster]: ../02-engine-systems/02-brake-booster.md
+[air-lockers]: ../08-exterior-systems/03-air-lockers.md
+[firewall-bus]: ../01-power-systems/03-aux-battery-distribution/02-constant-bus.md
+[harness-inventory]: ../01-power-systems/07-wire-routing/03-harness-inventory.md
+[subwoofer]: ../06-audio-systems/04-subwoofer.md
 [amplifier]: ../06-audio-systems/02-amplifier.md
-[winch]: ../08-exterior-systems/01-winch.md
-[ground-bus]: ../01-power-systems/05-grounding/01-engine-bay-ground-bus.md

--- a/docs/jeep_lj/09-installation/01-power-systems-checklist.md
+++ b/docs/jeep_lj/09-installation/01-power-systems-checklist.md
@@ -8,9 +8,9 @@ Organized by installation order for efficient build workflow.
 
 ### Battery Compartments
 
-- [ ] Install Odyssey PC1500 (START) in driver wheel well with access panel
-- [ ] Build enclosed compartment in passenger wheel well with access panel (AUX)
-- [ ] Install Barnes 4WD battery box (Group 24) in passenger wheel well - powdercoat before install
+- [ ] Install Odyssey PC1500 (START) in driver rear wheel well with access panel
+- [ ] Build enclosed compartment in passenger rear wheel well with access panel (AUX)
+- [ ] Install Barnes 4WD battery box (Group 24) in passenger rear wheel well - powdercoat before install
 - [ ] Install Dakota Lithium 135Ah LiFePO4 (AUX) in Barnes battery box
 
 ### Grounding System
@@ -82,24 +82,35 @@ Organized by installation order for efficient build workflow.
 - [ ] Verify voltage drop across main power cables under load (<3% at 60°C)
 - [ ] Verify ground resistance: Engine Bay Ground Bus to battery- (<0.1Ω)
 
-### AUX Battery Bus Bars & Circuit Breakers
+### AUX Battery Inline CBs & Firewall CONSTANT Bus
 
-**CONSTANT Bus Bar:**
+**Inline CBs at AUX battery (mount within 7" of battery on wheel well bracket):**
 
-- [ ] Mount CONSTANT bus bar (Blue Sea 2107 PowerBar, 600A) in passenger wheel well
-- [ ] Confirm 1/0 AWG: AUX battery+ → CONSTANT bus (~3 ft)
+- [ ] Mount Mechanical Products 174-S2-300-2 300A CB (forward feed to firewall bus)
+- [ ] Mount Mechanical Products 174-S2-150-2 150A CB (SafetyHub local feed)
+- [ ] Confirm AUX battery+ has 4 stacked ring lugs: Winch (1/0), BCDC output (4 AWG), 300A CB input (2/0), 150A CB input (2 AWG)
 
-**Circuit Breakers (mount within 7" of battery):**
+**Battery-Side Protected Feeds:**
 
-- [ ] Mount Blue Sea 187-150 150A CB (SwitchPros RCR-Force 12)
-- [ ] Mount Blue Sea 187-150 150A CB (SafetyHub 150)
+- [ ] Confirm 2/0 AWG: AUX battery+ → 300A CB → Firewall CONSTANT Bus (~13 ft via cabin trunk)
+- [ ] Confirm 2 AWG: AUX battery+ → 150A CB → SafetyHub 150 (~2 ft local)
+
+**Firewall CONSTANT Bus:**
+
+- [ ] Mount Blue Sea 2105 MaxiBus (250A) on firewall (passenger cabin side, near BODY PDU mounting area)
+- [ ] Confirm 2/0 AWG forward feed terminates at bus input stud
+
+**Firewall-Side CBs (mount within 7" of Firewall CONSTANT Bus):**
+
+- [ ] Mount Mechanical Products 174-S2-150-2 150A CB (SwitchPros)
 - [ ] Mount Mechanical Products 174-S2-100-2 100A CB (BODY PDU)
+- [ ] Mount Blue Sea 187-100A 100A CB (Fusion Apollo Amp)
 
-**CONSTANT Bus Wiring:**
+**Firewall CONSTANT Bus Wiring:**
 
-- [ ] Confirm 2 AWG: CONSTANT bus → 150A CB → SwitchPros RCR-Force 12 (~2 ft)
-- [ ] Confirm 2 AWG: CONSTANT bus → 150A CB → SafetyHub 150 (~2 ft)
-- [ ] Confirm 2 AWG: CONSTANT bus → 100A CB → BODY PDU (~12 ft through firewall)
+- [ ] Confirm 2 AWG: Firewall CONSTANT Bus → 150A CB → SwitchPros power module (~2 ft)
+- [ ] Confirm 2 AWG: Firewall CONSTANT Bus → 100A CB → BODY PDU power studs (~2 ft)
+- [ ] Confirm 4 AWG: Firewall CONSTANT Bus → 100A CB → Fusion Apollo Amp (~3 ft)
 
 **Direct AUX Battery Connections (No Circuit Breaker):**
 
@@ -109,7 +120,7 @@ Organized by installation order for efficient build workflow.
 
 ### BCDC Alpha 50 Installation
 
-- [ ] Mount BCDC in passenger wheel well (water-protected, LED visibility access)
+- [ ] Mount BCDC in passenger rear wheel well (water-protected, LED visibility access)
 - [ ] Confirm 4 AWG: START battery+ → 80A CB → BCDC input (red terminal, M8, ~6 ft)
 - [ ] Confirm 4 AWG: BCDC output (brown terminal, M8) → AUX battery+
 - [ ] Confirm 4 AWG: BCDC negative (black terminal, M8) → AUX battery-
@@ -118,7 +129,7 @@ Organized by installation order for efficient build workflow.
 **Battery Temperature Sensor (REQUIRED for LiFePO4):**
 
 - [ ] Install BCDC temp sensor ring terminal on AUX battery positive terminal bolt
-- [ ] Route sensor cable to BCDC (short run - both in passenger wheel well)
+- [ ] Route sensor cable to BCDC (short run - both in passenger rear wheel well)
 - [ ] Plug sensor into BCDC temperature sensor port (2-pin connector, polarity reversible)
 
 **BCDC Configuration & Testing:**
@@ -144,16 +155,16 @@ Organized by installation order for efficient build workflow.
 
 ### SafetyHub 150 Physical Installation
 
-- [ ] Mount SafetyHub 150 in passenger wheel well (co-located with AUX battery and circuit breakers)
-- [ ] Confirm 2 AWG: CONSTANT bus → 150A CB → SafetyHub input
-- [ ] Verify SafetyHub internal ground bus connected to SwitchPros Ground Bus
+- [ ] Mount SafetyHub 150 in passenger rear wheel well (co-located with AUX battery and inline CBs)
+- [ ] Confirm 2 AWG: AUX battery+ → 150A CB → SafetyHub input (~2 ft local)
+- [ ] Verify SafetyHub internal ground bus connected to chassis ground (rear frame rail)
 
 ### BODY PDU Physical Installation
 
 - [ ] Verify all circuit breakers and relays functional in LR-2 unit
 - [ ] Replace 24V relays (K40, K42, K53) with 12V relays (determine part numbers)
-- [ ] Mount LR-2 on firewall (body side, passenger side)
-- [ ] Confirm 2 AWG: CONSTANT bus → 100A CB → BODY PDU power studs (~12 ft)
+- [ ] Mount LR-2 on firewall (body side, passenger side, near Firewall CONSTANT Bus)
+- [ ] Confirm 2 AWG: Firewall CONSTANT Bus → 100A CB → BODY PDU power studs (~2 ft)
 - [ ] Confirm 14 AWG: BODY PDU ground → Firewall Stud Bus Terminal 3 (relay coil/logic only)
 - [ ] Create custom wiring harnesses to adapt J301-J306 military connectors to civilian loads
 - [ ] Route heated seat dash switches to LR-2 relay control inputs (K21, K22)
@@ -161,9 +172,11 @@ Organized by installation order for efficient build workflow.
 
 ### SwitchPros RCR-Force 12 Physical Installation
 
-- [ ] Mount SwitchPros controller
-- [ ] Confirm 2 AWG: CONSTANT bus → 150A CB → SwitchPros power input
-- [ ] Confirm SwitchPros ground connected to SwitchPros Ground Bus Terminal 1 (14 AWG)
+- [ ] Mount SwitchPros power module on firewall (cabin side, passenger area, next to BODY PDU)
+- [ ] Mount SwitchPros Ground Bus (Blue Sea 2105 MaxiBus) at firewall near power module
+- [ ] Confirm 2 AWG: Firewall CONSTANT Bus → 150A CB → SwitchPros power input (~2 ft)
+- [ ] Confirm 4 AWG: SwitchPros logic ground → chassis ground at firewall (short run)
+- [ ] Mount SwitchPros control panel on dash; order 5 ft control cable (firewall to dash)
 
 **SwitchPros Custom Harness Note:**
 
@@ -261,7 +274,7 @@ Create 12 custom 2-pin Delphi harnesses at SwitchPros:
 - [ ] Confirm WolfBox camera → CB39 (10A, 16 AWG, CONSTANT)
 - [ ] Confirm driver heated seat → CB45 (15A, 14 AWG) via relay K21 - 5A peak, 2A sustained
 - [ ] Confirm passenger heated seat → CB42 (20A, 14 AWG) via relay K22 - 5A peak, 2A sustained
-- [ ] Confirm cargo lights → CB20 (10A, 16 AWG) - switch on wheel well top
+- [ ] Confirm cargo lights → CB20 (10A, 16 AWG) - switch on rear wheel well top
 - [ ] Confirm winch control → CB43 (10A, 18 AWG) - dash rocker + remote parallel control
 
 **Verification:**
@@ -359,8 +372,8 @@ Create 12 custom 2-pin Delphi harnesses at SwitchPros:
 - [Batteries][batteries] - START (Odyssey PC1500) and AUX (Dakota Lithium 135Ah) specifications
 - [BCDC Alpha 50][bcdc] - DC-DC charger installation and configuration
 - [Solar Charging][solar] - Cascadia 80W panel and overvoltage protection
-- [START Battery Distribution][start-dist] - Driver wheel well connections
-- [AUX Battery Distribution][aux-dist] - Passenger wheel well connections
+- [START Battery Distribution][start-dist] - Driver rear wheel well connections
+- [AUX Battery Distribution][aux-dist] - Passenger rear wheel well connections
 
 **Ground Bus Bars:**
 

--- a/docs/jeep_lj/index.md
+++ b/docs/jeep_lj/index.md
@@ -18,8 +18,8 @@ The electrical system is organized into zones for logical distribution and maint
 ### Power Systems
 
 - **[Power Generation](01-power-systems/01-power-generation/index.md)** - Batteries, alternator, BCDC, solar, grounding
-- **[START battery Distribution](01-power-systems/02-starter-battery-distribution/index.md)** - Engine bay primary power distribution
-- **[AUX battery Distribution](01-power-systems/03-aux-battery-distribution/index.md)** - Wheel well accessory power distribution
+- **[START battery Distribution](01-power-systems/02-starter-battery-distribution/index.md)** - Driver rear wheel well primary power distribution
+- **[AUX battery Distribution](01-power-systems/03-aux-battery-distribution/index.md)** - Passenger rear wheel well accessory power distribution
 - **[Power Management Unit](01-power-systems/04-pmu/index.md)** - PMU24 programmable power management
 - **[BODY PDU](01-power-systems/03-aux-battery-distribution/03-body-pdu.md)** - Body relay/fuse panel
 - **[SafetyHub](01-power-systems/03-aux-battery-distribution/04-safetyhub.md)** - Safety control system
@@ -78,8 +78,8 @@ The electrical system is organized into zones for logical distribution and maint
 
 ### Dual Battery System
 
-- **START battery:** Engine bay - powers critical engine systems via PMU and SafetyHub
-- **AUX battery:** Wheel well - powers accessories via CONSTANT bus
+- **START battery:** Driver rear wheel well - powers critical engine systems via PMU and SafetyHub
+- **AUX battery:** Passenger rear wheel well - powers accessories via inline CBs + Firewall CONSTANT bus (cabin distribution cluster)
 - **Battery Isolation:** RedArc BCDC Alpha 50 DC-DC charger with automatic jump-start assist
 
 See [Power Generation](01-power-systems/01-power-generation/index.md) for complete battery and charging system details.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -136,6 +136,7 @@ nav:
       - 1.7 - Wire Routing:
         - jeep_lj/01-power-systems/07-wire-routing/index.md
         - 1.7.2 - Firewall Ingress: jeep_lj/01-power-systems/07-wire-routing/02-firewall-ingress.md
+        - 1.7.3 - Harness Inventory: jeep_lj/01-power-systems/07-wire-routing/03-harness-inventory.md
       - 1.8 - Load Analysis:
         - jeep_lj/01-power-systems/08-load-analysis/index.md
         - 1.8.1 - Scenarios: jeep_lj/01-power-systems/08-load-analysis/01-scenarios.md


### PR DESCRIPTION
## Summary

- **Architecture:** 2-stage AUX distribution (inline 300A + 150A CBs at battery; Firewall CONSTANT Bus replaces rear bus); SwitchPros relocated to firewall with dedicated HDP24-18-14 bulkhead; main firewall upsized to HDP24-24-29; winch trigger reallocated from SafetyHub to BODY PDU CB43 with CH4X4 Toyota-style dual-momentary push switch
- **Routing:** H1/H2/H4 along inside floor board and side wall; H3 under rear bench; new harness inventory (H1–H11) covers AUX/START trunks, BCDC cross-cab, winch, SP front/rear, PMU rear, ARB compressor, winch trigger, Kilduff shifter, TCU
- **New artifacts:** \`Jeep LJ Tub Map.drawio\` top-down LJ diagram showing controllers/CBs/backbones/loads with legends; \`03-harness-inventory.md\` cataloging each fabricatable harness with route, length, BOM, connectors, and 6 bundle-optimization opportunities
- **Cleanup:** Ambiguous "wheel well" refs clarified to "rear wheel well" across 30+ files; obsolete frame-rail routing language removed; TBD tracker updated with resolved architecture decisions and new sourcing TBDs (heated seat / drive mode switches, firewall grommets, Anderson SB175 service connector)

## Test plan

- [ ] Open \`Jeep LJ Tub Map.drawio\` in drawio.app — verify layout reads cleanly
- [ ] Run \`mkdocs build\` — confirm no broken cross-references
- [ ] Review \`harness-inventory.md\` H1–H11 against \`firewall-ingress.md\` pin assignments for consistency
- [ ] Spot-check that no docs still reference rear CONSTANT bus, SP at rear wheel well, or SafetyHub ATC-1 for winch trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)