### PR TITLE
docs(gauge): mark J1939 gear display as unverified pending vendor confirmation

### DIFF
--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/03-bim-j1939.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/03-bim-j1939.md
@@ -57,11 +57,14 @@ Interfaces Cummins R2.8 ECM J1939 CAN bus data with HDX instrument system. Provi
 - Engine hours
 - Diagnostic trouble codes (DTCs)
 
-**Turbolamik TCU 2.0 (8HP70) Broadcast:**
+**Turbolamik TCU 2.0 (8HP70) Broadcast (UNVERIFIED — see issue [#110][i110]):**
 
-- Gear position (PGN 61445 / SPN 524) → drives HDX GEAR display
+- Gear position (PGN 61445 / ETC2 — SPN 523 current gear, SPN 524 selected gear) → intended to drive HDX GEAR display
 - Transmission oil temperature
 - Selected gear (Drive / Sport / Manual)
+
+!!! warning "Gear display not yet vendor-confirmed"
+    The no-sender design assumes (1) the Turbolamik TCU **broadcasts** ETC2 gear on J1939 and (2) the BIM-01-2 / HDX **decodes and displays** it. Neither is confirmed — Dakota Digital's J1939 BIM has historically been engine-parameter focused, so a gear/PRNDL channel may not exist even if the data is on the bus. If either is false, a discrete gear-position input (GSS-style sender or 8HP70 range switch) is required. Tracked in issue [#110][i110].
 
 **Potentially Available:**
 
@@ -108,6 +111,8 @@ Specific J1939 parameters vary by ECM configuration and vehicle application. Cum
 ## Outstanding Items
 
 - [ ] Confirm all J1939 parameters available from Cummins R2.8 ECM configuration
+- [ ] Confirm Turbolamik TCU 2.0 broadcasts gear (ETC2 / SPN 523/524) on J1939 (issue [#110][i110])
+- [ ] Confirm BIM-01-2 / HDX decodes and displays a gear value from J1939; else add discrete gear sender (issue [#110][i110])
 
 ## Related Documentation
 
@@ -119,6 +124,7 @@ Specific J1939 parameters vary by ECM configuration and vehicle application. Cum
 
 [product-link]: https://www.dakotadigital.com/index.cfm/page/ptype=product/product_id=1328/category_id=646/mode=prod/prd1328.htm
 [manual-link]: https://www.dakotadigital.com/pdf/BIM-01-2-J1939.pdf
+[i110]: https://github.com/sob/drawings/issues/110
 [gauge-system]: index.md
 [dashboard-cluster]: 02-dashboard-cluster.md
 [ecm]: ../../02-engine-systems/index.md


### PR DESCRIPTION
## What

Tightens the BIM-01-2-J1939 gauge doc so transmission **gear position display** reads as pending-verification instead of fact, and opens a tracked TBD ([#110](https://github.com/sob/drawings/issues/110)) for it.

- `03-bim-j1939.md`: softened "Gear position … → drives HDX GEAR display" to "intended to drive", corrected the SPN reference (ETC2 PGN 61445, SPN 523 current / 524 selected), added a warning admonition, and added two Outstanding Items linking #110.

## Why

The doc asserted that gear position reaches the HDX cluster over J1939 as fact, with no citation — a violation of the repo's cite-or-TBD rule. The no-sender design depends on **two independent, unconfirmed** assumptions:

1. The **Turbolamik TCU 2.0** actually *broadcasts* ETC2 gear on J1939 (not just uses range internally).
2. The **Dakota Digital BIM-01-2 / HDX** actually *decodes and displays* a gear value from it — Dakota's J1939 BIM has historically been engine-parameter focused, so a gear/PRNDL channel is not guaranteed even if the data is on the bus.

If either is false, a discrete gear-position sender (GSS-style or 8HP70 range switch into a BIM input) is required — a BOM impact, so this gates a potential parts purchase.

## Reviewer notes

- Tracked in issue [#110](https://github.com/sob/drawings/issues/110) (`tbd`, `priority/high`, `area/engine-systems`). Draft vendor verification questions for Turbolamik and Dakota Digital are posted as a [comment](https://github.com/sob/drawings/issues/110#issuecomment-4609789338).
- No spec values changed — this is a provenance/accuracy correction. Resolution criterion: both assumptions confirmed → keep no-sender design; either fails → add discrete sender and close #110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)