### PR TITLE
Harness build sheets with LJ tub-map visuals

### DIFF
--- a/docs/jeep_lj/01-power-systems/07-wire-routing/03-harness-inventory.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/03-harness-inventory.md
@@ -63,7 +63,24 @@ Colors on the build sheets follow this convention. Power and ground colors are u
 | Vendor-supplied harness | **Per vendor pigtail** | SwitchPros (Delphi), ARB, CH4X4, Kilduff/ZF ship their own colors — match the supplied pigtail |
 | Signal / trigger / output (non-vendor) | **Builder's choice** | Choose a consistent scheme and record it |
 
-For protective wrap/loom, heat sleeve, abrasion sleeve, and P-clamp standards by location, see [Wire Protection Standards][wire-routing].
+For protective wrap/loom, heat sleeve, abrasion sleeve, and P-clamp standards by location, see [Wire Protection Standards][wire-routing]. This build wraps power runs in braided sleeve with per-harness tracers — see [Protective Sleeve & Tracers](#sleeve-convention).
+
+## Protective Sleeve & Tracers {#sleeve-convention}
+
+Wrap preference for this build:
+
+- **Power runs use braided expandable sleeve** (PET, e.g. Techflex Flexo PET) over the full length, sized to the bundle OD. Braided sleeve is abrasion-resistant, flexes around the sill / trans-tunnel path, and lets you fan branches out without cutting the wrap.
+- **Tracers identify each power trunk.** Braided sleeve is sold plain or with a contrasting **tracer stripe** woven in. A per-harness tracer color makes bundles identifiable where several run together (e.g. in the cabin trunk). Suggested scheme — builder's choice, adjust to taste:
+
+| Harness | Sleeve | Suggested tracer | Carries |
+|:--------|:-------|:-----------------|:--------|
+| **H1** Passenger Rear Power Trunk | Red braided | Black | AUX forward feed + winch power/ground |
+| **H2** START Engine Bay Trunk | Red braided | Yellow | Alternator, starter, PMU feed |
+| **H3** BCDC Cross-Cab | Red braided | Green | BCDC input + cross-ground reference |
+| **H6** ARB Compressor (motor pair) | Red braided | Blue | 2× 6 AWG compressor motor cables |
+
+- **Heat sleeve still applies** where any run enters the engine bay within ~12" of exhaust — over the braided sleeve as needed.
+- **Split loom** remains fine for the small-wire signal/lighting bundles (H4, H5, H7, H9) and for short, branchy, or frequently-accessed runs where braided sleeve is awkward; use a braided sleeve with a tracer instead if you prefer to color-code those too. H8 ships as a factory harness (no added wrap needed beyond loom through the tunnel).
 
 ---
 
@@ -173,7 +190,7 @@ The **cabin trunk** (trans tunnel / sill, firewall ↔ rear wheel wells) carries
 
 **Trans tunnel rearward (H5 + CT4 + ARB signal):** ~14 conductors of small wire (14–18 AWG)
 
-**Suggested trunk wrap:** 1.5"–2" split loom or wrapped harness sleeve per side. P-clamp every 12–18".
+**Suggested trunk wrap:** 1.5"–2" braided expandable sleeve (preferred for the power runs) or split loom per side, tracer-coded per harness so the bundles stay identifiable — see [Protective Sleeve & Tracers](#sleeve-convention). P-clamp every 12–18".
 
 ---
 
@@ -198,7 +215,7 @@ These were noted inline on the build sheets; consolidated here for review:
 - [ ] Confirm SwitchPros front locker wire routing (front axle access)
 - [ ] Decide if ARB control wires merge into H5 (recommended) or run as H6 signal pair
 - [ ] Source connector + lug + heat shrink BOM totals
-- [ ] Determine harness sleeve / wrap material (split loom vs braided sleeving) per zone
+- [ ] Confirm braided-sleeve sizes and per-harness tracer colors for the power runs (see [Protective Sleeve & Tracers](#sleeve-convention)); decide split loom vs braided for the small-wire bundles per zone
 - [ ] Define and record the signal-wire color scheme for non-vendor signal/trigger wires (power = red, ground = black are fixed; see [Wire Color Convention](#wire-color-convention))
 
 ## Related Documentation

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/03-harness-inventory.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/03-harness-inventory.md
@@ -1,6 +1,9 @@
 ---
 hide:
   - toc
+tags:
+  - wire-routing
+  - harness
 ---
 
 # 1.7.3 Harness Inventory {#harness-inventory}
@@ -9,7 +12,9 @@ hide:
 
 Catalogs each fabricatable wire harness in the build. A "harness" here = a discrete bundle of wires with a defined start connector, end connector(s), routing path, and BOM — something you'd lay out on a workbench and tape together as a unit.
 
-**Use this doc to:**
+This page is the **index and system-wide view**. The detailed, build-it-from-this specs (conductor tables, gauges, colors, lengths, protection, connectors) live on the three **build sheets** below — each pairs the harnesses with the [LJ Tub Map][lj-tub-map] diagram that shows their physical routing.
+
+**Use these docs to:**
 
 - Order connectors and lugs in correct quantities
 - Plan fabrication order (build harnesses bench-side, install in vehicle)
@@ -19,6 +24,46 @@ Catalogs each fabricatable wire harness in the build. A "harness" here = a discr
 **Bundling philosophy:** Each harness terminates at a connector at every transition point (firewall, body penetration, distribution box). This makes harnesses individually serviceable and lets you lay them out flat for fabrication. The cost is more connectors; the benefit is much easier R&R.
 
 **Numbering note:** Two prior bundles (the old H1+H4 power trunk and the old H6+H7 rear cabin bundle) were merged in May 2026. The catalog was renumbered to a single sequence H1–H9 — there are no compound names (no "H1/4", no "H6/7"). See the [interference assessment](#bundle-interference-assessment) for why the merged bundles are safe.
+
+---
+
+## Harness Build Sheets
+
+Each build sheet embeds the matching tub-map diagram and the workbench specs for the harnesses it shows.
+
+| Build sheet | Tub-map page | Harnesses |
+|:------------|:-------------|:----------|
+| [Power Distribution][power-build] | Power Distribution | **H1** Passenger Rear Power Trunk · **H2** START Engine Bay Trunk · **H3** BCDC Cross-Cab |
+| [Lighting & SwitchPros][lighting-build] | Lighting & SwitchPros | **H4** SwitchPros Front Bundle · **H5** Rear Cabin Trunk Bundle |
+| [Controls, Recovery & Drivetrain][controls-build] | Controls, Recovery & Drivetrain | **H6** ARB Compressor · **H7** Winch Trigger · **H8** Kilduff Shifter · **H9** TCU to Engine Bay |
+
+## Harness Summary
+
+| # | Harness | Build sheet | Conductors | Largest gauge | Length |
+|:--|:--------|:------------|:----------:|:-------------:|:-------|
+| H1 | Passenger Rear Power Trunk (AUX fwd + winch) | [Power][power-build] | 3 | 2/0 AWG | ~13 ft (+13 ft winch to bumper) |
+| H2 | START Engine Bay Trunk | [Power][power-build] | 3 | 2/0 AWG | 6–8 ft |
+| H3 | BCDC Cross-Cab | [Power][power-build] | 2 | 1/0 AWG | ~5–6 ft |
+| H4 | SwitchPros Front Bundle | [Lighting][lighting-build] | 3 outputs | 14 AWG | 4–8 ft |
+| H5 | Rear Cabin Trunk Bundle (SP rear + PMU rear) | [Lighting][lighting-build] | ~10 | 14 AWG | 8–14 ft |
+| H6 | ARB Compressor | [Controls][controls-build] | 4 | 6 AWG | ~10 ft |
+| H7 | Winch Trigger | [Controls][controls-build] | 5 | 18 AWG | ~3 ft + ~13 ft |
+| H8 | Kilduff Shifter → TCU | [Controls][controls-build] | 1 (multi) | Proprietary | ~3–5 ft |
+| H9 | TCU → Engine Bay | [Controls][controls-build] | 6 | 14 AWG | 3–4 ft |
+
+## Wire Color Convention {#wire-color-convention}
+
+Colors on the build sheets follow this convention. Power and ground colors are universal automotive practice; signal colors are the builder's choice — pick a consistent scheme and keep it the same across every harness.
+
+| Wire role | Color | Notes |
+|:----------|:------|:------|
+| Power / positive feed (+) | **Red** | All constant/switched +12V distribution, feeds, and high-current power |
+| Ground / negative (−) | **Black** | All returns and battery negatives |
+| CAN bus | **Twisted pair** | Keep the pair twisted; do not split. Color per controller (e.g., J1939) |
+| Vendor-supplied harness | **Per vendor pigtail** | SwitchPros (Delphi), ARB, CH4X4, Kilduff/ZF ship their own colors — match the supplied pigtail |
+| Signal / trigger / output (non-vendor) | **Builder's choice** | Choose a consistent scheme and record it |
+
+For protective wrap/loom, heat sleeve, abrasion sleeve, and P-clamp standards by location, see [Wire Protection Standards][wire-routing].
 
 ---
 
@@ -86,304 +131,6 @@ Catalogs each fabricatable wire harness in the build. A "harness" here = a discr
 
 ---
 
-## Harness Catalog
-
-### H1 — Passenger Rear Power Trunk (AUX Forward Feed + Winch)
-
-*Formed 2026-05-30 by merging the prior H1 (AUX forward feed) and H4 (winch feed). The two shared the entire passenger-side path, so they are fabricated and installed as a single 3-cable bundle.*
-
-**Route:** Passenger rear wheel well (AUX battery) → up inside passenger rear quarter sill → forward along **inside floor board / side wall** (passenger side) → A-pillar area → **3× bulkhead studs through firewall** → engine bay → forward along passenger inner fender → through grille area → front bumper (winch portion only)
-
-**Length:** ~13 ft to firewall (all 3 cables); ~13 ft additional for winch cables continuing to bumper
-
-**Contains:**
-
-| Wire | Gauge | Function | Termination at battery | Termination at firewall | Continues to |
-|:-----|:-----:|:---------|:----------------------|:------------------------|:-------------|
-| Forward feed (+) | 2/0 AWG | Powers SwitchPros + BODY PDU + Fusion via Firewall CONSTANT bus | Ring lug to 300A CB output stud | Ring lug to bulkhead stud | (terminates at firewall — bus input stud on engine bay side via short jumper) |
-| Winch power (+) | 1/0 AWG | AUX battery+ → winch contactor B+ | Ring lug to AUX battery+ stud | Ring lug to bulkhead stud | Lug to winch contactor B+ |
-| Winch ground (−) | 1/0 AWG | AUX battery- → winch contactor B− | Ring lug to AUX battery- stud | Ring lug to bulkhead stud | Lug to winch motor / chassis at front |
-
-**Firewall pass-through:** **Single sealed 2-piece rubber grommet** sized for the ~1.5" OD bundle (~1.75" firewall hole). Cables run continuously from rear wheel well to their respective destinations — no service break at the firewall. The grommet seals the firewall penetration only; the cables themselves are uninterrupted.
-
-**Why continuous cables + grommet (not inline connectors or bulkhead studs):**
-
-- WARN install documentation references this approach as standard for winch firewall pass-through
-- No amperage limit at the pass-through (the cable is the conductor; grommet just seals the hole)
-- Common feed-through marine bulkhead studs (Blue Sea 2203/2204, Cole Hersee 46211) max at 250A continuous — borderline for the forward feed (232A) and underrated for the winch leg (400A peak)
-- Anderson SB175 is undersized for the winch leg (175A continuous); SBE320/SB350 would work but adds complexity
-- Service is rare in practice — when needed, pulling the entire cable end-to-end is acceptable
-- Steele Rubber or similar 2-piece grommet, ~$5–15
-
-**Protection:** Split loom + wrapped harness sleeve along entire cabin path. Heat sleeve where the winch cables enter engine bay. P-clamps every 12–18".
-
-**Notes:**
-
-- 3-cable bundle: ~1.5" OD final wrapped harness
-- Path is fully inside the body until firewall transition (no exposed frame rail)
-- Cables terminate as ring lugs at destinations (lug-to-stud at battery / CB / bus / contactor on each end). If a service break is ever desired, do it as a lug-to-lug junction inside the rear wheel well, not at the firewall.
-
----
-
-### H2 — START Engine Bay Trunk
-
-**Route:** Driver rear wheel well (START battery) → up inside driver rear quarter sill → forward along **inside floor board / side wall** (driver side) → A-pillar area → driver firewall penetration → engine bay
-
-**Length:** 6–8 ft per cable
-
-**Contains:**
-
-| Wire | Gauge | Function | Termination at battery | Termination at engine bay |
-|:-----|:-----:|:---------|:----------------------|:--------------------------|
-| Alternator charging input | 2/0 AWG | Alternator → START battery+ | Lug to battery+ stud | Lug to alternator output stud |
-| Starter motor power | 2/0 AWG | START battery+ → starter | Lug to battery+ stud | Lug to starter B+ stud |
-| PMU24 main feed | 2/0 AWG | START battery+ → 250A CB → PMU24 | Lug to 250A CB output | Lug to PMU power stud |
-
-(BCDC input feed (4 AWG via 80A CB) takes the H3 cross-cab path instead — see H3.)
-
-**Connectors:** Lug terminations at both ends. Heat sleeve required where bundle enters engine bay (>12" from exhaust). Bundle 3 cables with looms; expect ~1.5" OD final bundle.
-
-**Protection:** Split loom + wrapped harness sleeve in cabin / sill. Heat sleeve in engine bay. P-clamps every 12–18".
-
-**Firewall penetration:** Driver-side grommet for high-current cables — separate from the HDP24 (HDP24 is passenger-side, signal-only). Three 2/0 AWG cables need a grommet sized for ~1.5" bundle OD.
-
-**Notes:**
-
-- All 3 high-current cables share the same driver-side floor / side wall path
-- Path is fully inside the body (no exposed frame rail)
-- Driver-side firewall grommet is a new firewall penetration — separate from existing passenger-side HDP24 and SwitchPros bulkheads
-
----
-
-### H3 — BCDC Cross-Cab
-
-**Route:** Driver rear wheel well (START battery) → **under the rear bench seat cushion** → passenger rear wheel well (BCDC + AUX battery)
-
-**Length:** ~5–6 ft (straight cross-cab run under bench)
-
-**Contains:**
-
-| Wire | Gauge | Function | Termination at driver well | Termination at passenger well |
-|:-----|:-----:|:---------|:--------------------------|:------------------------------|
-| BCDC input | 4 AWG | START battery+ via 80A CB → BCDC input terminal | Lug to 80A CB output | Lug to BCDC input red terminal (M8) |
-| Cross-ground reference | 1/0 AWG | START battery- → AUX battery- (critical for BCDC operation) | Lug to START battery- | Lug to AUX battery- |
-
-**Connectors:** Lug terminations both ends. No inline connectors needed for short run.
-
-**Protection:** Split loom along the run. Bench cushion provides physical shielding from above; floor pan shields from below. P-clamps to body cross-member at 1–2 points.
-
-**Notes:**
-
-- Under-bench routing is short, dry, accessible, and physically protected (bench cushion above, floor pan below)
-- No frame rail exposure; no need to share the longer floor / side wall paths used by H1 / H2
-- BCDC sensor cable (~6 ft, 2-pin) is included with BCDC unit, runs to AUX battery+ terminal at the same wheel well — short, stays passenger-side, not part of this harness
-- Path is independent of cabin trunk runs (H1 passenger side, H2 driver side), so no cabin trunk congestion impact
-
----
-
-### H4 — SwitchPros Front Bundle
-
-*Previously numbered H5. Renumbered 2026-05-31 when the catalog was compacted after the H1+H4 and H6+H7 merges.*
-
-**Route:** SwitchPros (firewall, cabin side) → **dedicated SwitchPros HDP24-18-14 firewall bulkhead** → engine bay → grille / front bumper / front axle
-
-**Length:** 4–8 ft (depending on destination)
-
-**Contains:**
-
-| SwitchPros output | Gauge | Function | Destination | SP bulkhead pins |
-|:-----------------:|:-----:|:---------|:------------|:----------------:|
-| OUT-3 (35A circuit) | 14 AWG | Fog light | Front bumper (BD S8 amber) | 1 (+) / 2 (−) |
-| OUT-6 (front rocks subset, 15A circuit, shared with rear) | 14 AWG | Front bumper rock light + 2x front wheel well rock lights | Splice at front for 3 lights | 3 (+) / 4 (−) |
-| OUT-17 (low-side 2A) | 18 AWG | Front ARB locker solenoid | Front axle (~12 ft from SP) | 5 (+) / 6 (−) |
-
-**Connectors:** Custom 2-pin Delphi at SwitchPros output side (per SP harness convention); harness terminates at HDP24-18-14 cabin-side plug at firewall. Engine-bay side picks up at HDP24-18-14 receptacle and re-terminates as 2-pin Delphi at each light/solenoid.
-
-**Ground strategy:** Each output's load ground returns through the SP bulkhead (pins 2, 4, 6) to the SwitchPros Ground Bus on cabin side. Clean SP-native architecture; no reliance on chassis ground at forward loads.
-
-**Notes:**
-
-- 3 forward-going SwitchPros circuits in this bundle, 6 pins through dedicated SP bulkhead (HDP24-18-14)
-- Front locker wire (18 AWG) is the longest run — passes through front fender well and along front axle
-- Front rock lights (4 in front wheel wells + 1 front bumper) all share OUT-6 with rear rocks
-- Could be split into "front bumper sub-harness" (fog + front rock + front bumper) and "front axle sub-harness" (front locker) if those routings diverge
-- **8 spare pins** on SP bulkhead accommodate future ditch/roof additions if A-pillar routing becomes impractical
-
-See [SwitchPros Firewall Bulkhead][firewall-ingress] for connector spec and pinout.
-
----
-
-### H5 — Rear Cabin Trunk Bundle (SwitchPros Rear + PMU Rear)
-
-*Formed 2026-05-30 by merging the prior H6 (SwitchPros rear outputs) and H7 (PMU rear lighting). The two shared the firewall-to-rear cabin trunk path, so they are fabricated as a single multi-conductor bundle with a rear cargo bulkhead breakout connector.*
-
-**Route:** SwitchPros (firewall, cabin side) + PMU24 outputs (via HDP24 pins 4/5/6 from engine bay) → converge at firewall → cabin trunk (trans tunnel) → rear cargo bulkhead breakout → fans out to rear destinations
-
-**Length:** 8–14 ft (depending on destination; PMU portion is ~11–16 ft total including engine bay leg)
-
-**Contains:**
-
-| Source | Output / Function | Gauge | Destination |
-|:-------|:------------------|:-----:|:------------|
-| **SwitchPros** OUT-6 (shared with front) | Rear rocks (rear bumper + 2× rear wheel well) | 14 AWG | Splice at rear for 3 lights |
-| **SwitchPros** OUT-7 | Chase light (BD RTL-S 30") | 14 AWG | Rear bumper |
-| **SwitchPros** OUT-10 | Rear ARB locker solenoid | 14 AWG | Rear axle |
-| **SwitchPros** OUT-12 | Rear work lights (2× BD S1) | 14 AWG | Above license plate |
-| **SwitchPros** OUT-13 | Cargo lights (2× flush in rear wheel wells) | 14 AWG | Triggered by rear cargo rocker |
-| **SwitchPros** TRIGGER-2 | Cargo rocker switch return | 18 AWG | Rear cargo rocker (rear wheel well top) |
-| **PMU** OUT-21 | Brake signal | 16 AWG | Tail clusters (L+R) + 3rd brake |
-| **PMU** OUT-22 | Reverse signal | 16 AWG | Tail clusters (L+R) |
-| **PMU** OUT-23 | Running/parking signal | 16 AWG | Tail clusters (L+R) + license plate |
-| **PMU** ground return | Common tail cluster ground | 16 AWG | SwitchPros GND bus at firewall |
-
-**Connectors:**
-
-- **Firewall (cabin side):** SwitchPros outputs originate as Delphi 2-pin pigtails at SP module; PMU outputs enter the cabin via HDP24 pins 4/5/6. Both join the trunk wrap aft of firewall.
-- **Rear cargo bulkhead breakout:** Single multi-pin connector — **Deutsch DT15-XX (15-pin)** or **AMP CPC ~15-pin**. All ~10 conductors mate at this single service point.
-- **Rear-side pigtails:** Short individual harnesses from breakout to each destination (chase, work, cargo, rocks, locker, tail clusters).
-
-**Protection:** Split loom + wrapped harness sleeve through cabin trunk. P-clamps every 12–18".
-
-**Notes:**
-
-- ~10 conductors in the cabin trunk bundle (mostly 14 AWG + a few 16/18 AWG)
-- **Service model:** R&R any rear light by swapping its pigtail at the rear bulkhead breakout. The cabin trunk pull stays in place.
-- Splices needed for the tail clusters: each PMU output feeds both driver and passenger sides + 3rd brake/license — can be done at the breakout or with Y-splices closer to lights
-- CT4 rear turn signals could also join this bundle through the cabin trunk; tracked separately because they originate at CT4 (steering column) not firewall
-
----
-
-### H6 — ARB Compressor Bundle
-
-*Previously numbered H8. Renumbered 2026-05-31.*
-
-**Route:** SafetyHub (passenger rear wheel well) → under cargo / under rear bench → under passenger seat (compressor mount)
-
-**Length:** ~10 ft
-
-**Contains:**
-
-| Wire | Gauge | Function | Termination at SafetyHub | Termination at compressor |
-|:-----|:-----:|:---------|:-------------------------|:--------------------------|
-| Motor 1 power | 6 AWG | SafetyHub MIDI-1 (60A) → compressor motor 1 | Lug to MIDI-1 output | Compressor motor terminal |
-| Motor 2 power | 6 AWG | SafetyHub MIDI-2 (60A) → compressor motor 2 | Lug to MIDI-2 output | Compressor motor terminal |
-| Control signal | 14 AWG | SwitchPros OUT-11 → compressor control terminal | (Comes from SwitchPros at firewall, not SafetyHub — runs separately or joins this bundle along common path) | Compressor control terminal |
-| Pressure switch | 18 AWG | ARB pressure switch (on manifold under passenger seat) → SwitchPros TRIGGER-3 | (At firewall, not SafetyHub) | Pressure switch normally-open contact |
-
-**Connectors:** Lug at SafetyHub side, ring/spade at compressor. ARB compressor manifold typically has a pigtail with its own connector.
-
-**Notes:**
-
-- Motor 1 + motor 2 are 6 AWG (high current, brief peaks) — bundle as a pair
-- Control + pressure switch wires originate at SwitchPros at firewall, NOT SafetyHub — they run from firewall through cabin to under passenger seat
-- Could be merged into H6 if they share routing, or kept separate as "H6b ARB signal"
-
-**Optimization opportunity:** Run the SwitchPros control + pressure switch wires through the cabin trunk to under passenger seat as part of H5 SwitchPros rear bundle (they're SP wires anyway), and split off at the compressor. Saves a separate harness — the only ARB-specific harness is the 2x 6 AWG motor cables from SafetyHub.
-
----
-
-### H7 — Winch Trigger Control (small wire)
-
-*Previously numbered H9. Renumbered 2026-05-31.*
-
-**Route:** BODY PDU (firewall, cabin side) → dash switch ([CH4X4 dual-momentary push][ch4x4-winch]) → HDP24 firewall pins 16/17 → winch contactor at front bumper
-
-**Length:** ~3 ft (BODY PDU → dash) + ~13 ft (dash → contactor via engine bay)
-
-**Contains:**
-
-| Wire | Gauge | Function | Termination |
-|:-----|:-----:|:---------|:------------|
-| Switch +12V supply | 18 AWG | BODY PDU CB43 (10A) → CH4X4 switch common | Spade at BODY PDU, included pigtail at switch |
-| IN trigger | 18 AWG | CH4X4 IN button → HDP24 pin 16 → contactor IN trigger | Included pigtail at switch, HDP24 socket, ring/spade at contactor |
-| OUT trigger | 18 AWG | CH4X4 OUT button → HDP24 pin 17 → contactor OUT trigger | Included pigtail at switch, HDP24 socket, ring/spade at contactor |
-| Illumination supply | 18 AWG | Dash illumination circuit | Included pigtail at switch |
-| Switch ground | 18 AWG | Switch common ground | Chassis ground at dash |
-
-**Connectors:** CH4X4 includes its own connector + cable kit. HDP24-24-29 at firewall penetration. Ring/spade terminals at contactor.
-
-**Notes:**
-
-- BODY PDU CB43 (10A, ~3 ft to dash) replaces the previously-planned SafetyHub ATC-1 (15A, ~13 ft from rear wheel well). The 18 AWG wire is properly sized for the ~3A trigger current; the prior 14 AWG / 15A spec was over-built and routed wastefully.
-- Switch is dual-momentary push (not a polarity-reversing rocker) — the WARN ZEON 10-S contactor handles polarity internally
-- Warn handheld remote wires in parallel at the contactor trigger terminals
-- SafetyHub ATC-1 slot freed for future use (recovery accessories etc.)
-
-[ch4x4-winch]: https://ch4x4.com/product/ch4x4-momentary-dual-push-switch-for-toyota-winch-in-out-symbol/
-
----
-
-### H8 — Kilduff Shifter to TCU
-
-*Previously numbered H10. Renumbered 2026-05-31.*
-
-**Route:** Kilduff shifter in **center console** → straight down through trans tunnel → Turbolamik TCU **mounted on 8HP70 mechatronic** (transmission valve body)
-
-**Length:** ~3–5 ft
-
-**Contains:**
-
-| Wire | Gauge | Function | Termination at shifter | Termination at TCU |
-|:-----|:-----:|:---------|:----------------------|:-------------------|
-| Shifter harness | Proprietary multi-conductor (factory 8HP70 connector) | All shifter signals (P/R/N/D, manual +/−, button states, illumination) | Kilduff-supplied connector at shifter base | Factory 8HP70 connector at TCU |
-
-**Connectors:**
-
-- Kilduff supplies the shifter end of the harness with their shifter kit
-- TCU end uses the factory 8HP70 mechatronic connector (Turbolamik TCU 2.0 mates to this)
-
-**Protection:** Split loom through trans tunnel. The trans tunnel keeps the cable away from cabin contents and provides a clean straight run.
-
-**Notes:**
-
-- TCU is **mounted on the 8HP70 mechatronic** (the trans valve body), not in cabin or engine bay — so this is a very short pull
-- No firewall penetration
-- No other H-series harnesses share this path — it's a single-purpose, self-contained run
-- Kilduff includes the wiring harness with the shifter kit — no separate fabrication required
-
-See [Transmission][transmission] for shifter and TCU specs.
-
----
-
-### H9 — TCU to Engine Bay
-
-*Previously numbered H11. Renumbered 2026-05-31.*
-
-**Route:** Turbolamik TCU on 8HP70 mechatronic → up through trans tunnel forward → engine bay (PMU + J1939 tap + starter P/N relay)
-
-**Length:** 3–4 ft
-
-**Contains:**
-
-| Wire | Gauge | Function | Source | Destination |
-|:-----|:-----:|:---------|:-------|:------------|
-| TCU power feed | 14 AWG | PMU OUT16 (CONSTANT, 15A) → TCU power input | PMU OUT16 (engine bay) | TCU power terminal |
-| J1939 CAN High | Twisted pair | Shared J1939 bus tap (same tap as PMU, Dakota Digital BIM-01-2) | CAN bus tap point | TCU CAN-H |
-| J1939 CAN Low | Twisted pair (paired with CAN High) | Shared J1939 bus tap | CAN bus tap point | TCU CAN-L |
-| Aux out (Reverse) | 18 AWG | TCU aux output: 12V when shifter in R → PMU In 3 (drives PMU OUT22 reverse lights) | TCU aux Reverse pin | PMU In 3 |
-| Aux out (P/N) | 18 AWG | TCU aux output: 12V when shifter in P or N → starter P/N interlock relay coil | TCU aux P/N pin | Starter P/N interlock relay coil+ |
-| TCU ground | 14 AWG | TCU ground return | TCU ground terminal | Engine bay ground bus |
-
-**Connectors:**
-
-- TCU end: Turbolamik TCU's connector (depends on TCU model — 2.0 typically uses a small Deutsch DT or similar)
-- Engine bay ends: Each wire terminates at its destination (PMU spade/screw terminal, J1939 splice, relay coil terminal, ground bus stud)
-
-**Protection:** Split loom from TCU through trans tunnel up to engine bay. Heat sleeve where it enters engine bay zone (>12" from exhaust).
-
-**Notes:**
-
-- All endpoints are in engine bay — no firewall penetration needed
-- J1939 CAN tap is shared with PMU and Dakota Digital BIM-01-2 — the TCU is a third node on the same bus (just adds a splice at the existing tap point)
-- The brake switch input to TCU (for unlock-from-Park) is sourced from the cabin brake pedal switch (which already feeds PMU In 2 via HDP24 pin 13) — could share routing or take a separate tap; routing TBD
-- TCU is one of three controllers tightly coupled to the engine bay: PMU24 (mounted on firewall), Dakota Digital BIM modules (on HDPE panel cabin side), and TCU (mounted on transmission). All share the J1939 CAN bus.
-
-See [Transmission][transmission] and [PMU Outputs][pmu-outputs] for related details.
-
-[transmission]: ../../10-drivetrain/01-transmission.md
-
----
-
 ## Bundle Interference Assessment {#bundle-interference-assessment}
 
 Two harnesses (H1 and H5) bundle multiple originally-separate runs into a single sleeve. EMI/crosstalk evaluation:
@@ -432,7 +179,7 @@ The **cabin trunk** (trans tunnel / sill, firewall ↔ rear wheel wells) carries
 
 ## Bundle Optimization Opportunities (Summary)
 
-These were noted inline above; consolidated here for review:
+These were noted inline on the build sheets; consolidated here for review:
 
 1. ~~Old H4 + old H1 share rear-well → firewall path~~ **Resolved (2026-05-30):** Merged into single **H1 Passenger Rear Power Trunk**. Firewall transition uses a **single sealed 2-piece rubber grommet** (e.g., Steele Rubber) — cables run continuously, no service break. Bulkhead studs (Blue Sea 2203/2204) max at 250A and were underrated for the winch peaks (400A); Anderson SB175 was also undersized. Continuous-cable + grommet is WARN's documented standard for high-current firewall pass-through.
 2. ~~Old H6 + old H7 + CT4 rear turn + old H8 SP signal wires share cabin trunk → rear~~ **Partially resolved (2026-05-30):** Old H6 + old H7 merged into **H5 Rear Cabin Trunk Bundle** with single multi-pin breakout (Deutsch DT15 or AMP CPC ~15-pin) at rear cargo bulkhead. CT4 rear turn signals and ARB control wires *could* still join — pending decision.
@@ -452,10 +199,14 @@ These were noted inline above; consolidated here for review:
 - [ ] Decide if ARB control wires merge into H5 (recommended) or run as H6 signal pair
 - [ ] Source connector + lug + heat shrink BOM totals
 - [ ] Determine harness sleeve / wrap material (split loom vs braided sleeving) per zone
+- [ ] Define and record the signal-wire color scheme for non-vendor signal/trigger wires (power = red, ground = black are fixed; see [Wire Color Convention](#wire-color-convention))
 
 ## Related Documentation
 
-- [Wire Routing][wire-routing] - Zone-based routing reference
+- [Power Distribution Build Sheet][power-build] - H1, H2, H3 with tub-map diagram
+- [Lighting & SwitchPros Build Sheet][lighting-build] - H4, H5 with tub-map diagram
+- [Controls, Recovery & Drivetrain Build Sheet][controls-build] - H6–H9 with tub-map diagram
+- [Wire Routing][wire-routing] - Zone-based routing reference and protection standards
 - [Firewall Ingress][firewall-ingress] - HDP24 pinout and penetrations
 - [AUX Battery Distribution][aux-battery] - H1 source
 - [START Battery Distribution][start-battery] - H2 and H3 source
@@ -465,6 +216,10 @@ These were noted inline above; consolidated here for review:
 - [Recovery Systems / Winch][recovery] - H1 (winch portion) destination
 - [Air Compressor][air-compressor] - H6 destination
 
+[power-build]: 04-harness-power-distribution.md
+[lighting-build]: 05-harness-lighting-switchpros.md
+[controls-build]: 06-harness-controls-recovery-drivetrain.md
+[lj-tub-map]: 04-harness-power-distribution.md
 [wire-routing]: index.md
 [firewall-ingress]: 02-firewall-ingress.md
 [aux-battery]: ../03-aux-battery-distribution/index.md

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/04-harness-power-distribution.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/04-harness-power-distribution.md
@@ -14,7 +14,7 @@ Workbench specs for the high-current power harnesses: **H1** Passenger Rear Powe
 
 *Top-down tub map of the power-distribution harnesses. Diagram source: `Jeep LJ Tub Map.drawio` (page "Power Distribution"); the image is regenerated from the draw.io file on each export.*
 
-**Reading this sheet:** Wire colors follow the [Wire Color Convention][color-convention] (power = red, ground = black). Protective wrap, heat sleeve, and P-clamp standards by location are in [Wire Protection Standards][wire-routing]. For the system-wide picture and the bundle interference analysis, see the [Harness Inventory][harness-inventory] overview.
+**Reading this sheet:** Wire colors follow the [Wire Color Convention][color-convention] (power = red, ground = black). These are power runs — they get a **red braided expandable sleeve with a per-harness tracer** ([Protective Sleeve & Tracers][sleeve-convention]); heat sleeve and P-clamp standards by location are in [Wire Protection Standards][wire-routing]. For the system-wide picture and the bundle interference analysis, see the [Harness Inventory][harness-inventory] overview.
 
 ---
 
@@ -22,7 +22,7 @@ Workbench specs for the high-current power harnesses: **H1** Passenger Rear Powe
 
 *Formed 2026-05-30 by merging the prior H1 (AUX forward feed) and H4 (winch feed). The two shared the entire passenger-side path, so they are fabricated and installed as a single 3-cable bundle.*
 
-**Build:** 3 conductors · longest run ~13 ft to firewall (+13 ft for the winch pair to the bumper) · ~1.5" OD wrapped bundle · ring lugs both ends.
+**Build:** 3 conductors · longest run ~13 ft to firewall (+13 ft for the winch pair to the bumper) · ~1.5" OD red braided sleeve, black tracer · ring lugs both ends.
 
 **Route:** Passenger rear wheel well (AUX battery) → up inside passenger rear quarter sill → forward along **inside floor board / side wall** (passenger side) → A-pillar area → **3× bulkhead studs through firewall** → engine bay → forward along passenger inner fender → through grille area → front bumper (winch portion only)
 
@@ -47,7 +47,7 @@ Workbench specs for the high-current power harnesses: **H1** Passenger Rear Powe
 - Service is rare in practice — when needed, pulling the entire cable end-to-end is acceptable
 - Steele Rubber or similar 2-piece grommet, ~$5–15
 
-**Protection:** Split loom + wrapped harness sleeve along entire cabin path. Heat sleeve where the winch cables enter engine bay. P-clamps every 12–18".
+**Protection:** Red braided expandable sleeve (black tracer) over the entire cabin path, sized to the ~1.5" OD bundle. Heat sleeve over the sleeve where the winch cables enter engine bay. P-clamps every 12–18".
 
 **Notes:**
 
@@ -59,7 +59,7 @@ Workbench specs for the high-current power harnesses: **H1** Passenger Rear Powe
 
 ## H2 — START Engine Bay Trunk {#h2}
 
-**Build:** 3 conductors (all 2/0 AWG) · 6–8 ft per cable · ~1.5" OD bundle · lug terminations both ends · heat sleeve at engine-bay entry.
+**Build:** 3 conductors (all 2/0 AWG) · 6–8 ft per cable · ~1.5" OD red braided sleeve, yellow tracer · lug terminations both ends · heat sleeve at engine-bay entry.
 
 **Route:** Driver rear wheel well (START battery) → up inside driver rear quarter sill → forward along **inside floor board / side wall** (driver side) → A-pillar area → driver firewall penetration → engine bay
 
@@ -77,7 +77,7 @@ Workbench specs for the high-current power harnesses: **H1** Passenger Rear Powe
 
 **Connectors:** Lug terminations at both ends. Heat sleeve required where bundle enters engine bay (>12" from exhaust). Bundle 3 cables with looms; expect ~1.5" OD final bundle.
 
-**Protection:** Split loom + wrapped harness sleeve in cabin / sill. Heat sleeve in engine bay. P-clamps every 12–18".
+**Protection:** Red braided expandable sleeve (yellow tracer) over the cabin / sill run, sized to the ~1.5" OD bundle. Heat sleeve in engine bay. P-clamps every 12–18".
 
 **Firewall penetration:** Driver-side grommet for high-current cables — separate from the HDP24 (HDP24 is passenger-side, signal-only). Three 2/0 AWG cables need a grommet sized for ~1.5" bundle OD.
 
@@ -91,7 +91,7 @@ Workbench specs for the high-current power harnesses: **H1** Passenger Rear Powe
 
 ## H3 — BCDC Cross-Cab {#h3}
 
-**Build:** 2 conductors · ~5–6 ft straight run under the rear bench · lug terminations both ends · split loom, no inline connectors.
+**Build:** 2 conductors · ~5–6 ft straight run under the rear bench · lug terminations both ends · red braided sleeve, green tracer, no inline connectors.
 
 **Route:** Driver rear wheel well (START battery) → **under the rear bench seat cushion** → passenger rear wheel well (BCDC + AUX battery)
 
@@ -106,7 +106,7 @@ Workbench specs for the high-current power harnesses: **H1** Passenger Rear Powe
 
 **Connectors:** Lug terminations both ends. No inline connectors needed for short run.
 
-**Protection:** Split loom along the run. Bench cushion provides physical shielding from above; floor pan shields from below. P-clamps to body cross-member at 1–2 points.
+**Protection:** Red braided expandable sleeve (green tracer) along the run. Bench cushion provides physical shielding from above; floor pan shields from below. P-clamps to body cross-member at 1–2 points.
 
 **Notes:**
 
@@ -130,6 +130,7 @@ Workbench specs for the high-current power harnesses: **H1** Passenger Rear Powe
 
 [harness-inventory]: 03-harness-inventory.md
 [color-convention]: 03-harness-inventory.md#wire-color-convention
+[sleeve-convention]: 03-harness-inventory.md#sleeve-convention
 [lighting-build]: 05-harness-lighting-switchpros.md
 [controls-build]: 06-harness-controls-recovery-drivetrain.md
 [wire-routing]: index.md

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/04-harness-power-distribution.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/04-harness-power-distribution.md
@@ -1,0 +1,139 @@
+---
+hide:
+  - toc
+tags:
+  - wire-routing
+  - harness
+---
+
+# 1.7.4 Build Sheet — Power Distribution {#harness-power-distribution}
+
+Workbench specs for the high-current power harnesses: **H1** Passenger Rear Power Trunk, **H2** START Engine Bay Trunk, and **H3** BCDC Cross-Cab. These move battery power between the rear wheel wells, the firewall, and the engine bay.
+
+![LJ Tub Map — Power Distribution routing (top-down): START + AUX batteries, circuit breakers, PMU feed, firewall pass-through, and the H1/H2/H3 runs](../../images/lj-tub-map-power-distribution.png)
+
+*Top-down tub map of the power-distribution harnesses. Diagram source: `Jeep LJ Tub Map.drawio` (page "Power Distribution"); the image is regenerated from the draw.io file on each export.*
+
+**Reading this sheet:** Wire colors follow the [Wire Color Convention][color-convention] (power = red, ground = black). Protective wrap, heat sleeve, and P-clamp standards by location are in [Wire Protection Standards][wire-routing]. For the system-wide picture and the bundle interference analysis, see the [Harness Inventory][harness-inventory] overview.
+
+---
+
+## H1 — Passenger Rear Power Trunk (AUX Forward Feed + Winch) {#h1}
+
+*Formed 2026-05-30 by merging the prior H1 (AUX forward feed) and H4 (winch feed). The two shared the entire passenger-side path, so they are fabricated and installed as a single 3-cable bundle.*
+
+**Build:** 3 conductors · longest run ~13 ft to firewall (+13 ft for the winch pair to the bumper) · ~1.5" OD wrapped bundle · ring lugs both ends.
+
+**Route:** Passenger rear wheel well (AUX battery) → up inside passenger rear quarter sill → forward along **inside floor board / side wall** (passenger side) → A-pillar area → **3× bulkhead studs through firewall** → engine bay → forward along passenger inner fender → through grille area → front bumper (winch portion only)
+
+**Length:** ~13 ft to firewall (all 3 cables); ~13 ft additional for winch cables continuing to bumper
+
+**Contains:**
+
+| Wire | Gauge | Color | Function | Termination at battery | Termination at firewall | Continues to |
+|:-----|:-----:|:-----:|:---------|:----------------------|:------------------------|:-------------|
+| Forward feed (+) | 2/0 AWG | Red | Powers SwitchPros + BODY PDU + Fusion via Firewall CONSTANT bus | Ring lug to 300A CB output stud | Ring lug to bulkhead stud | (terminates at firewall — bus input stud on engine bay side via short jumper) |
+| Winch power (+) | 1/0 AWG | Red | AUX battery+ → winch contactor B+ | Ring lug to AUX battery+ stud | Ring lug to bulkhead stud | Lug to winch contactor B+ |
+| Winch ground (−) | 1/0 AWG | Black | AUX battery- → winch contactor B− | Ring lug to AUX battery- stud | Ring lug to bulkhead stud | Lug to winch motor / chassis at front |
+
+**Firewall pass-through:** **Single sealed 2-piece rubber grommet** sized for the ~1.5" OD bundle (~1.75" firewall hole). Cables run continuously from rear wheel well to their respective destinations — no service break at the firewall. The grommet seals the firewall penetration only; the cables themselves are uninterrupted.
+
+**Why continuous cables + grommet (not inline connectors or bulkhead studs):**
+
+- WARN install documentation references this approach as standard for winch firewall pass-through
+- No amperage limit at the pass-through (the cable is the conductor; grommet just seals the hole)
+- Common feed-through marine bulkhead studs (Blue Sea 2203/2204, Cole Hersee 46211) max at 250A continuous — borderline for the forward feed (232A) and underrated for the winch leg (400A peak)
+- Anderson SB175 is undersized for the winch leg (175A continuous); SBE320/SB350 would work but adds complexity
+- Service is rare in practice — when needed, pulling the entire cable end-to-end is acceptable
+- Steele Rubber or similar 2-piece grommet, ~$5–15
+
+**Protection:** Split loom + wrapped harness sleeve along entire cabin path. Heat sleeve where the winch cables enter engine bay. P-clamps every 12–18".
+
+**Notes:**
+
+- 3-cable bundle: ~1.5" OD final wrapped harness
+- Path is fully inside the body until firewall transition (no exposed frame rail)
+- Cables terminate as ring lugs at destinations (lug-to-stud at battery / CB / bus / contactor on each end). If a service break is ever desired, do it as a lug-to-lug junction inside the rear wheel well, not at the firewall.
+
+---
+
+## H2 — START Engine Bay Trunk {#h2}
+
+**Build:** 3 conductors (all 2/0 AWG) · 6–8 ft per cable · ~1.5" OD bundle · lug terminations both ends · heat sleeve at engine-bay entry.
+
+**Route:** Driver rear wheel well (START battery) → up inside driver rear quarter sill → forward along **inside floor board / side wall** (driver side) → A-pillar area → driver firewall penetration → engine bay
+
+**Length:** 6–8 ft per cable
+
+**Contains:**
+
+| Wire | Gauge | Color | Function | Termination at battery | Termination at engine bay |
+|:-----|:-----:|:-----:|:---------|:----------------------|:--------------------------|
+| Alternator charging input | 2/0 AWG | Red | Alternator → START battery+ | Lug to battery+ stud | Lug to alternator output stud |
+| Starter motor power | 2/0 AWG | Red | START battery+ → starter | Lug to battery+ stud | Lug to starter B+ stud |
+| PMU24 main feed | 2/0 AWG | Red | START battery+ → 250A CB → PMU24 | Lug to 250A CB output | Lug to PMU power stud |
+
+(BCDC input feed (4 AWG via 80A CB) takes the H3 cross-cab path instead — see [H3](#h3).)
+
+**Connectors:** Lug terminations at both ends. Heat sleeve required where bundle enters engine bay (>12" from exhaust). Bundle 3 cables with looms; expect ~1.5" OD final bundle.
+
+**Protection:** Split loom + wrapped harness sleeve in cabin / sill. Heat sleeve in engine bay. P-clamps every 12–18".
+
+**Firewall penetration:** Driver-side grommet for high-current cables — separate from the HDP24 (HDP24 is passenger-side, signal-only). Three 2/0 AWG cables need a grommet sized for ~1.5" bundle OD.
+
+**Notes:**
+
+- All 3 high-current cables share the same driver-side floor / side wall path
+- Path is fully inside the body (no exposed frame rail)
+- Driver-side firewall grommet is a new firewall penetration — separate from existing passenger-side HDP24 and SwitchPros bulkheads
+
+---
+
+## H3 — BCDC Cross-Cab {#h3}
+
+**Build:** 2 conductors · ~5–6 ft straight run under the rear bench · lug terminations both ends · split loom, no inline connectors.
+
+**Route:** Driver rear wheel well (START battery) → **under the rear bench seat cushion** → passenger rear wheel well (BCDC + AUX battery)
+
+**Length:** ~5–6 ft (straight cross-cab run under bench)
+
+**Contains:**
+
+| Wire | Gauge | Color | Function | Termination at driver well | Termination at passenger well |
+|:-----|:-----:|:-----:|:---------|:--------------------------|:------------------------------|
+| BCDC input | 4 AWG | Red | START battery+ via 80A CB → BCDC input terminal | Lug to 80A CB output | Lug to BCDC input red terminal (M8) |
+| Cross-ground reference | 1/0 AWG | Black | START battery- → AUX battery- (critical for BCDC operation) | Lug to START battery- | Lug to AUX battery- |
+
+**Connectors:** Lug terminations both ends. No inline connectors needed for short run.
+
+**Protection:** Split loom along the run. Bench cushion provides physical shielding from above; floor pan shields from below. P-clamps to body cross-member at 1–2 points.
+
+**Notes:**
+
+- Under-bench routing is short, dry, accessible, and physically protected (bench cushion above, floor pan below)
+- No frame rail exposure; no need to share the longer floor / side wall paths used by H1 / H2
+- BCDC sensor cable (~6 ft, 2-pin) is included with BCDC unit, runs to AUX battery+ terminal at the same wheel well — short, stays passenger-side, not part of this harness
+- Path is independent of cabin trunk runs (H1 passenger side, H2 driver side), so no cabin trunk congestion impact
+
+---
+
+## Related Documentation
+
+- [Harness Inventory][harness-inventory] - Overview, harness map, and bundle interference assessment
+- [Lighting & SwitchPros Build Sheet][lighting-build] - H4, H5
+- [Controls, Recovery & Drivetrain Build Sheet][controls-build] - H6–H9
+- [Wire Routing][wire-routing] - Zone-based routing and protection standards
+- [Firewall Ingress][firewall-ingress] - Firewall penetrations and bulkhead specs
+- [AUX Battery Distribution][aux-battery] - H1 source
+- [START Battery Distribution][start-battery] - H2 / H3 source
+- [Recovery Systems / Winch][recovery] - H1 winch portion destination
+
+[harness-inventory]: 03-harness-inventory.md
+[color-convention]: 03-harness-inventory.md#wire-color-convention
+[lighting-build]: 05-harness-lighting-switchpros.md
+[controls-build]: 06-harness-controls-recovery-drivetrain.md
+[wire-routing]: index.md
+[firewall-ingress]: 02-firewall-ingress.md
+[aux-battery]: ../03-aux-battery-distribution/index.md
+[start-battery]: ../02-starter-battery-distribution/index.md
+[recovery]: ../../08-exterior-systems/01-winch.md

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/05-harness-lighting-switchpros.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/05-harness-lighting-switchpros.md
@@ -14,7 +14,7 @@ Workbench specs for the SwitchPros lighting harnesses: **H4** SwitchPros Front B
 
 *Top-down tub map of the lighting harnesses. Diagram source: `Jeep LJ Tub Map.drawio` (page "Lighting & SwitchPros"); the image is regenerated from the draw.io file on each export.*
 
-**Reading this sheet:** SwitchPros loads arrive on the controller's own 2-pin Delphi pigtails — match those supplied colors rather than re-coloring. PMU outputs and grounds follow the [Wire Color Convention][color-convention] (ground = black; signal = builder's choice). Protection standards by location are in [Wire Protection Standards][wire-routing]; system-wide context is in the [Harness Inventory][harness-inventory] overview.
+**Reading this sheet:** SwitchPros loads arrive on the controller's own 2-pin Delphi pigtails — match those supplied colors rather than re-coloring. PMU outputs and grounds follow the [Wire Color Convention][color-convention] (ground = black; signal = builder's choice). These are small-wire lighting bundles, so split loom is fine — use a braided sleeve with a tracer if you'd rather color-code the cabin-trunk pull ([Protective Sleeve & Tracers][sleeve-convention]). Other protection standards by location are in [Wire Protection Standards][wire-routing]; system-wide context is in the [Harness Inventory][harness-inventory] overview.
 
 ---
 
@@ -106,6 +106,7 @@ See [SwitchPros Firewall Bulkhead][firewall-ingress] for connector spec and pino
 
 [harness-inventory]: 03-harness-inventory.md
 [color-convention]: 03-harness-inventory.md#wire-color-convention
+[sleeve-convention]: 03-harness-inventory.md#sleeve-convention
 [power-build]: 04-harness-power-distribution.md
 [controls-build]: 06-harness-controls-recovery-drivetrain.md
 [wire-routing]: index.md

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/05-harness-lighting-switchpros.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/05-harness-lighting-switchpros.md
@@ -1,0 +1,114 @@
+---
+hide:
+  - toc
+tags:
+  - wire-routing
+  - harness
+---
+
+# 1.7.5 Build Sheet — Lighting & SwitchPros {#harness-lighting-switchpros}
+
+Workbench specs for the SwitchPros lighting harnesses: **H4** SwitchPros Front Bundle (forward loads through the dedicated SP bulkhead) and **H5** Rear Cabin Trunk Bundle (SwitchPros rear outputs + PMU rear lighting through the cabin trunk to a rear breakout).
+
+![LJ Tub Map — Lighting & SwitchPros routing (top-down): SwitchPros controller, forward and rear lighting fan-out, and the H4/H5 runs](../../images/lj-tub-map-lighting-switchpros.png)
+
+*Top-down tub map of the lighting harnesses. Diagram source: `Jeep LJ Tub Map.drawio` (page "Lighting & SwitchPros"); the image is regenerated from the draw.io file on each export.*
+
+**Reading this sheet:** SwitchPros loads arrive on the controller's own 2-pin Delphi pigtails — match those supplied colors rather than re-coloring. PMU outputs and grounds follow the [Wire Color Convention][color-convention] (ground = black; signal = builder's choice). Protection standards by location are in [Wire Protection Standards][wire-routing]; system-wide context is in the [Harness Inventory][harness-inventory] overview.
+
+---
+
+## H4 — SwitchPros Front Bundle {#h4}
+
+*Previously numbered H5. Renumbered 2026-05-31 when the catalog was compacted after the H1+H4 and H6+H7 merges.*
+
+**Build:** 3 SwitchPros outputs (6 conductors) · 4–8 ft depending on destination · Delphi 2-pin at SP side, HDP24-18-14 at firewall · split loom forward.
+
+**Route:** SwitchPros (firewall, cabin side) → **dedicated SwitchPros HDP24-18-14 firewall bulkhead** → engine bay → grille / front bumper / front axle
+
+**Length:** 4–8 ft (depending on destination)
+
+**Contains:**
+
+| SwitchPros output | Gauge | Color | Function | Destination | SP bulkhead pins |
+|:-----------------:|:-----:|:-----:|:---------|:------------|:----------------:|
+| OUT-3 (35A circuit) | 14 AWG | Per SP pigtail | Fog light | Front bumper (BD S8 amber) | 1 (+) / 2 (−) |
+| OUT-6 (front rocks subset, 15A circuit, shared with rear) | 14 AWG | Per SP pigtail | Front bumper rock light + 2x front wheel well rock lights | Splice at front for 3 lights | 3 (+) / 4 (−) |
+| OUT-17 (low-side 2A) | 18 AWG | Per SP pigtail | Front ARB locker solenoid | Front axle (~12 ft from SP) | 5 (+) / 6 (−) |
+
+**Connectors:** Custom 2-pin Delphi at SwitchPros output side (per SP harness convention); harness terminates at HDP24-18-14 cabin-side plug at firewall. Engine-bay side picks up at HDP24-18-14 receptacle and re-terminates as 2-pin Delphi at each light/solenoid.
+
+**Ground strategy:** Each output's load ground returns through the SP bulkhead (pins 2, 4, 6) to the SwitchPros Ground Bus on cabin side. Clean SP-native architecture; no reliance on chassis ground at forward loads.
+
+**Notes:**
+
+- 3 forward-going SwitchPros circuits in this bundle, 6 pins through dedicated SP bulkhead (HDP24-18-14)
+- Front locker wire (18 AWG) is the longest run — passes through front fender well and along front axle
+- Front rock lights (4 in front wheel wells + 1 front bumper) all share OUT-6 with rear rocks
+- Could be split into "front bumper sub-harness" (fog + front rock + front bumper) and "front axle sub-harness" (front locker) if those routings diverge
+- **8 spare pins** on SP bulkhead accommodate future ditch/roof additions if A-pillar routing becomes impractical
+
+See [SwitchPros Firewall Bulkhead][firewall-ingress] for connector spec and pinout.
+
+---
+
+## H5 — Rear Cabin Trunk Bundle (SwitchPros Rear + PMU Rear) {#h5}
+
+*Formed 2026-05-30 by merging the prior H6 (SwitchPros rear outputs) and H7 (PMU rear lighting). The two shared the firewall-to-rear cabin trunk path, so they are fabricated as a single multi-conductor bundle with a rear cargo bulkhead breakout connector.*
+
+**Build:** ~10 conductors (mostly 14 AWG) · 8–14 ft (PMU portion ~11–16 ft incl. engine-bay leg) · single multi-pin breakout at rear cargo bulkhead · split loom + wrapped sleeve through trans tunnel.
+
+**Route:** SwitchPros (firewall, cabin side) + PMU24 outputs (via HDP24 pins 4/5/6 from engine bay) → converge at firewall → cabin trunk (trans tunnel) → rear cargo bulkhead breakout → fans out to rear destinations
+
+**Length:** 8–14 ft (depending on destination; PMU portion is ~11–16 ft total including engine bay leg)
+
+**Contains:**
+
+| Source | Output / Function | Gauge | Color | Destination |
+|:-------|:------------------|:-----:|:-----:|:------------|
+| **SwitchPros** OUT-6 (shared with front) | Rear rocks (rear bumper + 2× rear wheel well) | 14 AWG | Per SP pigtail | Splice at rear for 3 lights |
+| **SwitchPros** OUT-7 | Chase light (BD RTL-S 30") | 14 AWG | Per SP pigtail | Rear bumper |
+| **SwitchPros** OUT-10 | Rear ARB locker solenoid | 14 AWG | Per SP pigtail | Rear axle |
+| **SwitchPros** OUT-12 | Rear work lights (2× BD S1) | 14 AWG | Per SP pigtail | Above license plate |
+| **SwitchPros** OUT-13 | Cargo lights (2× flush in rear wheel wells) | 14 AWG | Per SP pigtail | Triggered by rear cargo rocker |
+| **SwitchPros** TRIGGER-2 | Cargo rocker switch return | 18 AWG | Per SP pigtail | Rear cargo rocker (rear wheel well top) |
+| **PMU** OUT-21 | Brake signal | 16 AWG | Builder's choice | Tail clusters (L+R) + 3rd brake |
+| **PMU** OUT-22 | Reverse signal | 16 AWG | Builder's choice | Tail clusters (L+R) |
+| **PMU** OUT-23 | Running/parking signal | 16 AWG | Builder's choice | Tail clusters (L+R) + license plate |
+| **PMU** ground return | Common tail cluster ground | 16 AWG | Black | SwitchPros GND bus at firewall |
+
+**Connectors:**
+
+- **Firewall (cabin side):** SwitchPros outputs originate as Delphi 2-pin pigtails at SP module; PMU outputs enter the cabin via HDP24 pins 4/5/6. Both join the trunk wrap aft of firewall.
+- **Rear cargo bulkhead breakout:** Single multi-pin connector — **Deutsch DT15-XX (15-pin)** or **AMP CPC ~15-pin**. All ~10 conductors mate at this single service point.
+- **Rear-side pigtails:** Short individual harnesses from breakout to each destination (chase, work, cargo, rocks, locker, tail clusters).
+
+**Protection:** Split loom + wrapped harness sleeve through cabin trunk. P-clamps every 12–18".
+
+**Notes:**
+
+- ~10 conductors in the cabin trunk bundle (mostly 14 AWG + a few 16/18 AWG)
+- **Service model:** R&R any rear light by swapping its pigtail at the rear bulkhead breakout. The cabin trunk pull stays in place.
+- Splices needed for the tail clusters: each PMU output feeds both driver and passenger sides + 3rd brake/license — can be done at the breakout or with Y-splices closer to lights
+- CT4 rear turn signals could also join this bundle through the cabin trunk; tracked separately because they originate at CT4 (steering column) not firewall
+
+---
+
+## Related Documentation
+
+- [Harness Inventory][harness-inventory] - Overview, harness map, and bundle interference assessment
+- [Power Distribution Build Sheet][power-build] - H1, H2, H3
+- [Controls, Recovery & Drivetrain Build Sheet][controls-build] - H6–H9
+- [Wire Routing][wire-routing] - Zone-based routing and protection standards
+- [Firewall Ingress][firewall-ingress] - SwitchPros bulkhead (HDP24-18-14) pinout
+- [SwitchPros SP-1200][switchpros] - H4 / H5 source controller
+- [PMU24 Outputs][pmu-outputs] - H5 PMU source
+
+[harness-inventory]: 03-harness-inventory.md
+[color-convention]: 03-harness-inventory.md#wire-color-convention
+[power-build]: 04-harness-power-distribution.md
+[controls-build]: 06-harness-controls-recovery-drivetrain.md
+[wire-routing]: index.md
+[firewall-ingress]: 02-firewall-ingress.md
+[switchpros]: ../../05-control-interfaces/02-switchpros-sp1200.md
+[pmu-outputs]: ../04-pmu/03-pmu-outputs.md

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/06-harness-controls-recovery-drivetrain.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/06-harness-controls-recovery-drivetrain.md
@@ -1,0 +1,180 @@
+---
+hide:
+  - toc
+tags:
+  - wire-routing
+  - harness
+---
+
+# 1.7.6 Build Sheet — Controls, Recovery & Drivetrain {#harness-controls-recovery-drivetrain}
+
+Workbench specs for the recovery and drivetrain harnesses: **H6** ARB Compressor, **H7** Winch Trigger, **H8** Kilduff Shifter → TCU, and **H9** TCU → Engine Bay.
+
+![LJ Tub Map — Controls, Recovery & Drivetrain routing (top-down): ARB compressor, winch contactor trigger, shifter, and TCU runs (H6–H9)](../../images/lj-tub-map-controls-recovery-drivetrain.png)
+
+*Top-down tub map of the controls/recovery/drivetrain harnesses. Diagram source: `Jeep LJ Tub Map.drawio` (page "Controls, Recovery & Drivetrain"); the image is regenerated from the draw.io file on each export.*
+
+**Reading this sheet:** Power = red, ground = black; CAN runs as a twisted pair; vendor-supplied harnesses (ARB, CH4X4, Kilduff/ZF) keep their shipped colors. See the [Wire Color Convention][color-convention]. Protection standards by location are in [Wire Protection Standards][wire-routing]; system-wide context is in the [Harness Inventory][harness-inventory] overview.
+
+---
+
+## H6 — ARB Compressor Bundle {#h6}
+
+*Previously numbered H8. Renumbered 2026-05-31.*
+
+**Build:** 4 conductors (2× 6 AWG motor + 2 signal) · ~10 ft · lug at SafetyHub, ring/spade at compressor · the two signal wires originate at SwitchPros, not SafetyHub.
+
+**Route:** SafetyHub (passenger rear wheel well) → under cargo / under rear bench → under passenger seat (compressor mount)
+
+**Length:** ~10 ft
+
+**Contains:**
+
+| Wire | Gauge | Color | Function | Termination at SafetyHub | Termination at compressor |
+|:-----|:-----:|:-----:|:---------|:-------------------------|:--------------------------|
+| Motor 1 power | 6 AWG | Red (per ARB) | SafetyHub MIDI-1 (60A) → compressor motor 1 | Lug to MIDI-1 output | Compressor motor terminal |
+| Motor 2 power | 6 AWG | Red (per ARB) | SafetyHub MIDI-2 (60A) → compressor motor 2 | Lug to MIDI-2 output | Compressor motor terminal |
+| Control signal | 14 AWG | Per SP pigtail | SwitchPros OUT-11 → compressor control terminal | (Comes from SwitchPros at firewall, not SafetyHub — runs separately or joins this bundle along common path) | Compressor control terminal |
+| Pressure switch | 18 AWG | Per SP pigtail | ARB pressure switch (on manifold under passenger seat) → SwitchPros TRIGGER-3 | (At firewall, not SafetyHub) | Pressure switch normally-open contact |
+
+**Connectors:** Lug at SafetyHub side, ring/spade at compressor. ARB compressor manifold typically has a pigtail with its own connector.
+
+**Notes:**
+
+- Motor 1 + motor 2 are 6 AWG (high current, brief peaks) — bundle as a pair
+- Control + pressure switch wires originate at SwitchPros at firewall, NOT SafetyHub — they run from firewall through cabin to under passenger seat
+- Could be merged into H6 if they share routing, or kept separate as "H6b ARB signal"
+
+**Optimization opportunity:** Run the SwitchPros control + pressure switch wires through the cabin trunk to under passenger seat as part of [H5 SwitchPros rear bundle][lighting-build] (they're SP wires anyway), and split off at the compressor. Saves a separate harness — the only ARB-specific harness is the 2x 6 AWG motor cables from SafetyHub.
+
+---
+
+## H7 — Winch Trigger Control (small wire) {#h7}
+
+*Previously numbered H9. Renumbered 2026-05-31.*
+
+**Build:** 5 conductors (all 18 AWG) · ~3 ft (BODY PDU → dash) + ~13 ft (dash → contactor) · CH4X4 switch ships its own pigtail + cable kit · HDP24 at firewall.
+
+**Route:** BODY PDU (firewall, cabin side) → dash switch ([CH4X4 dual-momentary push][ch4x4-winch]) → HDP24 firewall pins 16/17 → winch contactor at front bumper
+
+**Length:** ~3 ft (BODY PDU → dash) + ~13 ft (dash → contactor via engine bay)
+
+**Contains:**
+
+| Wire | Gauge | Color | Function | Termination |
+|:-----|:-----:|:-----:|:---------|:------------|
+| Switch +12V supply | 18 AWG | Red | BODY PDU CB43 (10A) → CH4X4 switch common | Spade at BODY PDU, included pigtail at switch |
+| IN trigger | 18 AWG | Per CH4X4 pigtail | CH4X4 IN button → HDP24 pin 16 → contactor IN trigger | Included pigtail at switch, HDP24 socket, ring/spade at contactor |
+| OUT trigger | 18 AWG | Per CH4X4 pigtail | CH4X4 OUT button → HDP24 pin 17 → contactor OUT trigger | Included pigtail at switch, HDP24 socket, ring/spade at contactor |
+| Illumination supply | 18 AWG | Per CH4X4 pigtail | Dash illumination circuit | Included pigtail at switch |
+| Switch ground | 18 AWG | Black | Switch common ground | Chassis ground at dash |
+
+**Connectors:** CH4X4 includes its own connector + cable kit. HDP24-24-29 at firewall penetration. Ring/spade terminals at contactor.
+
+**Notes:**
+
+- BODY PDU CB43 (10A, ~3 ft to dash) replaces the previously-planned SafetyHub ATC-1 (15A, ~13 ft from rear wheel well). The 18 AWG wire is properly sized for the ~3A trigger current; the prior 14 AWG / 15A spec was over-built and routed wastefully.
+- Switch is dual-momentary push (not a polarity-reversing rocker) — the WARN ZEON 10-S contactor handles polarity internally
+- Warn handheld remote wires in parallel at the contactor trigger terminals
+- SafetyHub ATC-1 slot freed for future use (recovery accessories etc.)
+
+---
+
+## H8 — Kilduff Shifter to TCU {#h8}
+
+*Previously numbered H10. Renumbered 2026-05-31.*
+
+**Build:** 1 multi-conductor proprietary harness (supplied with the Kilduff shifter kit) · ~3–5 ft · factory 8HP70 connectors · no fabrication required.
+
+**Route:** Kilduff shifter in **center console** → straight down through trans tunnel → Turbolamik TCU **mounted on 8HP70 mechatronic** (transmission valve body)
+
+**Length:** ~3–5 ft
+
+**Contains:**
+
+| Wire | Gauge | Color | Function | Termination at shifter | Termination at TCU |
+|:-----|:-----:|:-----:|:---------|:----------------------|:-------------------|
+| Shifter harness | Proprietary multi-conductor (factory 8HP70 connector) | Factory (Kilduff/ZF) | All shifter signals (P/R/N/D, manual +/−, button states, illumination) | Kilduff-supplied connector at shifter base | Factory 8HP70 connector at TCU |
+
+**Connectors:**
+
+- Kilduff supplies the shifter end of the harness with their shifter kit
+- TCU end uses the factory 8HP70 mechatronic connector (Turbolamik TCU 2.0 mates to this)
+
+**Protection:** Split loom through trans tunnel. The trans tunnel keeps the cable away from cabin contents and provides a clean straight run.
+
+**Notes:**
+
+- TCU is **mounted on the 8HP70 mechatronic** (the trans valve body), not in cabin or engine bay — so this is a very short pull
+- No firewall penetration
+- No other H-series harnesses share this path — it's a single-purpose, self-contained run
+- Kilduff includes the wiring harness with the shifter kit — no separate fabrication required
+
+See [Transmission][transmission] for shifter and TCU specs.
+
+---
+
+## H9 — TCU to Engine Bay {#h9}
+
+*Previously numbered H11. Renumbered 2026-05-31.*
+
+**Build:** 6 conductors (incl. one twisted CAN pair) · 3–4 ft · TCU connector at one end, individual terminations in engine bay · split loom + heat sleeve at engine-bay entry.
+
+**Route:** Turbolamik TCU on 8HP70 mechatronic → up through trans tunnel forward → engine bay (PMU + J1939 tap + starter P/N relay)
+
+**Length:** 3–4 ft
+
+**Contains:**
+
+| Wire | Gauge | Color | Function | Source | Destination |
+|:-----|:-----:|:-----:|:---------|:-------|:------------|
+| TCU power feed | 14 AWG | Red | PMU OUT16 (CONSTANT, 15A) → TCU power input | PMU OUT16 (engine bay) | TCU power terminal |
+| J1939 CAN High | Twisted pair | Twisted pair (CAN) | Shared J1939 bus tap (same tap as PMU, Dakota Digital BIM-01-2) | CAN bus tap point | TCU CAN-H |
+| J1939 CAN Low | Twisted pair (paired with CAN High) | Twisted pair (CAN) | Shared J1939 bus tap | CAN bus tap point | TCU CAN-L |
+| Aux out (Reverse) | 18 AWG | Builder's choice | TCU aux output: 12V when shifter in R → PMU In 3 (drives PMU OUT22 reverse lights) | TCU aux Reverse pin | PMU In 3 |
+| Aux out (P/N) | 18 AWG | Builder's choice | TCU aux output: 12V when shifter in P or N → starter P/N interlock relay coil | TCU aux P/N pin | Starter P/N interlock relay coil+ |
+| TCU ground | 14 AWG | Black | TCU ground return | TCU ground terminal | Engine bay ground bus |
+
+**Connectors:**
+
+- TCU end: Turbolamik TCU's connector (depends on TCU model — 2.0 typically uses a small Deutsch DT or similar)
+- Engine bay ends: Each wire terminates at its destination (PMU spade/screw terminal, J1939 splice, relay coil terminal, ground bus stud)
+
+**Protection:** Split loom from TCU through trans tunnel up to engine bay. Heat sleeve where it enters engine bay zone (>12" from exhaust).
+
+**Notes:**
+
+- All endpoints are in engine bay — no firewall penetration needed
+- J1939 CAN tap is shared with PMU and Dakota Digital BIM-01-2 — the TCU is a third node on the same bus (just adds a splice at the existing tap point)
+- The brake switch input to TCU (for unlock-from-Park) is sourced from the cabin brake pedal switch (which already feeds PMU In 2 via HDP24 pin 13) — could share routing or take a separate tap; routing TBD
+- TCU is one of three controllers tightly coupled to the engine bay: PMU24 (mounted on firewall), Dakota Digital BIM modules (on HDPE panel cabin side), and TCU (mounted on transmission). All share the J1939 CAN bus.
+
+See [Transmission][transmission] and [PMU Outputs][pmu-outputs] for related details.
+
+---
+
+## Related Documentation
+
+- [Harness Inventory][harness-inventory] - Overview, harness map, and bundle interference assessment
+- [Power Distribution Build Sheet][power-build] - H1, H2, H3
+- [Lighting & SwitchPros Build Sheet][lighting-build] - H4, H5
+- [Wire Routing][wire-routing] - Zone-based routing and protection standards
+- [Firewall Ingress][firewall-ingress] - HDP24 pinout (H7 trigger pins 16/17)
+- [SafetyHub 150][safetyhub] - H6 source
+- [SwitchPros SP-1200][switchpros] - H6 control source
+- [Transmission][transmission] - H8 shifter and H9 TCU specs
+- [PMU24 Outputs][pmu-outputs] - H9 source
+- [Air Compressor][air-compressor] - H6 destination
+
+[harness-inventory]: 03-harness-inventory.md
+[color-convention]: 03-harness-inventory.md#wire-color-convention
+[power-build]: 04-harness-power-distribution.md
+[lighting-build]: 05-harness-lighting-switchpros.md
+[wire-routing]: index.md
+[firewall-ingress]: 02-firewall-ingress.md
+[safetyhub]: ../03-aux-battery-distribution/04-safetyhub.md
+[switchpros]: ../../05-control-interfaces/02-switchpros-sp1200.md
+[transmission]: ../../10-drivetrain/01-transmission.md
+[pmu-outputs]: ../04-pmu/03-pmu-outputs.md
+[air-compressor]: ../../08-exterior-systems/02-air-compressor.md
+[ch4x4-winch]: https://ch4x4.com/product/ch4x4-momentary-dual-push-switch-for-toyota-winch-in-out-symbol/

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/06-harness-controls-recovery-drivetrain.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/06-harness-controls-recovery-drivetrain.md
@@ -14,7 +14,7 @@ Workbench specs for the recovery and drivetrain harnesses: **H6** ARB Compressor
 
 *Top-down tub map of the controls/recovery/drivetrain harnesses. Diagram source: `Jeep LJ Tub Map.drawio` (page "Controls, Recovery & Drivetrain"); the image is regenerated from the draw.io file on each export.*
 
-**Reading this sheet:** Power = red, ground = black; CAN runs as a twisted pair; vendor-supplied harnesses (ARB, CH4X4, Kilduff/ZF) keep their shipped colors. See the [Wire Color Convention][color-convention]. Protection standards by location are in [Wire Protection Standards][wire-routing]; system-wide context is in the [Harness Inventory][harness-inventory] overview.
+**Reading this sheet:** Power = red, ground = black; CAN runs as a twisted pair; vendor-supplied harnesses (ARB, CH4X4, Kilduff/ZF) keep their shipped colors. See the [Wire Color Convention][color-convention]. The H6 compressor motor pair is a power run and takes a red braided sleeve (blue tracer); the small-wire signal harnesses (H7, H9) use split loom — see [Protective Sleeve & Tracers][sleeve-convention]. Other protection standards by location are in [Wire Protection Standards][wire-routing]; system-wide context is in the [Harness Inventory][harness-inventory] overview.
 
 ---
 
@@ -22,7 +22,7 @@ Workbench specs for the recovery and drivetrain harnesses: **H6** ARB Compressor
 
 *Previously numbered H8. Renumbered 2026-05-31.*
 
-**Build:** 4 conductors (2× 6 AWG motor + 2 signal) · ~10 ft · lug at SafetyHub, ring/spade at compressor · the two signal wires originate at SwitchPros, not SafetyHub.
+**Build:** 4 conductors (2× 6 AWG motor + 2 signal) · ~10 ft · lug at SafetyHub, ring/spade at compressor · motor pair in red braided sleeve (blue tracer) · the two signal wires originate at SwitchPros, not SafetyHub.
 
 **Route:** SafetyHub (passenger rear wheel well) → under cargo / under rear bench → under passenger seat (compressor mount)
 
@@ -38,6 +38,8 @@ Workbench specs for the recovery and drivetrain harnesses: **H6** ARB Compressor
 | Pressure switch | 18 AWG | Per SP pigtail | ARB pressure switch (on manifold under passenger seat) → SwitchPros TRIGGER-3 | (At firewall, not SafetyHub) | Pressure switch normally-open contact |
 
 **Connectors:** Lug at SafetyHub side, ring/spade at compressor. ARB compressor manifold typically has a pigtail with its own connector.
+
+**Protection:** Red braided expandable sleeve (blue tracer) over the 2× 6 AWG motor pair along the under-floor / under-seat run. Split loom for the control + pressure signal wires. P-clamps every 12–18".
 
 **Notes:**
 
@@ -168,6 +170,7 @@ See [Transmission][transmission] and [PMU Outputs][pmu-outputs] for related deta
 
 [harness-inventory]: 03-harness-inventory.md
 [color-convention]: 03-harness-inventory.md#wire-color-convention
+[sleeve-convention]: 03-harness-inventory.md#sleeve-convention
 [power-build]: 04-harness-power-distribution.md
 [lighting-build]: 05-harness-lighting-switchpros.md
 [wire-routing]: index.md

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/index.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/index.md
@@ -13,7 +13,8 @@ All wire runs require appropriate protection based on location and environment:
 
 | Method              | Application                                 | Products                                        |
 | :------------------ | :------------------------------------------ | :---------------------------------------------- |
-| **Split Loom**      | General protection, bundling multiple wires | 1/4" to 1" diameter, slit for easy installation |
+| **Braided Sleeve (expandable)** | Preferred wrap for power runs and cabin/trunk bundles | PET expandable braid sized to bundle OD; plain or with a tracer stripe for harness ID — see [Protective Sleeve & Tracers][sleeve-convention] |
+| **Split Loom**      | General protection, bundling multiple wires; short/branchy small-wire runs | 1/4" to 1" diameter, slit for easy installation |
 | **Heat Sleeve**     | Engine bay, exhaust proximity               | Fiberglass sleeve rated 500°F+, 1/2" to 1"      |
 | **Abrasion Sleeve** | Frame rail contact, sharp edges             | Braided nylon or polyester                      |
 | **P-Clamps**        | Securing runs to frame/body                 | Rubber-lined, stainless steel                   |
@@ -213,6 +214,7 @@ J1939 CAN High/Low wires tap into Cummins harness at firewall punch-through, the
 [power-build]: 04-harness-power-distribution.md
 [lighting-build]: 05-harness-lighting-switchpros.md
 [controls-build]: 06-harness-controls-recovery-drivetrain.md
+[sleeve-convention]: 03-harness-inventory.md#sleeve-convention
 
 [grounding]: ../05-grounding/index.md
 [starter-battery]: ../02-starter-battery-distribution/index.md

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/index.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/index.md
@@ -194,7 +194,10 @@ J1939 CAN High/Low wires tap into Cummins harness at firewall punch-through, the
 
 ## Related Documentation
 
-- [Harness Inventory][harness-inventory] - Fabricatable harness BOMs (H1–H9) with connectors, bundle interference assessment, and optimization notes
+- [Harness Inventory][harness-inventory] - Fabricatable harness overview (H1–H9): summary, harness map, bundle interference assessment, and optimization notes
+- [Build Sheet — Power Distribution][power-build] - H1, H2, H3 with tub-map diagram
+- [Build Sheet — Lighting & SwitchPros][lighting-build] - H4, H5 with tub-map diagram
+- [Build Sheet — Controls, Recovery & Drivetrain][controls-build] - H6–H9 with tub-map diagram
 - [Grounding Architecture][grounding] - Complete grounding system design
 - [START battery Distribution][starter-battery] - Driver rear wheel well power
 - [AUX battery Distribution][aux-battery] - Passenger rear wheel well power
@@ -207,6 +210,9 @@ J1939 CAN High/Low wires tap into Cummins harness at firewall punch-through, the
 - [Recovery Systems][recovery-systems] - Winch installation and wiring
 
 [harness-inventory]: 03-harness-inventory.md
+[power-build]: 04-harness-power-distribution.md
+[lighting-build]: 05-harness-lighting-switchpros.md
+[controls-build]: 06-harness-controls-recovery-drivetrain.md
 
 [grounding]: ../05-grounding/index.md
 [starter-battery]: ../02-starter-battery-distribution/index.md

--- a/hooks/copy_export_assets.py
+++ b/hooks/copy_export_assets.py
@@ -1,0 +1,59 @@
+"""MkDocs build hook: publish build artifacts from the repo-root ``export/``
+directory into the documentation site.
+
+The draw.io export workflow (``.github/workflows/drawio-export.yml``) renders
+each ``*.drawio`` file to ``export/*.png``. Those PNGs live outside ``docs/``,
+so MkDocs does not serve them by default. This hook copies selected export
+artifacts into the site at build time — for ``mkdocs serve``, ``mkdocs build``,
+and any deployment that runs a build — so the diagrams stay current with the
+source automatically and no generated copies are committed under ``docs/``.
+
+To publish another export artifact, add an entry to ``ASSETS``:
+
+    "export/<source-file>": "<path under docs_dir>"
+
+``dest`` is the path the file lives at inside the site relative to ``docs_dir``,
+so pages reference it with the normal central-image convention, e.g.
+``![alt](../../images/lj-tub-map-power-distribution.png)``.
+"""
+
+import os
+
+from mkdocs.plugins import get_plugin_logger
+from mkdocs.structure.files import File
+
+log = get_plugin_logger(__name__)
+
+# export artifact (repo-root relative)  ->  site path (docs_dir relative)
+ASSETS = {
+    "export/Jeep LJ Tub Map-Power-Distribution.png":
+        "jeep_lj/images/lj-tub-map-power-distribution.png",
+    "export/Jeep LJ Tub Map-Lighting---SwitchPros.png":
+        "jeep_lj/images/lj-tub-map-lighting-switchpros.png",
+    "export/Jeep LJ Tub Map-Controls--Recovery---Drivetrain.png":
+        "jeep_lj/images/lj-tub-map-controls-recovery-drivetrain.png",
+}
+
+
+def on_files(files, config):
+    repo_root = os.path.dirname(config["config_file_path"])
+    for src, dest in ASSETS.items():
+        abs_src = os.path.join(repo_root, src)
+        if not os.path.isfile(abs_src):
+            log.warning("export asset not found, skipping: %s", src)
+            continue
+        published = File(
+            dest,
+            config["docs_dir"],
+            config["site_dir"],
+            config["use_directory_urls"],
+        )
+        # Source the file from export/ rather than from docs_dir.
+        published.abs_src_path = abs_src
+        # Replace any file already registered at this destination.
+        existing = files.get_file_from_path(dest)
+        if existing is not None:
+            files.remove(existing)
+        files.append(published)
+        log.info("published export asset: %s -> %s", src, dest)
+    return files

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -74,6 +74,9 @@ markdown_extensions:
       permalink: true
       toc_depth: 3
 
+hooks:
+  - hooks/copy_export_assets.py
+
 plugins:
   - search
   - autorefs
@@ -137,6 +140,9 @@ nav:
         - jeep_lj/01-power-systems/07-wire-routing/index.md
         - 1.7.2 - Firewall Ingress: jeep_lj/01-power-systems/07-wire-routing/02-firewall-ingress.md
         - 1.7.3 - Harness Inventory: jeep_lj/01-power-systems/07-wire-routing/03-harness-inventory.md
+        - 1.7.4 - Build Sheet&#58; Power Distribution: jeep_lj/01-power-systems/07-wire-routing/04-harness-power-distribution.md
+        - 1.7.5 - Build Sheet&#58; Lighting & SwitchPros: jeep_lj/01-power-systems/07-wire-routing/05-harness-lighting-switchpros.md
+        - 1.7.6 - Build Sheet&#58; Controls, Recovery & Drivetrain: jeep_lj/01-power-systems/07-wire-routing/06-harness-controls-recovery-drivetrain.md
       - 1.8 - Load Analysis:
         - jeep_lj/01-power-systems/08-load-analysis/index.md
         - 1.8.1 - Scenarios: jeep_lj/01-power-systems/08-load-analysis/01-scenarios.md


### PR DESCRIPTION
## Goal

Refactor the harness inventory into a builder-focused reference that incorporates the **Jeep LJ Tub Map** diagrams, so whoever is building the harnesses can see — on one page per system — the routing diagram alongside exactly what to fabricate (gauge, color, protective wrap, length, routing, terminations).

## What changed

### Structure — split by tub-map page
The single `03-harness-inventory.md` is split so each tub-map diagram pairs with the harnesses it shows:

| Page | Diagram | Harnesses |
|------|---------|-----------|
| 1.7.3 Harness Inventory (**overview**) | — | Index, H1–H9 summary, wire-color key, harness map, interference assessment, cabin-trunk summary, optimization |
| 1.7.4 Build Sheet — Power Distribution | Power Distribution | H1, H2, H3 |
| 1.7.5 Build Sheet — Lighting & SwitchPros | Lighting & SwitchPros | H4, H5 |
| 1.7.6 Build Sheet — Controls, Recovery & Drivetrain | Controls, Recovery & Drivetrain | H6, H7, H8, H9 |

Each build sheet embeds its diagram, adds a **build-at-a-glance** line per harness (conductor count, longest run, wrap, connectors), and keeps the full conductor tables.

### Wire colors
Every conductor table gains a **Color** column. Per the agreed convention (documented in a new *Wire Color Convention* key on the overview): power = **red**, ground = **black**; CAN = twisted pair; vendor harnesses (SwitchPros/ARB/CH4X4/Kilduff) keep their shipped pigtail colors; non-vendor signal wires are builder's choice (tracked as an Outstanding Item). No specifics were invented.

### Getting the diagrams into the site (general build step)
MkDocs only serves `docs/`, but the diagrams are generated into `export/`. Rather than committing copies, this adds a manifest-driven MkDocs build hook — `hooks/copy_export_assets.py` — that publishes selected `export/` artifacts into the central images location **at build time** (`mkdocs serve`/`build`/any deploy). The diagrams stay in sync with the `.drawio` source automatically, and the hook is reusable for future export assets (add a line to its `ASSETS` map).

## Verification
`mkdocs build` succeeds; the three diagrams publish to `jeep_lj/images/` and all three build sheets render. The new pages and tub-map images produce **no link warnings**. (Remaining build warnings — the `nissan_nv`/`jeep_jku` nav stubs and a few `08-exterior-systems` image-path typos — are pre-existing and untouched here.)

## Note for reviewers
Because the diagrams are published at build time (not committed), the embedded images render in the built MkDocs site but will appear as broken links in GitHub's raw markdown preview of the build sheets. That's expected with this approach and was the explicit goal (deploy-time copy, no committed duplicates).

https://claude.ai/code/session_01VE4o4bjEia1DBDewyMyN1F

---
_Generated by [Claude Code](https://claude.ai/code/session_01VE4o4bjEia1DBDewyMyN1F)_