### PR TITLE
Increase draw.io PNG export quality (3x scale)

### DIFF
--- a/.github/workflows/drawio-export.yml
+++ b/.github/workflows/drawio-export.yml
@@ -26,6 +26,11 @@ jobs:
           format: adoc
           transparent: false
           output: export
+          # Render PNGs at 3x pixel density (~288 DPI) so diagram
+          # lines and text stay crisp when zoomed or on hi-DPI displays.
+          scale: 3
+          # Small breathing room around the diagram edges.
+          border: 10
 
       - name: Get author and committer info from HEAD commit
         uses: rlespinasse/git-commit-data-action@v1


### PR DESCRIPTION
## Problem

The `Keep draw.io export synchronized` workflow rasterizes each `.drawio` file to PNG at the action's **default scale (1×, ~96 DPI)**. When those PNGs are zoomed or viewed on hi-DPI/retina displays, the lines and text look soft/blurry.

## Change

Added two inputs to the `rlespinasse/drawio-export-action` step:

- `scale: 3` — renders PNGs at ~288 DPI (3× pixel density) so diagrams stay crisp.
- `border: 10` — adds a small margin so content isn't flush against the edges.

No format change — the pipeline still produces `.adoc` + `.png` exactly as before, just at higher resolution.

## Trade-off

Exported PNGs will be larger (roughly the square of the scale factor — a few MB for the biggest diagrams). If that becomes a concern, `scale` can be dialed back to `2`, or we could switch the format to `svg` for resolution-independent, generally smaller vector output.

## Testing

The change will be exercised on the next push to `main` that touches a `.drawio` file (or this workflow). Worth confirming the resulting PNG sizes are acceptable.

https://claude.ai/code/session_01VE4o4bjEia1DBDewyMyN1F

---
_Generated by [Claude Code](https://claude.ai/code/session_01VE4o4bjEia1DBDewyMyN1F)_