### PR TITLE
docs: nightly tidiness — trim verbosity (2026-06-02)

### DIFF
--- a/docs/jeep_lj/01-power-systems/04-pmu/03-pmu-outputs.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/03-pmu-outputs.md
@@ -80,17 +80,8 @@ Complete configuration of all 24 PMU outputs, load allocations, and combined out
 
 - PMU thermal protection will shut down overloaded outputs
 - Monitor output temperatures during initial testing (PMU displays thermal status)
-- **iBooster thermal design:** Non-adjacent combining (OUT1+10) provides 46A @ 40°C capacity vs 40A peak load = 87% utilization ✓
 - **Non-adjacent combining recommended** for all high-current loads (>30A) to maximize thermal margin
 - **Continuous loads** (HVAC, fans) require more conservative thermal margins than brief peaks
-
-!!! success "Thermal Analysis - iBooster Resolved"
-**iBooster relocated from OUT5+6 (adjacent) to OUT1+10 (non-adjacent)** per ECUMaster PMU24 manual Section 2.13:
-
-    - Non-adjacent 2.8mm terminals @ 40°C: 46A combined capacity (23A each)
-    - iBooster 40A peak: 87% utilization ✓ Excellent thermal margin
-    - Maximum physical separation eliminates adjacent terminal heating concerns
-    - HVAC blower relocated to OUT5 (single output, 87% utilization, unchanged)
 
 **Grounding Architecture:**
 

--- a/docs/jeep_lj/01-power-systems/04-pmu/04-pmu-programming.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/04-pmu-programming.md
@@ -65,8 +65,6 @@ ELSEIF (J1939_SPN110_CoolantTemp >= 205°F) THEN Out234_RadiatorFan_PWM = 100% /
 - **PWM frequency:** 100-400 Hz (PMU supports 4-400 Hz on 25A outputs)
 - **Temperature source:** J1939 SPN 110 (coolant temp) - same as PS fan
 - **Quieter operation:** Low speed sufficient for highway cruising
-- **Thermal management:** Progressive cooling matches engine demand
-
 **Replaces:** Dakota Digital PAC-2800BT controller, BIM-01-2 adapter (for fan), external relay, 100A circuit breaker
 
 ### Sequential Load Startup
@@ -100,26 +98,12 @@ LOG EngineRPM (J1939_SPN190)
 - **<12.5V** (engine running): Alternator undersized or failing
 - **<11.5V** (engine running): Critical - load exceeds alternator output
 
-**Monitoring Strategy:**
-
-1. **Baseline Testing:** Run engine at idle with all loads off - note voltage (should be 14.2-14.4V)
-2. **Progressive Load Testing:** Add loads incrementally (HVAC → fans → lights) and monitor voltage drop
-3. **Peak Load Testing:** Run all typical simultaneous loads and verify voltage stays >13.5V
-4. **Data Analysis:** Export PMU logs to identify which load combinations cause voltage sag
-
 **Warning Triggers:**
 
 ```text
 IF (BatteryVoltage < 12.5V) AND (EngineRPM > 1000)
   THEN Trigger_Low_Voltage_Warning = ON
 ```
-
-**Use Cases:**
-
-- Verify 270A alternator capacity under real-world loads
-- Identify which load combinations exceed alternator output
-- Monitor battery state of charge during off-grid camping
-- Track battery health over time (voltage recovery patterns)
 
 ### ARB Compressor Load Shedding
 

--- a/docs/jeep_lj/05-control-interfaces/02-switchpros-sp1200.md
+++ b/docs/jeep_lj/05-control-interfaces/02-switchpros-sp1200.md
@@ -143,14 +143,12 @@ Factory Passenger Door Plunger (NO)─┘
 **Configuration:**
 
 - Program Button 4 to control OUTPUT-4 OR TRIGGER-1 → OUTPUT-4
-- Manual control: Press Button 4
-- Automatic control: Open driver or passenger door
 
 **Note:** Rear tailgate replaced factory rear door - no rear door switch needed
 
 ### TRIGGER-2: Rear Rocker Switch → Cargo Light
 
-Physical rocker switch mounted in rear cargo area for convenient access when loading/unloading.
+Physical rocker switch mounted in rear cargo area.
 
 **Wiring:**
 
@@ -161,8 +159,6 @@ Rear Cargo Rocker Switch (SPST) → TRIGGER-2 (Pin 8, PINK)
 **Configuration:**
 
 - Program TRIGGER-2 → OUTPUT-13 (cargo light)
-- No button assignment needed
-- Physical switch location: Rear cargo area (easily accessible from tailgate)
 - Switch type: SPST rocker or toggle switch
 
 ### TRIGGER-3: Air Pressure Switch → Auto Compressor Control

--- a/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
+++ b/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
@@ -61,7 +61,6 @@ The CT4 provides complete turn signal and headlight control:
   - **Brake/Turn wire (Yellow):** Combined brake and turn signal function
   - Wired to CT4 SW1 (right) and SW2 (left) outputs (parallel with front signals)
   - Wire gauge: 14 AWG from CT4 to rear junction
-  - **Note:** Yellow wire handles both brake and turn signal (combined function)
 
 ### Headlight Control
 
@@ -191,11 +190,6 @@ END
 
 - Tap CT4 SW3 output (low beam circuit) to PMU In 7 for headlight status monitoring
 - Use 14 AWG wire from PMU Out 9 to DRL junction
-- PMU Out 9 distributes to:
-  - LP6 Pin 3 (DRL) - both lights
-  - License plate lights
-  - Front LED side markers
-  - Maxbilt tail RED wire (marker/parking)
 - Total DRL circuit load: ~8A (4 circuits: license plate, LP6 DRL, front markers, rear markers)
 - PMU Out 9 capacity: 15A (sufficient for 8A load)
 

--- a/docs/jeep_lj/08-exterior-systems/02-air-compressor.md
+++ b/docs/jeep_lj/08-exterior-systems/02-air-compressor.md
@@ -181,14 +181,6 @@ Compressor fills tank to 150 PSI → pressure switch opens → compressor stops
 
 ---
 
-## Safety Considerations
-
-!!! warning "Compressor Operation"
-    - Monitor compressor duty cycle during extended use
-    - Allow cooling periods if running continuously for tire inflation
-    - Check air line connections regularly for leaks
-    - Drain moisture from tank/system periodically
-
 ## Outstanding Items
 
 - [ ] Verify ARB CKBLTA12 wiring harness connector pinout for motor 1, motor 2, and control terminals


### PR DESCRIPTION
Nightly automated tidiness pass. 5 files edited, 44 lines removed, 0 numbers/specs/identifiers changed.

**Note:** Please apply label `tidiness` (create it if missing — it doesn't exist yet in this repo).

## Changes

| File | Lines before → after | What was cut | Which persona it failed |
| :--- | :-------------------: | :----------- | :---------------------- |
| `08-exterior-systems/02-air-compressor.md` | 209 → 201 | "Safety Considerations" `!!! warning` block — 4 bullets of generic maintenance advice (duty cycle monitoring, cooling periods, leak checks, drain moisture). The CKBLTA12 is rated 100% duty cycle, so two bullets contradict the spec table on the same page; the others are standard practice. | Mechanic/Installer: standard practice not specific to this build |
| `01-power-systems/04-pmu/03-pmu-outputs.md` | 121 → 112 | (1) `!!! success "Thermal Analysis - iBooster Resolved"` callout — 7 lines restating numbers already in the thermal table (46A @ 40°C, 87% utilisation, HVAC relocation). (2) One Installation Notes bullet repeating the same table figures. | All personas: same data in the table two paragraphs above |
| `01-power-systems/04-pmu/04-pmu-programming.md` | 168 → 152 | (1) "Monitoring Strategy" section (4 numbered steps) — generic commissioning procedure; voltage targets already in the Critical Voltage Thresholds table above. (2) "Use Cases" section (4 bullets) — obvious purposes of battery monitoring. (3) One "Thermal management: Progressive cooling matches engine demand" bullet from PWM Benefits — definitional restatement. | Owner/Designer: rationale not needed; Parts Buyer/Mechanic: not actionable |
| `05-control-interfaces/02-switchpros-sp1200.md` | 236 → 232 | TRIGGER-1 config: removed "Manual control: Press Button 4" and "Automatic control: Open driver or passenger door" bullets (restate the programming line above them). TRIGGER-2: removed "for convenient access when loading/unloading" phrase; removed "No button assignment needed" and "Physical switch location: Rear cargo area (easily accessible from tailgate)" bullets (duplicates of the preceding sentence). | Mechanic/Installer: all restated from the same paragraph |
| `05-control-interfaces/03-command-touch-ct4.md` | 308 → 302 | (1) "Note: Yellow wire handles both brake and turn signal (combined function)" — identical to the bullet directly above it. (2) "PMU Out 9 distributes to: [4-item sub-list]" inside the PMU DRL Auto-Off Logic Installation Notes — exact duplicate of the list at the top of the DRL/Parking Lights subsection on the same page. | All personas: verbatim duplicate within the same file |

## Build verification

- `mkdocs build` passes with no new warnings — all pre-existing lint/build warnings are unchanged.
- `mkdocs build --strict` fails with `tags_file` deprecation warning — **pre-existing** on `main` before any edits; not caused by this PR.
- `markdownlint-cli2` reports 14 errors — **identical set on unmodified `main`**; my edits introduced zero new lint issues.

## Left for human judgment

- **CT4 "How It Works" walkthrough** (lines 171–188): 18-line plain-language breakdown of the DRL auto-off logic that restates the 4-line pseudocode block above it. Left in because the walkthrough aids real-time troubleshooting (check each state against expected behaviour) — borderline restatement vs. troubleshooter value.
- **SwitchPros Power and Ground Connections section** (lines 115–121): partially duplicates the `product-info` div at the top of the same file, but the prose section adds the full AUX→CB→bus→SwitchPros signal chain in one line that the div abbreviates. Left in.
- **Brake booster (`02-brake-booster.md`)**: surveyed thoroughly; every prose section is build-specific rationale, sourced specs, or non-obvious installation constraints. No confident cuts found — file is already lean for its complexity.
- **`markdownlint-cli2` pre-existing errors**: 14 MD060/MD032 errors in tables and wire-routing lists across these files. Not caused by this PR; fixing them would touch tables (touching tables risks changing spec data) — left for a dedicated linting pass.

https://claude.ai/code/session_017A6gjetTJndLNMDsGq64fz

---
_Generated by [Claude Code](https://claude.ai/code/session_017A6gjetTJndLNMDsGq64fz)_