### PR TITLE
Fix active nav link indent (top-level TBD Tracker clipped)

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -84,13 +84,17 @@
   text-transform: uppercase;
 }
 
-/* Highlight current/active navigation item with background */
+/* Highlight current/active navigation item with background.
+   Keep the same left indent as inactive links (0.8rem padding + 0.2rem margin,
+   per the base .md-nav__link rule) so a top-level page link (e.g. TBD Tracker)
+   aligns with siblings instead of bleeding to the sidebar edge. Nested items
+   get their level indent from the container, so this matches at every depth. */
 .md-sidebar__inner .md-nav--primary .md-nav__item a.md-nav__link--active {
   background-color: rgba(99, 102, 241, 0.1);
   font-weight: 600;
   border-radius: 4px;
-  padding: 0.5rem 0.75rem 0.5rem 0;
-  margin: 0.25rem 0;
+  padding: 0.5rem 0.75rem 0.5rem 0.8rem;
+  margin: 0.25rem 0.2rem;
 }
 
 /* Section headings - uppercase with horizontal line separator */


### PR DESCRIPTION
## Problem

The promoted top-level **TBD Tracker** nav link rendered flush against the sidebar's left edge with its text clipped, and the active highlight bled past the gutter.

## Cause

A pre-existing rule in `docs/stylesheets/extra.css` for the active nav item hardcoded `padding-left: 0` and `margin-left: 0`. Nested pages get their indent from the nav container, so this was invisible — but TBD Tracker is the first **top-level page link** in the LJ section (promoted in #45), and at level 0 there's no container indent, so the link sat at x=0.

## Fix

Restore the base link indent (`0.8rem` padding + `0.2rem` margin) on the active link. The container still supplies per-level indent, so this aligns active items with their inactive siblings at every depth (verified: active text padding-left now 16px, matching "Home").

🤖 Generated with [Claude Code](https://claude.com/claude-code)