### PR TITLE
Fix mobile navigation to collapse into hamburger menu

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,8 +1,7 @@
-/* Increase width of primary (left) sidebar */
-.md-sidebar--primary {
-  width: 14rem;
-}
-
+/* Increase width of primary (left) sidebar (desktop only).
+   Scoped to the desktop breakpoint so it does NOT override Material's
+   off-canvas hamburger drawer on mobile (<= 76.1875em), where the primary
+   sidebar must stay translated off-screen until the drawer is toggled. */
 @media screen and (min-width: 76.25em) {
   .md-sidebar--primary {
     width: 14rem;
@@ -26,11 +25,15 @@
   overflow: visible;
 }
 
-/* Hide expand/collapse toggles in navigation */
-.md-nav__toggle,
-.md-nav__toggle + label::before,
-label.md-nav__link {
-  display: none;
+/* Hide expand/collapse toggles in navigation (desktop only).
+   On mobile the toggles drive Material's collapsible hamburger drawer, so
+   they must remain functional below the desktop breakpoint. */
+@media screen and (min-width: 76.25em) {
+  .md-nav__toggle,
+  .md-nav__toggle + label::before,
+  label.md-nav__link {
+    display: none;
+  }
 }
 
 /* Expand main content to use full width when TOC is hidden */


### PR DESCRIPTION
## Problem

On mobile/phone viewports the site navigation did not collapse into the hamburger drawer — it rendered expanded/broken instead of behind the hamburger toggle.

## Root cause

This is a stock **Material for MkDocs** theme (no `custom_dir`/template overrides), so the hamburger markup itself was fine — the bug was purely in `docs/stylesheets/extra.css`. Two custom rules were declared **without any media query**, so they overrode Material's responsive off-canvas drawer at *every* breakpoint:

1. `.md-sidebar--primary { width: 14rem }` — pinned the primary sidebar to a fixed width even on mobile.
2. `.md-nav__toggle, .md-nav__toggle + label::before, label.md-nav__link { display: none }` — globally hid the nav toggle checkboxes/labels that drive the collapsible mobile drawer.

Together these forced the nav to stay expanded on phones instead of collapsing behind the hamburger.

## Fix

Scoped both rules inside `@media screen and (min-width: 76.25em)` (Material's desktop breakpoint) so they only apply on desktop. The redundant global sidebar-width declaration was merged into the existing desktop media block. At/below the mobile breakpoint, the stock off-canvas hamburger drawer and its collapsible toggles now work; desktop layout is unchanged.

Net change: one file (`docs/stylesheets/extra.css`).

## Test plan

- [ ] `mkdocs serve` and view on a narrow viewport (or browser devtools device mode, <1220px): the nav should collapse behind the hamburger and expand/collapse correctly.
- [ ] Verify desktop layout (≥1220px) is unchanged (sidebar visible at 14rem, sections expanded).

https://claude.ai/code/session_01SQt2M5SWXvhb6Gr3czghPv

---
_Generated by [Claude Code](https://claude.ai/code/session_01SQt2M5SWXvhb6Gr3czghPv)_