### PR TITLE
Resolve nightly health digest #44 + reconcile DRL load analysis

### DIFF
--- a/docs/jeep_jku/index.md
+++ b/docs/jeep_jku/index.md
@@ -1,0 +1,8 @@
+---
+hide:
+  - toc
+---
+
+# Jeep Wrangler JKU
+
+Documentation for the Jeep Wrangler JKU is not yet started. Content will be added here as the project develops.

--- a/docs/jeep_lj/01-power-systems/01-power-generation/02-alternator.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/02-alternator.md
@@ -69,8 +69,35 @@ See [START Battery Load Analysis][start-load-analysis] for complete scenario det
 
 ## Outstanding Items
 
-- [ ] Determine alternator positive output terminal size (for 1/0 AWG lug selection)
-- [ ] Verify alternator voltage regulator set point (14.2-14.4V for AGM batteries)
+- [ ] Determine alternator positive output terminal size (for 1/0 AWG lug selection) — see [Vendor Inquiry](#vendor-inquiry) below
+- [ ] Verify alternator voltage regulator set point (14.2–14.4V is the correct AGM target;[^agm-target] confirm the HO-C28 actually regulates there) — see [Vendor Inquiry](#vendor-inquiry) below
+
+## Vendor Inquiry — Premier Power Welder (draft) {#vendor-inquiry}
+
+Both open items above are answered by one email to Premier Power Welder:
+
+```text
+Subject: HO-C28 (Cummins R2.8 270A) — output stud size & regulator set point
+
+Hi Premier Power Welder,
+
+I'm wiring the HO-C28 270A alternator (Cummins R2.8) into a dual-battery
+truck and need two specs to finish the install:
+
+1. Output terminal: what is the thread/stud size of the positive output
+   post? I'm sizing a ring lug for 1/0 AWG cable and want the correct
+   stud diameter (e.g. 1/4"-20, 5/16"-18, M8, etc.).
+
+2. Voltage regulation: what is the regulator set point, and is it
+   suitable for AGM batteries (target ~14.2-14.4V at the battery)? Is the
+   regulator internal and fixed, or adjustable? My START battery is AGM.
+
+Application: HO-C28 on a Cummins R2.8 Repower, charging an AGM start
+battery (~850 CCA).
+
+Thanks,
+[name]
+```
 
 ## Related Documentation
 
@@ -84,3 +111,5 @@ See [START Battery Load Analysis][start-load-analysis] for complete scenario det
 [start-load-analysis]: ../08-load-analysis/02-start-battery.md
 [grounding]: ../05-grounding/index.md
 [wire-distance]: 05-wire-distance-reference.md
+
+[^agm-target]: AGM batteries take an absorption/charge voltage of ~14.2–14.7V at the terminals (mfr range 14.0–14.7V), so the 14.2–14.4V target is correct; many stock regulators sit lower (13.8–14.0V) and undercharge AGM. The target is validated — what remains is confirming the HO-C28's actual set point (vendor or field measurement). General AGM charging references (Victron / battery-mfr guidance), accessed 2026-06-03.

--- a/docs/jeep_lj/01-power-systems/04-pmu/01-pmu-overview.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/01-pmu-overview.md
@@ -62,7 +62,7 @@ tags:
 
 **Utilization:** 23 of 24 outputs used (96%)
 
-**Primary loads:** Radiator fan (OUT2+3+4: 3×25A combined), iBooster (OUT1+10: 2×25A non-adjacent), HVAC (OUT5: 25A), GMRS radio (OUT6: 25A), aux fans (OUT7+8: 2×15A), Dakota Digital (OUT9: 25A), wipers (OUT11: 15A), Ham radio (OUT12: 15A), CT4 (OUT13: 15A), DRL (OUT14: 15A), winch trigger (OUT15: 15A), Turbolamik TCU (OUT16: 15A), A/C clutch (OUT17: 7A), horn (OUT18: 7A), iBooster ignition (OUT19: 7A), intercom (OUT20: 7A), brake lights (OUT21: 7A), reverse lights (OUT22: 7A)
+**Primary loads:** Radiator fan (OUT2+3+4: 3×25A combined), iBooster (OUT1+10: 2×25A non-adjacent), HVAC (OUT5: 25A), GMRS radio (OUT6: 25A), aux fans (OUT7+8: 2×15A), Dakota Digital (OUT9: 25A), wipers (OUT11: 15A), Ham radio (OUT12: 15A), CT4 (OUT13: 15A), winch trigger (OUT15: 15A), Turbolamik TCU (OUT16: 15A), A/C clutch (OUT17: 7A), horn (OUT18: 7A), iBooster ignition (OUT19: 7A), intercom (OUT20: 7A), brake lights (OUT21: 7A), reverse lights (OUT22: 7A), DRL/parking (OUT23: 7A)
 
 **Load:** ~253A theoretical peak (all radios transmitting + full radiator fan + iBooster braking), ~106A typical PMU circuits continuous (excluding radiator fan which varies 16-53A via PWM), total typical load ~140-170A (well within 300A PMU capacity)
 

--- a/docs/jeep_lj/01-power-systems/04-pmu/02-pmu-inputs.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/02-pmu-inputs.md
@@ -31,7 +31,7 @@ See [Ignition Signal Distribution][ignition-signal] for complete wiring architec
 | **In 4** | **\[Available\]**    | -                            | -                       | Available for future expansion           |
 | **In 5** | **\[Available\]**    | -                            | -                       | Available for future expansion           |
 | **In 6** | **\[Available\]**    | -                            | -                       | Available for future expansion           |
-| **In 7** | CT4 SW3 (Headlights) | CT4 lever pull               | Out 14 (DRL) logic      | 12V when headlights active, disables DRL |
+| **In 7** | CT4 SW3 (Headlights) | CT4 lever pull               | Out 23 (DRL) logic      | 12V when headlights active, disables DRL |
 | **In 8** | **\[Available\]**      | -                            | -                       | Available for future expansion           |
 | **In 9** | A/C Request          | Factory TJ A/C button signal | Out 17 (A/C Clutch)     | 12V when factory dash A/C button pressed |
 

--- a/docs/jeep_lj/01-power-systems/04-pmu/03-pmu-outputs.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/03-pmu-outputs.md
@@ -47,7 +47,7 @@ Complete configuration of all 24 PMU outputs, load allocations, and combined out
 | **Out 20** | STX Intercom             | ~5A  | [Direct START battery-][starter-battery-distribution] | Auto (ignition ON)  | RF noise isolation             |
 | **Out 21** | Brake Lights             | ~3A  | [SwitchPros Ground Bus][switchpros-ground]            | External input      | Shared tail light ground       |
 | **Out 22** | Reverse Lights           | ~5A  | [SwitchPros Ground Bus][switchpros-ground]            | External input      | Maxbilt + Squadron Sport       |
-| **Out 23** | DRL/Parking Lights       | ~2A  | [SwitchPros Ground Bus][switchpros-ground]            | Auto (ignition)     | See [DRL & Parking][drl-parking-lights] |
+| **Out 23** | DRL/Parking Lights       | ~2.6A | [SwitchPros Ground Bus][switchpros-ground]           | Auto (ignition)     | See [DRL & Parking][drl-parking-lights] |
 | **Out 24** | **[Available]**          | -    | -                                                     | -                   | Available for future expansion (7A)                                                                                                                          |
 
 ## Combined Outputs

--- a/docs/jeep_lj/01-power-systems/04-pmu/04-pmu-programming.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/04-pmu-programming.md
@@ -109,7 +109,7 @@ IF (BatteryVoltage < 12.5V) AND (EngineRPM > 1000)
 
 **Purpose:** Automatically shed non-critical loads when ARB compressor runs (90A) to prevent exceeding 270A alternator capacity.
 
-**Summary:** Detects ARB activation and disables DRL (8A), A/C (5A), and conditionally oil/PS cooler fans (15A each) to reduce total load from 271A to 243A, providing +27A alternator margin during tire inflation.
+**Summary:** Detects ARB activation and disables DRL (~2.6A), A/C (5A), and conditionally oil/PS cooler fans (15A each) to reduce total load from 266A to 243A, providing +27A alternator margin during tire inflation.
 
 **See:** [ARB Load Shedding Logic][arb-load-shedding] for complete implementation details, load analysis, testing procedures, and operator guidelines.
 

--- a/docs/jeep_lj/01-power-systems/04-pmu/04-pmu-programming.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/04-pmu-programming.md
@@ -9,12 +9,12 @@ PMU configuration examples, logic sequences, and implementation checklist.
 
 ## Programming Examples
 
-### DRL Auto-Off Logic (Output 14)
+### DRL Auto-Off Logic (Output 23)
 
 ```text
 IF (Pin7_IgnitionRUN == ON) AND (In7_CT4_Headlights == OFF)
-  THEN Out14_DRL = ON
-ELSE Out14_DRL = OFF
+  THEN Out23_DRL = ON
+ELSE Out23_DRL = OFF
 ```
 
 DRL on with ignition, off when headlights active.

--- a/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
@@ -65,7 +65,7 @@ Detect ARB compressor activation and disable non-critical START battery loads to
 IF (SwitchPros_OUT11_ARB == ON) OR (BatteryVoltage < 13.0V AND EngineRPM > 1000):
 
   // Shed non-critical loads (priority order: lowest to highest impact)
-  Out14_DRL = OFF              // -8A: Daytime running lights (cosmetic)
+  Out23_DRL = OFF              // -8A: Daytime running lights (cosmetic)
   Out17_AC_Clutch = OFF        // -5A: Air conditioning (comfort)
 
   // Conditionally shed cooler fans if temperatures allow
@@ -82,7 +82,7 @@ IF (SwitchPros_OUT11_ARB == ON) OR (BatteryVoltage < 13.0V AND EngineRPM > 1000)
 
 ELSE:
   // Restore normal operation when ARB stops
-  Out14_DRL = (Per DRL auto-off logic)
+  Out23_DRL = (Per DRL auto-off logic)
   Out17_AC_Clutch = (Per A/C request logic)
   Out7_OilFan = (Per oil temp thresholds)
   Out8_PSFan = (Per coolant temp thresholds)
@@ -93,7 +93,7 @@ ELSE:
 
 | Load Shed             | Current Saved | Impact                       | When Disabled         |
 | :-------------------- | :------------ | :--------------------------- | :-------------------- |
-| DRL (OUT14)           | 8A            | Low - cosmetic only          | Always when ARB runs  |
+| DRL (OUT23)           | 8A            | Low - cosmetic only          | Always when ARB runs  |
 | A/C Clutch (OUT17)    | 5A            | Medium - comfort loss        | Always when ARB runs  |
 | Oil Cooler Fan (OUT7) | 15A           | Low - if oil temp <220°F     | Temperature-dependent |
 | PS Cooler Fan (OUT8)  | 15A           | Low - if coolant temp <210°F | Temperature-dependent |
@@ -288,7 +288,7 @@ ELSE:
 LOG BatteryVoltage (1 Hz)
 LOG TotalCurrent_PMU (1 Hz)
 LOG EngineRPM (J1939_SPN190)
-LOG Out14_DRL (state)
+LOG Out23_DRL (state)
 LOG Out17_AC_Clutch (state)
 LOG Out7_OilFan (state)
 LOG Out8_PSFan (state)

--- a/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
@@ -65,7 +65,7 @@ Detect ARB compressor activation and disable non-critical START battery loads to
 IF (SwitchPros_OUT11_ARB == ON) OR (BatteryVoltage < 13.0V AND EngineRPM > 1000):
 
   // Shed non-critical loads (priority order: lowest to highest impact)
-  Out23_DRL = OFF              // -8A: Daytime running lights (cosmetic)
+  Out23_DRL = OFF              // -2.6A: Daytime running lights (cosmetic)
   Out17_AC_Clutch = OFF        // -5A: Air conditioning (comfort)
 
   // Conditionally shed cooler fans if temperatures allow
@@ -75,7 +75,7 @@ IF (SwitchPros_OUT11_ARB == ON) OR (BatteryVoltage < 13.0V AND EngineRPM > 1000)
   IF (J1939_SPN110_CoolantTemp < 210°F):
     Out8_PSFan = OFF           // -15A: PS cooler fan (temp-dependent)
 
-  // Total load reduction: 28-43A depending on temperatures
+  // Total load reduction: ~8-38A depending on temperatures
 
   // Optional: Trigger dashboard indicator
   Out_ARB_Active_Indicator = ON  // Visual feedback to driver
@@ -93,11 +93,11 @@ ELSE:
 
 | Load Shed             | Current Saved | Impact                       | When Disabled         |
 | :-------------------- | :------------ | :--------------------------- | :-------------------- |
-| DRL (OUT23)           | 8A            | Low - cosmetic only          | Always when ARB runs  |
+| DRL (OUT23)           | 2.6A          | Low - cosmetic only          | Always when ARB runs  |
 | A/C Clutch (OUT17)    | 5A            | Medium - comfort loss        | Always when ARB runs  |
 | Oil Cooler Fan (OUT7) | 15A           | Low - if oil temp <220°F     | Temperature-dependent |
 | PS Cooler Fan (OUT8)  | 15A           | Low - if coolant temp <210°F | Temperature-dependent |
-| **Total Saved**       | **28-43A**    | -                            | -                     |
+| **Total Saved**       | **~8-38A**    | -                            | -                     |
 
 ## AUX Battery Impact Analysis
 
@@ -124,13 +124,13 @@ Time to 50% SOC:         45 minutes
 - Alternator: 270A
 - **Margin: +105A** Alternator is NOT the constraint
 
-### WITH Load Shedding (Minimum - 13A shed from START)
+### WITH Load Shedding (Minimum - ~8A shed from START)
 
-Shedding DRL (8A) and A/C clutch (5A) from PMU reduces START battery load, allowing maximum BCDC output:
+Shedding DRL (~2.6A) and A/C clutch (5A) from PMU reduces START battery load, allowing maximum BCDC output:
 
 ```text
 START battery:
-PMU reduced:          93A   (was 106A, shed DRL + A/C)
+PMU reduced:          93A   (was 101A, shed DRL + A/C)
 Radiator fan:         35A   (moderate, stationary)
 BCDC at full rate:    50A   (maximized)
 ─────────────────────────────
@@ -148,7 +148,7 @@ Net AUX drain:        45A   (unchanged - BCDC still maxed)
 
 **Primary benefit:** Ensures BCDC maintains full 50A output even if START battery voltage sags.
 
-### WITH Load Shedding (Maximum - 43A shed from START)
+### WITH Load Shedding (Maximum - ~38A shed from START)
 
 **When oil/coolant temps allow disabling cooler fans:**
 

--- a/docs/jeep_lj/01-power-systems/05-grounding/03-switchpros-ground-bus.md
+++ b/docs/jeep_lj/01-power-systems/05-grounding/03-switchpros-ground-bus.md
@@ -40,7 +40,7 @@ tags:
 | Terminal 2 (#10-24)     | Headlights (LP6) - pair 1         | 16 AWG ✓      | ~10 ft       | ~8A             | See [Headlights][headlights]           |
 | Terminal 3 (#10-24)     | Headlights (LP6) - pair 2         | 16 AWG ✓      | ~10 ft       | ~8A             | See [Headlights][headlights]           |
 | Terminal 4 (#10-24)     | Tail/brake/reverse (PMU OUT21+22) | 16 AWG ✓      | ~12 ft       | ~6A             | Integrated unit, single ground wire    |
-| Terminal 5 (#10-24)     | DRL/Parking (PMU OUT14)           | 16 AWG ✓      | ~10 ft       | ~8A             | Front marker/DRL lights                |
+| Terminal 5 (#10-24)     | DRL/Parking (PMU OUT23)           | 16 AWG ✓      | ~10 ft       | ~2.6A           | Front marker/DRL lights                |
 | Terminal 6 (#10-24)     | Roof lights (8x XL Sport)         | 14 AWG ✓      | ~8 ft        | ~18A            | Single circuit via XL Linkable harness |
 | Terminal 7 (#10-24)     | Ditch lights                      | 16 AWG ✓      | ~8 ft        | ~8A             | Auxiliary lighting                     |
 | Terminal 8 (#10-24)     | Rock lights                       | 16 AWG ✓      | ~6 ft        | ~5A             | Auxiliary lighting                     |

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/02-firewall-ingress.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/02-firewall-ingress.md
@@ -18,7 +18,7 @@ All firewall penetration points for wire routing between engine bay and cabin.
 
 ---
 
-## Deutsch HDP20 Bulkhead Connector
+## Deutsch HDP24-24-29 Bulkhead Connector
 
 Single weatherproof bulkhead connector for all custom wiring through firewall.
 

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/06-harness-controls-recovery-drivetrain.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/06-harness-controls-recovery-drivetrain.md
@@ -135,6 +135,7 @@ See [Transmission][transmission] for shifter and TCU specs.
 | J1939 CAN Low | Twisted pair (paired with CAN High) | Twisted pair (CAN) | Shared J1939 bus tap | CAN bus tap point | TCU CAN-L |
 | Aux out (Reverse) | 18 AWG | Builder's choice | TCU aux output: 12V when shifter in R → PMU In 3 (drives PMU OUT22 reverse lights) | TCU aux Reverse pin | PMU In 3 |
 | Aux out (P/N) | 18 AWG | Builder's choice | TCU aux output: 12V when shifter in P or N → starter P/N interlock relay coil | TCU aux P/N pin | Starter P/N interlock relay coil+ |
+| Brake input | 18 AWG | Builder's choice | Dedicated brake-pedal signal for unlock-from-Park (separate from PMU In 2 tap) — crosses firewall via HDP24 | Cabin brake pedal switch | TCU brake input pin |
 | TCU ground | 14 AWG | Black | TCU ground return | TCU ground terminal | Engine bay ground bus |
 
 **Connectors:**
@@ -146,9 +147,9 @@ See [Transmission][transmission] for shifter and TCU specs.
 
 **Notes:**
 
-- All endpoints are in engine bay — no firewall penetration needed
+- Engine-bay endpoints need no firewall penetration; the one exception is the brake-switch input below, which originates at the cabin brake pedal switch
 - J1939 CAN tap is shared with PMU and Dakota Digital BIM-01-2 — the TCU is a third node on the same bus (just adds a splice at the existing tap point)
-- The brake switch input to TCU (for unlock-from-Park) is sourced from the cabin brake pedal switch (which already feeds PMU In 2 via HDP24 pin 13) — could share routing or take a separate tap; routing TBD
+- **Brake switch input to TCU (for unlock-from-Park): dedicated wire** (decided 2026-06-03). A separate 18 AWG conductor runs from the cabin brake pedal switch through the firewall (HDP24, dedicated pin) to the TCU brake input — **not** a shared tap off the PMU In 2 feed. A dedicated wire keeps the TCU and PMU brake-sense paths electrically independent (a fault or load on one cannot disturb the other) at the cost of one added HDP24 contact
 - TCU is one of three controllers tightly coupled to the engine bay: PMU24 (mounted on firewall), Dakota Digital BIM modules (on HDPE panel cabin side), and TCU (mounted on transmission). All share the J1939 CAN bus.
 
 See [Transmission][transmission] and [PMU Outputs][pmu-outputs] for related details.

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/index.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/index.md
@@ -105,7 +105,7 @@ All wire runs require appropriate protection based on location and environment:
 
 | Component                              | Wire Gauge | Distance | Source/Destination                         | Notes                                           |
 | :------------------------------------- | :--------- | :------- | :----------------------------------------- | :---------------------------------------------- |
-| **Firewall CONSTANT Bus (input)**      | 2/0 AWG    | ~13 ft   | FROM AUX battery+ via 300A master CB       | Heavy feed through cabin trunk - routing TBD    |
+| **Firewall CONSTANT Bus (input)**      | 2/0 AWG    | ~13 ft   | FROM AUX battery+ via 300A master CB       | Heavy feed via H1: passenger floor/side wall → A-pillar → firewall (resolved 2026-05-30) |
 | **Bus → SwitchPros**                   | 2 AWG      | ~2 ft    | TO SwitchPros power module                 | Via 150A CB                                     |
 | **Bus → BODY PDU**                     | 2 AWG      | ~2 ft    | TO BODY PDU                                | Via 100A CB                                     |
 | **AUX bat → JL Audio MV800/8i Amp**    | 4 AWG      | ~3-4 ft  | TO MV800/8i amp (under rear seat)          | Via 100A CB at AUX battery (not via firewall bus) |
@@ -122,13 +122,13 @@ All wire runs require appropriate protection based on location and environment:
 | Penetration | Location | Direction | Circuits | Wire Count | Notes |
 |:------------|:---------|:----------|:---------|:-----------|:------|
 | **Cummins Harness** | Factory location | Engine ↔ Cabin | Engine harness, J1939 CAN | Factory | Dedicated bulkhead connector |
-| **Deutsch HDP20** | TBD (near PMU) | Bidirectional | All custom wiring | 17 | Single weatherproof connector |
+| **Deutsch HDP24-24-29** | TBD (near PMU) | Bidirectional | All custom wiring | 17 | Single weatherproof connector |
 | **Temp Probe Grommet** | Near grille | Cabin → Grille | BIM-17-2 temp sensor | 2 (22 AWG) | Small grommet, twisted pair |
 
 !!! info "J1939 CAN Bus"
 J1939 CAN High/Low wires tap into Cummins harness at firewall punch-through, then route to Dakota Digital 01-2-J1939 module on firewall HDPE panel (cabin side).
 
-**Complete Details:** See [Firewall Ingress][firewall-ingress] for Deutsch HDP20 connector pinout and BOM
+**Complete Details:** See [Firewall Ingress][firewall-ingress] for Deutsch HDP24-24-29 connector pinout and BOM
 
 ---
 

--- a/docs/jeep_lj/01-power-systems/08-load-analysis/02-start-battery.md
+++ b/docs/jeep_lj/01-power-systems/08-load-analysis/02-start-battery.md
@@ -30,7 +30,7 @@ All circuits powered by START battery (alternator charging):
 | OUT20            | STX Intercom      |      1A |       5A | Brief TX bursts        | Standby vs transmit   |
 | OUT21            | Brake Lights      |      0A |       3A | Seconds during braking | Traffic-dependent     |
 | OUT22            | Reverse Lights    |      0A |       3A | Seconds in reverse     | Parking only          |
-| OUT23            | DRL               |      8A |       8A | Daytime only           | Auto-off at night     |
+| OUT23            | DRL               |    2.6A |     2.6A | Daytime only           | Auto-off at night     |
 | **BCDC Charger** |                   |         |          |                        |                       |
 | -                | BCDC to AUX       |     30A |      50A | Continuous             | Charges AUX battery   |
 | **Direct Loads** |                   |         |          |                        |                       |
@@ -57,11 +57,11 @@ All circuits powered by START battery (alternator charging):
 | **CT4 (OUT13)**               |   **10A** | Running lights              |
 | **iBooster Ignition (OUT19)** |    **5A** | Always on                   |
 | **STX Intercom (OUT20)**      |    **1A** | Standby                     |
-| **DRL (OUT23)**               |    **8A** | Daytime                     |
+| **DRL (OUT23)**               |    **2.6A** | Daytime                     |
 | **BCDC Charger**              |   **30A** | Maintaining AUX             |
-| **TOTAL**                     |  **106A** |                             |
+| **TOTAL**                     |  **101A** |                             |
 
-**Alternator Load:** 106A of 270A capacity = **39% utilization** Excellent
+**Alternator Load:** 101A of 270A capacity = **37% utilization** Excellent
 
 ---
 
@@ -84,11 +84,11 @@ All circuits powered by START battery (alternator charging):
 | **iBooster Ignition (OUT19)** |   **5A** | Always on                    |
 | **STX Intercom (OUT20)**      |   **1A** | Standby                      |
 | **Brake Lights (OUT21)**      |   **1A** | Average - traffic            |
-| **DRL (OUT23)**               |   **8A** | Daytime                      |
+| **DRL (OUT23)**               |   **2.6A** | Daytime                      |
 | **BCDC Charger**              |  **40A** | Higher rate                  |
-| **TOTAL**                     | **193A** |                              |
+| **TOTAL**                     | **188A** |                              |
 
-**Alternator Load:** 193A of 270A capacity = **71% utilization** Good
+**Alternator Load:** 188A of 270A capacity = **70% utilization** Good
 
 ---
 
@@ -109,11 +109,11 @@ All circuits powered by START battery (alternator charging):
 | **CT4 (OUT13)**               |  **10A** | Running lights                    |
 | **iBooster Ignition (OUT19)** |   **5A** | Always on                         |
 | **STX Intercom (OUT20)**      |   **3A** | Occasional TX                     |
-| **DRL (OUT23)**               |   **8A** | Daytime                           |
+| **DRL (OUT23)**               |   **2.6A** | Daytime                           |
 | **BCDC Charger**              |  **50A** | Full rate - supporting SwitchPros |
-| **TOTAL**                     | **206A** |                                   |
+| **TOTAL**                     | **201A** |                                   |
 
-**Alternator Load:** 206A of 270A capacity = **76% utilization** Good
+**Alternator Load:** 201A of 270A capacity = **74% utilization** Good
 
 **Note:** Offroad lighting (SwitchPros) draws from AUX battery, not alternator.
 
@@ -177,13 +177,13 @@ All circuits powered by START battery (alternator charging):
 
 | Scenario          | Total Load | Alternator | Utilization | Status    |
 | :---------------- | :--------- | :--------- | :---------- | :-------- |
-| Highway Driving   | 106A       | 270A       | 39%         | Excellent |
-| Hot City Driving  | 193A       | 270A       | 71%         | Good      |
-| Offroad Trail     | 206A       | 270A       | 76%         | Good      |
+| Highway Driving   | 101A       | 270A       | 37%         | Excellent |
+| Hot City Driving  | 188A       | 270A       | 70%         | Good      |
+| Offroad Trail     | 201A       | 270A       | 74%         | Good      |
 | Emergency Braking | 165A       | 270A       | 61%         | Excellent |
 | Parked Idling     | 122A       | 270A       | 45%         | Excellent |
 
-**Worst Realistic Case:** 206A (offroad with hot engine) = **64A margin**
+**Worst Realistic Case:** 201A (offroad with hot engine) = **69A margin**
 
 **Key Insight:** All realistic scenarios stay well within alternator capacity. The 270A alternator provides adequate margin for all operating conditions.
 

--- a/docs/jeep_lj/01-power-systems/CLAUDE.md
+++ b/docs/jeep_lj/01-power-systems/CLAUDE.md
@@ -41,7 +41,7 @@ Ignition sense signal to CT4, SwitchPros, Fusion Radio, BCDC
 | Section                | Power Connection                               | Find In                     |
 | :--------------------- | :--------------------------------------------- | :-------------------------- |
 | Engine Systems (2)     | HVAC→OUT5, Fan→OUT2+3+4, Starter direct        | `02-engine-systems/`        |
-| Lighting (3)           | DRL→OUT14, Brake→OUT21, Reverse→OUT22          | `03-lighting-systems/`      |
+| Lighting (3)           | DRL→OUT23, Brake→OUT21, Reverse→OUT22          | `03-lighting-systems/`      |
 | Control Interfaces (4) | CT4→OUT13, Dakota→OUT9, SwitchPros→AUX 150A CB | `05-control-interfaces/`    |
 | Audio (5)              | Fusion→BODY PDU                                | `06-audio-systems/`         |
 | Communication (6)      | Radios→PMU OUT6/20                             | `07-communication-systems/` |

--- a/docs/jeep_lj/02-engine-systems/07-grid-heater.md
+++ b/docs/jeep_lj/02-engine-systems/07-grid-heater.md
@@ -30,6 +30,17 @@ tags:
 
 ///
 
+## Specifications
+
+| Spec              | Value                                              |
+| :---------------- | :------------------------------------------------- |
+| Type              | Cold-start air intake heater                       |
+| Relay part number | Cummins 5467024                                    |
+| Coil control      | ECM pins 46/21 (~0.5–1A)                           |
+| Element current   | 40–80A (design estimate)[^grid-current]            |
+| Duty cycle        | 3–5 s during cold start (ECM-controlled)           |
+| Protection        | Integrated fusible link                            |
+
 ## System Architecture
 
 1. **ECM Control (Direct):**

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/03-bim-j1939.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/03-bim-j1939.md
@@ -39,7 +39,7 @@ Interfaces Cummins R2.8 ECM J1939 CAN bus data with HDX instrument system. Provi
 - **Compatible ECUs:** Cummins R2.8, Mercury Racing SBF, BIGStuff EFI
 - **Wiring:** CAN High, CAN Low (twisted pair)
 - **Power:** Via BIM harness from HDX control
-- **Current Draw:** TBD (powered via BIM cable)
+- **Current Draw:** Negligible — bus-powered via the HDX BIM/IO cable (no separate feed); draw is included in the HDX system budget on PMU OUT9 (25A cap, ~12A typ). Dakota Digital publishes no per-module current for these data modules (only power modules like the BIM-RGB, 7.4A, list a figure).
 
 ## J1939 Data Available
 

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/04-bim-gps.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/04-bim-gps.md
@@ -41,7 +41,7 @@ GPS-based speedometer, compass, altimeter, and clock sync module. Eliminates nee
 - **Accuracy:** ±0.1 MPH (GPS-dependent)
 - **Output Signals:** 4k, 8k, 16k PPM (selectable)
 - **Signal Types:** Sine wave or square wave (configurable)
-- **Current Draw:** TBD (powered via BIM cable)
+- **Current Draw:** Negligible — bus-powered via the HDX BIM/IO cable (no separate feed); draw is included in the HDX system budget on PMU OUT9 (25A cap, ~12A typ). Dakota Digital publishes no per-module current for these data modules (only power modules like the BIM-RGB, 7.4A, list a figure).
 - **Antenna:** Integrated omni-directional (optional external antenna available)
 - **Warranty:** 2 years
 

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/05-bim-tpms.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/05-bim-tpms.md
@@ -41,7 +41,7 @@ Wireless TPMS module displaying real-time tire pressure for all four wheels on H
 - **Communication:** Wireless RF (sensors → BIM-22-3 receiver)
 - **Display:** Dashboard message center shows all 4 tire pressures
 - **Programming:** Sensors easily reprogrammed via Bluetooth app
-- **Current Draw:** TBD (powered via BIM cable)
+- **Current Draw:** Negligible — bus-powered via the HDX BIM/IO cable (no separate feed); draw is included in the HDX system budget on PMU OUT9 (25A cap, ~12A typ). Dakota Digital publishes no per-module current for these data modules (only power modules like the BIM-RGB, 7.4A, list a figure).
 - **Compatibility:** HDX, RTX, GRFX systems (limited VFD3/VHX compatibility)
 
 ## Display Integration

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/06-bim-compass.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/06-bim-compass.md
@@ -39,7 +39,7 @@ tags:
 - Directions: 8-point (N, NE, E, SE, S, SW, W, NW)
 - Internal Resolution: 1° (displayed as 8 directions)
 - Calibration: Automatic via internal accelerometers
-- Current Draw: TBD (powered via BIM cable)
+- Current Draw: Negligible — bus-powered via the HDX BIM/IO cable (no separate feed); draw is included in the HDX system budget on PMU OUT9 (25A cap, ~12A typ). Dakota Digital publishes no per-module current for these data modules (only power modules like the BIM-RGB, 7.4A, list a figure).
 
 **Temperature (SEN-15-1 Sender Included):**
 

--- a/docs/jeep_lj/03-lighting-systems/01-lighting-overview.md
+++ b/docs/jeep_lj/03-lighting-systems/01-lighting-overview.md
@@ -49,7 +49,7 @@ This section covers all street-legal DOT-required lighting circuits controlled b
 
 ### DRL & Parking Lights {#drl-parking-overview}
 
-- **Circuit:** PMU Out 23 (7A capacity, ~2A load)
+- **Circuit:** PMU Out 23 (7A capacity, ~2.6A load)
 - **Components:** LP6 DRL, Maxbilt tail markers
 - **Control:** Automatic with ignition, PMU logic disables when headlights on
 - **No external relay needed** - handled by PMU programming
@@ -61,7 +61,7 @@ This section covers all street-legal DOT-required lighting circuits controlled b
 | :------------------ | :--------------------- | :------- | :------ |
 | CT4 Controller      | START battery CONSTANT | 40A      | ~20A    |
 | Headlights Low/High | CT4 SW3/SW4            | 10A each | 3.6/5.6A|
-| DRL/Parking         | PMU Out 23             | 7A       | ~2A     |
+| DRL/Parking         | PMU Out 23             | 7A       | ~2.6A   |
 | Brake Lights        | PMU Out 21             | 7A       | ~3A     |
 | Reverse Lights      | PMU Out 22             | 7A       | ~5A     |
 

--- a/docs/jeep_lj/03-lighting-systems/05-drl-parking.md
+++ b/docs/jeep_lj/03-lighting-systems/05-drl-parking.md
@@ -36,11 +36,11 @@ PMU Out 23 splices to all running/marker lights:
 
 ```text
 PMU Input 7 (In 7): CT4 SW3 headlight status signal
-PMU Input 6 (In 6): Ignition RUN signal
+PMU Pin 7: Ignition RUN signal (12V switched input)
 PMU Output 23 (Out 23): DRL/Parking lights circuit
 
 Programming Logic:
-IF (In6_IgnitionRUN == ON) AND (In7_CT4_Headlights == OFF)
+IF (Pin7_IgnitionRUN == ON) AND (In7_CT4_Headlights == OFF)
   THEN Out23_DRL = ON
 ELSE
   Out23_DRL = OFF
@@ -51,21 +51,21 @@ END
 
 **1. Ignition ON, Headlights OFF:**
 
-- PMU In 6 = ON (ignition RUN)
+- PMU Pin 7 = ON (ignition RUN)
 - PMU In 7 = OFF (CT4 SW3 not active)
 - PMU Out 23 = ON
 - **Result:** All DRL/parking lights illuminated
 
 **2. Ignition ON, Headlights ON:**
 
-- PMU In 6 = ON (ignition RUN)
+- PMU Pin 7 = ON (ignition RUN)
 - PMU In 7 = ON (CT4 SW3 active)
 - PMU Out 23 = OFF
 - **Result:** Headlights active, DRL off
 
 **3. Ignition OFF:**
 
-- PMU In 6 = OFF
+- PMU Pin 7 = OFF
 - PMU Out 23 = OFF (regardless of headlight status)
 - **Result:** All DRL/parking lights off
 
@@ -73,7 +73,7 @@ END
 
 **PMU Input Wiring:**
 
-- **In 6:** Ignition switch RUN output (shared with CT4, SwitchPros)
+- **Pin 7:** Ignition switch RUN signal (12V switched input, shared source with CT4, SwitchPros)
 - **In 7:** CT4 SW3 output (tapped from headlight low beam circuit)
 
 **PMU Output Wiring:**
@@ -86,7 +86,7 @@ END
 
 ## Outstanding Items
 
-- [ ] Plan wire routing from ignition switch RUN to PMU In 6 (splits to CT4, SwitchPros)
+- [ ] Plan wire routing from ignition switch RUN to PMU Pin 7 (splits to CT4, SwitchPros)
 - [ ] Plan wire routing from CT4 SW3 to PMU In 7 (DRL cutoff logic)
 - [ ] Create PMU programming configuration with DRL auto-off logic
 

--- a/docs/jeep_lj/04-offroad-lighting/01-ditch-lights.md
+++ b/docs/jeep_lj/04-offroad-lighting/01-ditch-lights.md
@@ -43,9 +43,13 @@ A-pillar mounted lights for peripheral and side illumination (Baja Designs Zone 
 | Output       | 4,400 lumens each (8,800 total) |
 | Draw         |              4A each (8A total) |
 
-## Control
+## Wiring
 
-**Controller:** SwitchPros Button 2 (OUTPUT-2)
+Both LP4 Pro pods run on SwitchPros OUTPUT-2 via 2-pin Delphi connectors (power + ground combined per pod).
+
+**Wire Routing:** SwitchPros (engine bay) to both A-pillars.
+
+**Controller:** SwitchPros Button 2 (OUTPUT-2) - 8A load on 35A output (23% utilization).
 
 See [SwitchPros SP-1200][switchpros-sp-1200] for wiring details.
 

--- a/docs/jeep_lj/04-offroad-lighting/03-roof-lights.md
+++ b/docs/jeep_lj/04-offroad-lighting/03-roof-lights.md
@@ -55,6 +55,10 @@ All 8 pods on single circuit via XL Linkable harness.
 
 See [SwitchPros SP-1200][switchpros-sp-1200] for wiring details.
 
+## Outstanding Items
+
+- [ ] Plan wire routing from SwitchPros to roof rack (passenger A-pillar to roof)
+- [ ] Confirm roof rack mounting points for XL Linkable brackets
 
 ## Related Documentation
 

--- a/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
+++ b/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
@@ -93,7 +93,7 @@ Automatic ignition-controlled circuit that powers:
 - Front 2" LED side markers (parking function)
 - Maxbilt tail light RED wire (marker/parking function)
 
-**Power Source:** PMU Out 9 (8A capacity, SWITCHED)
+**Power Source:** PMU Out 23 (7A capacity, ~2.6A load, auto with ignition)
 
 **DRL Auto-Off:** PMU programming logic disables when CT4 SW3 activates (headlights on = DRL off)
 
@@ -113,7 +113,7 @@ See [PMU DRL Auto-Off Logic](#pmu-drl-auto-off-logic) section below for complete
 | Yellow      | SW4, PUSH  | High Beams              | LP6 Pin 4 (high beam, both lights)                                       | 10A output, 5.6A load, disabled when ignition off        |
 | Red (thick) | 12V Supply | Main power input        | PMU Out 13 (15A CONSTANT)                                                | Powers all SW outputs, allows hazards when ignition off  |
 | Black       | Ground     | Ground return           | Chassis ground or firewall ground stud                                   | Via ignition/ground harness                              |
-| White/Gray  | Ignition   | Ignition signal input   | Ignition switch RUN output (18 AWG, splits to PMU In 6, SwitchPros, CT4) | Disables SW3/SW4 when ignition off, keeps SW1/SW2 active |
+| White/Gray  | Ignition   | Ignition signal input   | Ignition switch RUN output (18 AWG, splits to PMU Pin 7, SwitchPros, CT4) | Disables SW3/SW4 when ignition off, keeps SW1/SW2 active |
 
 ## Programming Configuration
 
@@ -156,42 +156,42 @@ The CT4 is highly programmable. Recommended configuration for this build:
 
 ```text
 PMU Input 7 (In 7): CT4 SW3 headlight status signal (tapped from low beam circuit)
-PMU Input 6 (In 6): Ignition RUN signal
-PMU Output 9 (Out 9): DRL/Parking lights circuit
+PMU Pin 7: Ignition RUN signal (12V switched input)
+PMU Output 23 (Out 23): DRL/Parking lights circuit
 
 Programming Logic:
-IF (In6_IgnitionRUN == ON) AND (In7_CT4_Headlights == OFF)
-  THEN Out9_DRL = ON
+IF (Pin7_IgnitionRUN == ON) AND (In7_CT4_Headlights == OFF)
+  THEN Out23_DRL = ON
 ELSE
-  Out9_DRL = OFF
+  Out23_DRL = OFF
 END
 ```
 
 **How It Works:**
 
 1. **Ignition ON, Headlights OFF (CT4 SW3 off):**
-   - PMU In 6 = ON (ignition RUN)
+   - PMU Pin 7 = ON (ignition RUN)
    - PMU In 7 = OFF (CT4 SW3 not active)
-   - PMU Out 9 = ON
+   - PMU Out 23 = ON
    - All DRL/parking lights illuminated
 
 2. **Ignition ON, Headlights ON (CT4 SW3 on):**
-   - PMU In 6 = ON (ignition RUN)
+   - PMU Pin 7 = ON (ignition RUN)
    - PMU In 7 = ON (CT4 SW3 active)
-   - PMU Out 9 = OFF
+   - PMU Out 23 = OFF
    - Headlights (low or high beam) active instead
 
 3. **Ignition OFF:**
-   - PMU In 6 = OFF
-   - PMU Out 9 = OFF (regardless of headlight status)
+   - PMU Pin 7 = OFF
+   - PMU Out 23 = OFF (regardless of headlight status)
    - All DRL/parking lights off
 
 **Installation Notes:**
 
 - Tap CT4 SW3 output (low beam circuit) to PMU In 7 for headlight status monitoring
-- Use 14 AWG wire from PMU Out 9 to DRL junction
-- Total DRL circuit load: ~8A (4 circuits: license plate, LP6 DRL, front markers, rear markers)
-- PMU Out 9 capacity: 15A (sufficient for 8A load)
+- Run wire from PMU Out 23 to DRL junction
+- Total DRL/parking circuit load: ~2.6A — see [DRL & Parking][drl-parking] for the itemized load breakdown and wiring
+- PMU Out 23 capacity: 7A (sufficient for the ~2.6A load)
 
 ## Installation Checklist
 
@@ -202,7 +202,7 @@ END
 
 ### Ignition Signal
 
-- [ ] Connect CT4 ignition signal to ignition switch RUN output (Y-split shared with PMU In 6, SwitchPros)
+- [ ] Connect CT4 ignition signal to ignition switch RUN output (Y-split shared with PMU Pin 7, SwitchPros)
 - [ ] Route ignition signal wire from ignition switch to steering column (18 AWG)
 - [ ] Verify SW3/SW4 (headlights) are disabled when ignition is off
 - [ ] Verify SW1/SW2 (turn signals/hazards) work with ignition off (safety feature)
@@ -221,14 +221,14 @@ END
   - BLACK wire → Ground (chassis ground)
   - WHITE wire → Reverse lights (PMU Out 18)
   - YELLOW wire → Brake/Turn (CT4 turn signal output + PMU Out 17 via diodes)
-  - RED wire → Marker/parking lights (PMU Out 9)
+  - RED wire → Marker/parking lights (PMU Out 23)
 - [ ] Verify turn signals flash front and rear simultaneously
 - [ ] Test lane change feature (< 0.5 sec press = 3 flashes)
 - [ ] Verify brake lights work independently of turn signals
 
 ### Headlight Wiring
 
-- [ ] Route ignition signal from ignition switch RUN output (18 AWG) to CT4 ignition input (splits to PMU In 6, SwitchPros, CT4)
+- [ ] Route ignition signal from ignition switch RUN output (18 AWG) to CT4 ignition input (splits to PMU Pin 7, SwitchPros, CT4)
 - [ ] Route CT4 main power from PMU Out 13 to CT4 12V supply
 - [ ] Route CT4 SW3 output wire to LP6 Pin 1 (low beam, both lights in parallel, 14 AWG)
 - [ ] Route CT4 SW4 output wire to LP6 Pin 4 (high beam, both lights in parallel, 14 AWG)
@@ -242,8 +242,8 @@ END
 ### DRL/Parking Light Wiring
 
 - [ ] Tap CT4 SW3 output (low beam circuit) to PMU In 7 for headlight status monitoring
-- [ ] Configure PMU Out 9 DRL auto-off logic (see PMU programming section)
-- [ ] Route 14 AWG wire from PMU Out 9 to DRL junction
+- [ ] Configure PMU Out 23 DRL auto-off logic (see PMU programming section)
+- [ ] Route 14 AWG wire from PMU Out 23 to DRL junction
 - [ ] Route 16 AWG wire from junction to each light:
   - License plate lights
   - LP6 Headlight Pin 3 (DRL input) - both left and right
@@ -300,3 +300,4 @@ END
 [control-interfaces-overview]: 01-overview.md
 [vehicle-lighting-overview]: ../03-lighting-systems/01-lighting-overview.md
 [pmu-power-distribution]: ../01-power-systems/04-pmu/index.md
+[drl-parking]: ../03-lighting-systems/05-drl-parking.md

--- a/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
+++ b/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
@@ -252,7 +252,7 @@ END
 - [ ] Verify all DRL/parking lights illuminate when ignition is turned on
 - [ ] Verify DRL automatically turns off when headlights are activated (CT4 SW3)
 - [ ] Verify DRL turns back on when headlights are turned off
-- [ ] Test total current draw on DRL circuit via PMU diagnostics (should be ~8A)
+- [ ] Test total current draw on DRL circuit via PMU diagnostics (should be ~2.6A)
 
 ### GPS Module Installation
 

--- a/docs/jeep_lj/05-control-interfaces/06-keyless-ignition.md
+++ b/docs/jeep_lj/05-control-interfaces/06-keyless-ignition.md
@@ -54,13 +54,13 @@ The Cummins R2.8 ECM uses a **sink-circuit lamp topology**: keyswitch +12V → l
 
 | Specification | Value |
 | :------------ | :---- |
-| Type | SPST automotive, 30A continuous, NC contacts in start path |
-| Coil | 12V DC, ~150 mA |
+| Type | 5-pin SPDT changeover, used as SPST-NC (30/87a wired, 87 unused); 30A NO / 20A NC contacts[^wait-relay] |
+| Coil | 12V DC, ~160 mA |
 | Coil+ | Switched +12V (tap from ignition signal bus bar — same source as the WAIT lamp itself) |
 | Coil- | ECM Pin 35 (yellow WAIT-to-Start wire) tap on cabin side (shared with HDX WAIT/EX input) |
-| Contacts | NC; close when WAIT lamp off, open when WAIT lamp on |
+| Contacts | NC (87a); closed when coil de-energized (WAIT lamp off), opens when coil energized (WAIT lamp on) |
 | Mounting | Cabin, adjacent to PBS-I |
-| Suggested Part | Bosch 0332019150 or Hella 4RA 003 510-04 (TBD) |
+| Part | **Bosch 0332209150** (superseded by 0986332400) — 5-pin changeover[^wait-relay] |
 
 ### Cole Hersee 24213 Solenoid
 
@@ -154,13 +154,13 @@ Normal engine shutdown (press brake + 2 sec button hold) drops PBS-I's PINK IGN 
 
 - [ ] Confirm the WAIT-gate relay coil (~150 mA) in parallel with the dash WAIT lamp does not exceed the ECM lamp-driver sink rating (Pin 35 polarity itself is confirmed active-low per Cummins 5504137 — see [^wait-polarity]). If marginal, drive the relay from the lamp's keyswitch side or use a higher-impedance/solid-state relay
 - [ ] Order Digital Guard Dawg PBS-I kit (includes ICM, 2 fobs, Start Button, Programming Button, Bypass Card, harnesses)
-- [ ] Select WAIT-gate relay part (SPST 30A automotive, NC contacts used in start path)
+- [x] ~~Select WAIT-gate relay part~~ → **Bosch 0332209150** (5-pin SPDT changeover, superseded by 0986332400); wire COM (30) + NC (87a), leave NO (87) open. See [^wait-relay].
 - [ ] Add 5A inline fuse on the ignition (keyswitch) feed to ECM Pin 41 — pink wire, per Cummins 5504137 (see [^ecm-fuse])
 - [ ] Select PBS-I module mounting location (cabin under-dash, away from heat and water)
 - [ ] Select Start Button dash mounting position (within easy reach of driver)
 - [ ] Select Programming Button storage location (hidden but accessible)
 - [ ] Verify PBS-I quiescent current draw to add to START battery parasitic budget
-- [ ] Set DIP switches / jumpers per install manual (PBS-I has no DIP/Jumper menu; check Feature Programming defaults are acceptable)
+- [x] ~~Confirm Feature Programming defaults~~ → PBS-I has no DIP/jumper menu; **shipped Feature Programming defaults confirmed acceptable** for this build (no reprogramming required at install). Owner decision, 2026-06-03.
 
 ## Related Documentation
 
@@ -171,6 +171,8 @@ Normal engine shutdown (press brake + 2 sec button hold) drops PBS-I's PINK IGN 
 - [Firewall Ingress][firewall-ingress] - PBS-I pin assignments
 
 [^pbs-i-specs]: Onboard relay ratings (4× 60A), 300A inrush capacity, and kit contents per the Digital Guard Dawg PBS-I install manual ([PBS-I Manual PDF][pbs-i-manual]) and product page ([Digital Guard Dawg PBS-I][pbs-i]).
+
+[^wait-relay]: **Bosch 0332209150** — 5-pin SPDT *changeover* mini-relay, 12V, 30A NO / **20A NC**, ~160 mA coil (Bosch/Amazon listing, accessed 2026-06-03; superseded by **0986332400**). This circuit energizes the coil to *open* the start path (WAIT lamp on → coil energized → contacts open), so it must use the **NC (87a)** contact — which requires a changeover relay. The earlier "suggested" parts were both wrong for this: Bosch **0332019150** is a twin-87 NO-only relay (no 87a terminal) and Hella **4RA** is an SPST make-only series — neither has an NC contact. The NC side here carries only the Cole Hersee 24213 coil (~0.69A), far under the 20A NC rating. Equivalent changeover relays (Hella **4RD** series, Tyco/TE V23234) are acceptable substitutes.
 
 [^ch-coil]: Cole Hersee 24213 coil draw ~0.69A (17.5 Ω @ 12V) per the Littelfuse datasheet — see the `[^ch-24213]` footnote in [Starter System][starter]. Supersedes the earlier unsourced "~1.6A" figure that appeared in pre-merge drafts.
 

--- a/docs/jeep_lj/06-audio-systems/03-speakers.md
+++ b/docs/jeep_lj/06-audio-systems/03-speakers.md
@@ -11,7 +11,7 @@ tags:
 
 Marine-grade coaxial speakers with integrated RGB LED lighting for front dash and rear roll bar positions.
 
-## Front Dash Speakers
+## Front Half-Door Speakers
 
 /// html | div.product-info
 ![JL Audio M6-650X-S-GmTi-i](../images/jl-audio-m6-650x-s-gmti-i.jpg){ loading=lazy }
@@ -26,7 +26,7 @@ Marine-grade coaxial speakers with integrated RGB LED lighting for front dash an
 
 **Quantity:** 2 (pair)
 
-**Mounting:** Dashboard (custom 6.5" cutouts)
+**Mounting:** In-door, custom Gatekeeper Offroad half-doors (6.5" cutouts)[^front-mount]
 
 **Power Source:** Amplifier Channels 3+4
 
@@ -107,7 +107,7 @@ Single cable run per speaker carries both audio and LED control.
 
 ## Outstanding Items
 
-- [ ] Determine front speaker mounting locations (dash end caps or kick panels)
+- [x] ~~Determine front speaker mounting locations~~ → **In-door, custom Gatekeeper Offroad half-doors** (6.5" cutouts). Route speaker/LED cable through the door hinge into the body via a service grommet.
 
 ## Related Documentation
 
@@ -120,3 +120,5 @@ Single cable run per speaker carries both audio and LED control.
 [led-controller]: 05-led-controller.md
 [front-product-link]: https://www.jlaudio.com/products/m6-650x-s-gmti-i-marine-audio-coaxial-speakers-93715
 [rear-product-link]: https://www.jlaudio.com/products/m6-650vex-mb-s-gmti-i-marine-audio-enclosed-speaker-systems-vex-93411
+
+[^front-mount]: Front speakers mount in custom **Gatekeeper Offroad** half-doors (in-door location, not dash end caps or kick panels). Owner decision, 2026-06-03.

--- a/docs/jeep_lj/06-audio-systems/04-subwoofer.md
+++ b/docs/jeep_lj/06-audio-systems/04-subwoofer.md
@@ -12,8 +12,6 @@ tags:
 Pair of 8" infinite baffle marine subwoofers with RGB LED lighting, mounted symmetrically in the rear quarter panels.
 
 /// html | div.product-info
-![JL Audio M6-8IB-S-GmTi-i-4](../images/jl-audio-m6-8ib-s-gmti-i-4.jpg){ loading=lazy }
-
 **Type:** 8" Infinite Baffle Marine Subwoofer
 
 **Model:** M6-8IB-S-GmTi-i-4
@@ -100,6 +98,7 @@ The single 12" M7-12IB option (600W RMS, 14" overall diameter, 7.94" mounting de
 
 - [ ] Confirm exact mounting locations in rear quarter panels (clear of cage tubes and rear seatbelts)
 - [ ] Verify quarter panel material can support sub weight + mounting torque (may need backing plate)
+- [ ] Source M6-8IB-S product image (`docs/jeep_lj/images/jl-audio-m6-8ib-s-gmti-i-4.jpg`)
 
 ## Related Documentation
 

--- a/docs/jeep_lj/06-audio-systems/index.md
+++ b/docs/jeep_lj/06-audio-systems/index.md
@@ -28,7 +28,7 @@ Marine-grade audio system with multi-zone control and RGB LED lighting integrati
 ```text
 MS-RA670 Head Unit
     │
-    ├─► Zone 1 RCA ──► MV800/8i Ch 5+6 ──► Front Dash Speakers
+    ├─► Zone 1 RCA ──► MV800/8i Ch 5+6 ──► Front Half-Door Speakers
     ├─► Zone 2 RCA ──► MV800/8i Ch 7+8 ──► Rear Roll Bar Speakers
     ├─► Sub RCA ────► MV800/8i (DSP signal-routed to:)
     │                   ├─► Ch 1+2 bridged @ 4Ω ──► Sub A (200W RMS)

--- a/docs/jeep_lj/08-exterior-systems/01-winch.md
+++ b/docs/jeep_lj/08-exterior-systems/01-winch.md
@@ -24,7 +24,7 @@ tags:
 
 **Product Image:**
 
-![Warn Zeon 10-S Winch](../../images/warn-zeon-10s-winch.jpg)
+![Warn Zeon 10-S Winch](../images/warn-zeon-10s-winch.jpg)
 
 ## Electrical Specifications
 

--- a/docs/jeep_lj/08-exterior-systems/02-air-compressor.md
+++ b/docs/jeep_lj/08-exterior-systems/02-air-compressor.md
@@ -34,7 +34,7 @@ ARB Twin Compressor system with air tank and automatic pressure management for l
 
 **Product Image:**
 
-![ARB CKBLTA12 Brushless Twin Compressor](../../images/arb-ckblta12-compressor.jpg)
+![ARB CKBLTA12 Brushless Twin Compressor](../images/arb-ckblta12-compressor.jpg)
 
 ## Specifications
 
@@ -86,7 +86,7 @@ ARB Twin Compressor system with air tank and automatic pressure management for l
 
 **Product Image:**
 
-![ARB 171507 1-Gallon Aluminum Air Tank](../../images/arb-171507-air-tank-1gal.jpg)
+![ARB 171507 1-Gallon Aluminum Air Tank](../images/arb-171507-air-tank-1gal.jpg)
 
 | Spec             | Value                                |
 | ---------------- | ------------------------------------ |
@@ -110,7 +110,7 @@ ARB Twin Compressor system with air tank and automatic pressure management for l
 
 **Product Image:**
 
-![ARB 180901 Pressure Switch](../../images/arb-180901-pressure-switch.jpg)
+![ARB 180901 Pressure Switch](../images/arb-180901-pressure-switch.jpg)
 
 | Spec             | Value                    |
 | ---------------- | ------------------------ |

--- a/docs/jeep_lj/08-exterior-systems/03-air-lockers.md
+++ b/docs/jeep_lj/08-exterior-systems/03-air-lockers.md
@@ -28,7 +28,7 @@ ARB RD116 air-operated locking differentials for front and rear Dana 44 axles.
 
 **Product Image:**
 
-![ARB RD116 Air Locker (Dana 44, 30-spline)](../../images/arb-rd116-air-locker.jpg)
+![ARB RD116 Air Locker (Dana 44, 30-spline)](../images/arb-rd116-air-locker.jpg)
 
 ## Specifications
 

--- a/docs/jeep_lj/09-installation/01-power-systems-checklist.md
+++ b/docs/jeep_lj/09-installation/01-power-systems-checklist.md
@@ -194,7 +194,7 @@ Create 12 custom 2-pin Delphi harnesses at SwitchPros:
 
 ### Firewall Bulkhead Connector
 
-**Deutsch HDP20 Installation:**
+**Deutsch HDP24-24-29 Installation:**
 
 - [ ] Drill 1.5" diameter hole in firewall for bulkhead connector
 - [ ] Mount HDP24-24-21PE-L015 receptacle (flange mount, engine side)
@@ -392,7 +392,7 @@ Create 12 custom 2-pin Delphi harnesses at SwitchPros:
 
 - [BODY PDU][body-pdu] - LR-2 circuit breaker and relay assignments
 - [SafetyHub 150][safetyhub] - ARB and winch fuse assignments
-- [Firewall Ingress][firewall-ingress] - Deutsch HDP20 connector pinout
+- [Firewall Ingress][firewall-ingress] - Deutsch HDP24-24-29 connector pinout
 
 **External Manuals:**
 

--- a/docs/jeep_lj/09-installation/01-power-systems-checklist.md
+++ b/docs/jeep_lj/09-installation/01-power-systems-checklist.md
@@ -256,7 +256,7 @@ Create 12 custom 2-pin Delphi harnesses at SwitchPros:
 - [ ] Confirm STX Intercom → OUT20 (5A) - ground: direct to START battery-
 - [ ] Confirm brake lights → OUT21 (3A) - ground: SwitchPros Ground Bus T4
 - [ ] Confirm reverse lights → OUT22 (5A) - ground: SwitchPros Ground Bus T4
-- [ ] Confirm DRL/parking → OUT23 (2A) - ground: SwitchPros Ground Bus T5
+- [ ] Confirm DRL/parking → OUT23 (~2.6A) - ground: SwitchPros Ground Bus T5
 - [ ] OUT24 — Available for future expansion (no current wiring)
 
 ### PMU CAN Bus Integration

--- a/docs/jeep_lj/09-installation/03-purchase-tracker.md
+++ b/docs/jeep_lj/09-installation/03-purchase-tracker.md
@@ -135,7 +135,7 @@ _(Most electrical distribution components already purchased - see Purchased Item
 | Ron Francis WS-51C Wiper Controller | Ron Francis | ~$80 | Medium | [Wipers][wipers] |
 | PIAA 85115 Sports Horn | PIAA | ~$50 | Low | [Horn][horn] |
 | Overvoltage Protection Relay | Generic | ~$15-25 | Low | Solar protection - [Solar][solar] |
-| Deutsch HDP20 Connector Kit | Deutsch | ~$80 | High | [Firewall Ingress][firewall-ingress] |
+| Deutsch HDP24-24-29 Connector Kit | Deutsch | ~$80 | High | [Firewall Ingress][firewall-ingress] |
 | ARB Air Line Installation Kit | ARB | ~$50 | Medium | [Air Lockers][air-lockers] |
 | 0-200 PSI Pressure Gauge | Generic | ~$20 | Medium | [Air Compressor][air-compressor] |
 | Air Chuck Plate and Fittings | Generic | ~$30 | Low | [Rear Air Chuck][rear-air-chuck] |

--- a/docs/jeep_lj/09-installation/index.md
+++ b/docs/jeep_lj/09-installation/index.md
@@ -22,7 +22,7 @@ Physical installation planning, tracking, and validation procedures.
 
 **Firewall Planning:**
 
-- [Section 1.7.2 - Firewall Ingress][firewall-ingress] - Deutsch HDP20 connector pinout and specifications
+- [Section 1.7.2 - Firewall Ingress][firewall-ingress] - Deutsch HDP24-24-29 connector pinout and specifications
 
 ## System Overview
 

--- a/docs/jeep_lj/10-drivetrain/02-transfer-case.md
+++ b/docs/jeep_lj/10-drivetrain/02-transfer-case.md
@@ -27,7 +27,7 @@ tags:
 | Low Range Ratio | 2.72:1[^lowrange] |
 | High Range Ratio | 1.0:1 |
 | Rear Output | 32-spline, fixed yoke[^output] |
-| Input | Adapter-dependent — mates to 8HP70 via adapter[^input] |
+| Input | 23-spline (DomiWorks 24004001 adapter + ZTNP22390 input gear)[^input] |
 
 ## Gear Ratios
 
@@ -87,8 +87,6 @@ The 8HP *family* does pair with an NV241 from the factory — the JL Wrangler au
 | :------------ | :---- |
 | Fluid Type | ATF+4[^fluid] |
 | Capacity | ≈1.6 L (3.4 pt); fill to overflow[^fluid] |
-
-[^tc-ratio]: The 2012 Jeep Wrangler JK Command-Trac (NVG241 Gen II) low-range ratio is **2.72:1** per Jeep factory specification; the 4.0:1 unit is the Rubicon-only Rock-Trac (NV241OR), which this build no longer uses. Confirm against the JK FSM transfer-case section when finalizing crawl-ratio math.
 
 ## Outstanding Items
 

--- a/docs/jeep_lj/index.md
+++ b/docs/jeep_lj/index.md
@@ -17,60 +17,58 @@ The electrical system is organized into zones for logical distribution and maint
 
 ### Power Systems
 
-- **[Power Generation](01-power-systems/01-power-generation/index.md)** - Batteries, alternator, BCDC, solar, grounding
-- **[START battery Distribution](01-power-systems/02-starter-battery-distribution/index.md)** - Driver rear wheel well primary power distribution
-- **[AUX battery Distribution](01-power-systems/03-aux-battery-distribution/index.md)** - Passenger rear wheel well accessory power distribution
-- **[Power Management Unit](01-power-systems/04-pmu/index.md)** - PMU24 programmable power management
-- **[BODY PDU](01-power-systems/03-aux-battery-distribution/03-body-pdu.md)** - Body relay/fuse panel
-- **[SafetyHub](01-power-systems/03-aux-battery-distribution/04-safetyhub.md)** - Safety control system
+- **[Power Generation][power-generation]** - Batteries, alternator, BCDC, solar, grounding
+- **[START battery Distribution][start-battery]** - Driver rear wheel well primary power distribution
+- **[AUX battery Distribution][aux-battery]** - Passenger rear wheel well accessory power distribution
+- **[Power Management Unit][pmu]** - PMU24 programmable power management
+- **[BODY PDU][body-pdu]** - Body relay/fuse panel
+- **[SafetyHub][safetyhub]** - Safety control system
 
 ### Critical Systems
 
-- **[Starter System](02-engine-systems/01-starter.md)** - Engine starting system
-- **[Brake Booster](02-engine-systems/02-brake-booster.md)** - Vacuum brake booster
-- **[HVAC System](02-engine-systems/03-hvac.md)** - Heating, ventilation, and air conditioning
-- **[Wiper System](02-engine-systems/04-wipers.md)** - Windshield wipers
-- **[Horn System](02-engine-systems/05-horn.md)** - Vehicle horn
-- **[Radiator Fan](02-engine-systems/06-radiator-fan.md)** - Engine cooling fan
-- **[Grid Heater](02-engine-systems/07-grid-heater.md)** - Diesel grid heater
+- **[Starter System][starter]** - Engine starting system
+- **[Brake Booster][brake-booster]** - Vacuum brake booster
+- **[HVAC System][hvac]** - Heating, ventilation, and air conditioning
+- **[Wiper System][wipers]** - Windshield wipers
+- **[Horn System][horn]** - Vehicle horn
+- **[Radiator Fan][radiator-fan]** - Engine cooling fan
+- **[Grid Heater][grid-heater]** - Diesel grid heater
 
 ### Lighting Systems
 
-- **[Lighting Overview](03-lighting-systems/01-lighting-overview.md)** - Complete lighting system overview
-- **[Headlights](03-lighting-systems/02-headlights.md)** - Main headlights
-- **[Turn Signals](03-lighting-systems/03-turn-signals.md)** - Turn signal system
-- **[Tail, Brake & Reverse](03-lighting-systems/04-tail-brake-reverse.md)** - Rear lighting
-- **[DRL & Parking Lights](03-lighting-systems/05-drl-parking.md)** - Daytime running and parking lights
-- **[Offroad & Aux Lighting](04-offroad-lighting/index.md)** - Auxiliary and offroad lighting
+- **[Lighting Overview][lighting-overview]** - Complete lighting system overview
+- **[Headlights][headlights]** - Main headlights
+- **[Turn Signals][turn-signals]** - Turn signal system
+- **[Tail, Brake & Reverse][tail-brake-reverse]** - Rear lighting
+- **[DRL & Parking Lights][drl-parking]** - Daytime running and parking lights
+- **[Offroad & Aux Lighting][offroad-lighting]** - Auxiliary and offroad lighting
 
 ### Control Interfaces
 
-- **[Overview](05-control-interfaces/01-overview.md)** - Control systems overview
-- **[SwitchPros SP-1200](05-control-interfaces/02-switchpros-sp1200.md)** - SwitchPros lighting controller
-- **[Command Touch CT4](05-control-interfaces/03-command-touch-ct4.md)** - Command Touch control panel
-- **[Digital Gauge Cluster](02-engine-systems/09-gauge-cluster/index.md)** - Dakota Digital gauge cluster
-- **[Dashboard Switches](05-control-interfaces/05-dashboard-controls.md)** - Physical dashboard controls
+- **[Overview][control-overview]** - Control systems overview
+- **[SwitchPros SP-1200][switchpros]** - SwitchPros lighting controller
+- **[Command Touch CT4][ct4]** - Command Touch control panel
+- **[Digital Gauge Cluster][gauge-cluster]** - Dakota Digital gauge cluster
+- **[Dashboard Switches][dashboard-controls]** - Physical dashboard controls
 
 ### Stereo Systems
 
-- **[Audio Systems](06-audio-systems/index.md)** - Fusion head unit, JL Audio MV800/8i 8-channel amp, JL Audio speakers and subwoofers
+- **[Audio Systems][audio]** - Fusion head unit, JL Audio MV800/8i 8-channel amp, JL Audio speakers and subwoofers
 
 ### Communications
 
-- **[Communication Systems](07-communication-systems/index.md)** - GMRS radio, intercom, dash camera
+- **[Communication Systems][communications]** - GMRS radio, intercom, dash camera
 
 ### Auxiliary Systems
 
-- **[Winch](08-exterior-systems/01-winch.md)** - Warn Zeon 10-S winch (10,000 lb)
-- **[Air Compressor](08-exterior-systems/02-air-compressor.md)** - ARB Twin Compressor and tank
-- **[Air Lockers](08-exterior-systems/03-air-lockers.md)** - ARB RD116 front/rear lockers
-- **[Rear Air Chuck](08-exterior-systems/04-rear-air-chuck.md)** - External air access
+- **[Winch][winch]** - Warn Zeon 10-S winch (10,000 lb)
+- **[Air Compressor][air-compressor]** - ARB Twin Compressor and tank
+- **[Air Lockers][air-lockers]** - ARB RD116 front/rear lockers
+- **[Rear Air Chuck][rear-air-chuck]** - External air access
 
 ### Install Notes
 
 - **[Wire Routing & Layout][wire-routing]** - Physical wire routing, grommets, grounds
-
-[wire-routing]: 01-power-systems/07-wire-routing/index.md
 
 </div>
 
@@ -82,38 +80,38 @@ The electrical system is organized into zones for logical distribution and maint
 - **AUX battery:** Passenger rear wheel well - powers accessories via inline CBs + Firewall CONSTANT bus (cabin distribution cluster)
 - **Battery Isolation:** RedArc BCDC Alpha 50 DC-DC charger with automatic jump-start assist
 
-See [Power Generation](01-power-systems/01-power-generation/index.md) for complete battery and charging system details.
+See [Power Generation][power-generation] for complete battery and charging system details.
 
 ### TIPM Replacement
 
 Complete replacement of factory TIPM with modular power distribution:
 
-- **[PMU24](01-power-systems/04-pmu/index.md):** Programmable 24-channel power management unit
-- **[BODY PDU](01-power-systems/03-aux-battery-distribution/03-body-pdu.md):** Body relay/fuse panel for cabin accessories
-- **[SafetyHub](01-power-systems/03-aux-battery-distribution/04-safetyhub.md):** 12-channel advanced safety controller
-- **[Ron Francis WS-51C](02-engine-systems/04-wipers.md):** Wiper control system
+- **[PMU24][pmu]:** Programmable 24-channel power management unit
+- **[BODY PDU][body-pdu]:** Body relay/fuse panel for cabin accessories
+- **[SafetyHub][safetyhub]:** 12-channel advanced safety controller
+- **[Ron Francis WS-51C][wipers]:** Wiper control system
 
 ### Major Systems
 
-- **[Lighting Control](05-control-interfaces/02-switchpros-sp1200.md):** SwitchPros SP-1200 for offroad and auxiliary lighting
-- **[Command Touch CT4](05-control-interfaces/03-command-touch-ct4.md):** Street-legal lighting and turn signal control
-- **[Audio System](06-audio-systems/index.md):** JL Audio MV800/8i 8-channel amp w/ DSP, JL Audio marine speakers and 2× 8" subs with RGB LED
-- **[Communication](07-communication-systems/index.md):** Rugged Radio G1 GMRS, STX 4-place intercom, WolfBox dash camera
-- **[Recovery & Air](08-exterior-systems/index.md):** Warn 10,000 lb winch, ARB air lockers, ARB Twin Air Compressor
+- **[Lighting Control][switchpros]:** SwitchPros SP-1200 for offroad and auxiliary lighting
+- **[Command Touch CT4][ct4]:** Street-legal lighting and turn signal control
+- **[Audio System][audio]:** JL Audio MV800/8i 8-channel amp w/ DSP, JL Audio marine speakers and 2× 8" subs with RGB LED
+- **[Communication][communications]:** Rugged Radio G1 GMRS, STX 4-place intercom, WolfBox dash camera
+- **[Recovery & Air][recovery-air]:** Warn 10,000 lb winch, ARB air lockers, ARB Twin Air Compressor
 
 ## Documentation Notes
 
 !!! info "Outstanding Items"
     Throughout this documentation, you'll find "Outstanding Items" checklists. These track design decisions, measurements, and tasks that need to be completed during installation.
 
-    **[View Global TBD Tracker](tbd-tracker.md)** - Centralized tracking of all To-Be-Determined items with priorities
+    **[View Global TBD Tracker][tbd-tracker]** - Centralized tracking of all To-Be-Determined items with priorities
 
 !!! warning "Work in Progress"
     This is a living document that evolves as the build progresses. Some specifications may be marked as TBD (To Be Determined) and will be updated during the build process.
 
 ## Outstanding Items
 
-Live from open GitHub issues labeled `tbd` for this build. Full filterable view: **[TBD Tracker](tbd-tracker.md)**.
+Live from open GitHub issues labeled `tbd` for this build. Full filterable view: **[TBD Tracker][tbd-tracker]**.
 
 {{ tbds(scope='project', layout='github') }}
 
@@ -134,3 +132,37 @@ Need a physical copy for the shop? Use the print page which combines all documen
 5. For duplex printing, select "Print on both sides" with "Flip on long edge"
 
 </div>
+
+[power-generation]: 01-power-systems/01-power-generation/index.md
+[start-battery]: 01-power-systems/02-starter-battery-distribution/index.md
+[aux-battery]: 01-power-systems/03-aux-battery-distribution/index.md
+[pmu]: 01-power-systems/04-pmu/index.md
+[body-pdu]: 01-power-systems/03-aux-battery-distribution/03-body-pdu.md
+[safetyhub]: 01-power-systems/03-aux-battery-distribution/04-safetyhub.md
+[starter]: 02-engine-systems/01-starter.md
+[brake-booster]: 02-engine-systems/02-brake-booster.md
+[hvac]: 02-engine-systems/03-hvac.md
+[wipers]: 02-engine-systems/04-wipers.md
+[horn]: 02-engine-systems/05-horn.md
+[radiator-fan]: 02-engine-systems/06-radiator-fan.md
+[grid-heater]: 02-engine-systems/07-grid-heater.md
+[lighting-overview]: 03-lighting-systems/01-lighting-overview.md
+[headlights]: 03-lighting-systems/02-headlights.md
+[turn-signals]: 03-lighting-systems/03-turn-signals.md
+[tail-brake-reverse]: 03-lighting-systems/04-tail-brake-reverse.md
+[drl-parking]: 03-lighting-systems/05-drl-parking.md
+[offroad-lighting]: 04-offroad-lighting/index.md
+[control-overview]: 05-control-interfaces/01-overview.md
+[switchpros]: 05-control-interfaces/02-switchpros-sp1200.md
+[ct4]: 05-control-interfaces/03-command-touch-ct4.md
+[gauge-cluster]: 02-engine-systems/09-gauge-cluster/index.md
+[dashboard-controls]: 05-control-interfaces/05-dashboard-controls.md
+[audio]: 06-audio-systems/index.md
+[communications]: 07-communication-systems/index.md
+[winch]: 08-exterior-systems/01-winch.md
+[air-compressor]: 08-exterior-systems/02-air-compressor.md
+[air-lockers]: 08-exterior-systems/03-air-lockers.md
+[rear-air-chuck]: 08-exterior-systems/04-rear-air-chuck.md
+[recovery-air]: 08-exterior-systems/index.md
+[wire-routing]: 01-power-systems/07-wire-routing/index.md
+[tbd-tracker]: tbd-tracker.md

--- a/docs/nissan_nv/index.md
+++ b/docs/nissan_nv/index.md
@@ -1,0 +1,8 @@
+---
+hide:
+  - toc
+---
+
+# Nissan NV 3500
+
+Documentation for the Nissan NV 3500 is not yet started. Content will be added here as the project develops.

--- a/docs/tags.md
+++ b/docs/tags.md
@@ -2,4 +2,4 @@
 
 This page lists all products documented in this technical documentation.
 
-[TAGS]
+<!-- material/tags -->

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,8 +87,7 @@ plugins:
       # mistaken for a comment-open. {{ }} variables are unused elsewhere in docs.
       j2_comment_start_string: '{##'
       j2_comment_end_string: '##}'
-  - tags:
-      tags_file: tags.md
+  - tags
   - print-site:
       add_to_navigation: true
       print_page_title: 'Print / PDF'
@@ -115,11 +114,12 @@ nav:
     - TBD Tracker: jeep_lj/tbd-tracker.md
     - Power Systems:
       - jeep_lj/01-power-systems/index.md
+      - Standards Exceptions: jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
       - 1.1 - Power Generation:
         - jeep_lj/01-power-systems/01-power-generation/index.md
         - 1.1.1 - Batteries: jeep_lj/01-power-systems/01-power-generation/01-batteries.md
         - 1.1.2 - Alternator: jeep_lj/01-power-systems/01-power-generation/02-alternator.md
-        - 1.1.3 - BCDC Alpha 25: jeep_lj/01-power-systems/01-power-generation/03-bcdc.md
+        - 1.1.3 - BCDC Alpha 50: jeep_lj/01-power-systems/01-power-generation/03-bcdc.md
         - 1.1.4 - Solar Charging: jeep_lj/01-power-systems/01-power-generation/04-solar.md
         - 1.1.5 - Wire Distance Reference: jeep_lj/01-power-systems/01-power-generation/05-wire-distance-reference.md
       - 1.2 - START Battery Distribution:


### PR DESCRIPTION
Resolves the items in the nightly health digest #44, then reconciles the DRL load value through the full load analysis.

## #44 — health digest (commit `3e541bd`)

**Build & link integrity**
- Migrated deprecated `tags_file` → `material/tags` directive (this was aborting `mkdocs build --strict`)
- Fixed 5 image links with wrong `../../images/` depth
- Dropped the broken subwoofer image ref (asset never existed); tracked as an Outstanding Item per repo convention
- Added `nissan_nv` + `jeep_jku` index stubs (phantom nav entry / empty-page warning)
- Removed an orphaned, never-referenced footnote (`#fnref:tc-ratio`)

**Spec contradictions** (conformed to authoritative PMU outputs table)
- DRL output `Out 9` / `Out 14` → **`Out 23`** repo-wide (+ fixed the contradicted 15A/8A capacity → 7A)
- DRL ignition sense `In 6` → **`Pin 7`** in drl-parking and CT4
- Firewall connector `Deutsch HDP20` → **`HDP24-24-29`**
- Nav `BCDC Alpha 25` → **`Alpha 50`**

**TBD / terminology / templates / nav**
- Opened tracking issues for 4 untracked TBDs (#105–#108); resolved the stale Firewall CONSTANT Bus routing note
- Converted `jeep_lj/index.md` inline links → reference-style
- Added missing template sections (ditch-lights Wiring, roof-lights Outstanding Items, grid-heater Specifications)
- Added `STANDARDS-EXCEPTIONS.md` to nav

## Full load analysis (commit `340e72f`)

DRL/parking (Out 23) was carried at a stale **8A**; the authoritative DRL & Parking page itemizes it at **~2.6A**. Conformed every figure and recomputed dependents:
- START battery scenarios: Highway 106→101A (37%), Hot City 193→188A (70%), Offroad 206→201A (74%), worst-case margin 64→69A
- ARB load shedding: shed 8A→2.6A, range 28–43A → ~8–38A; post-shed totals/margins unchanged (DRL cancels out of baseline and shed)
- pmu-outputs / pmu-programming / lighting-overview / CT4 / checklist aligned to ~2.6A

`mkdocs build --strict` passes.

> [!NOTE]
> A concurrent process committed `b577aa5` (unrelated TBD #50/#65/#85/#87/#90 + alternator work) onto this branch between the two commits above. There is no file overlap with this PR's work; it's included here only because it landed on the branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)