### PR TITLE
Replace static TBD sections with live issue-driven rendering

### DIFF
--- a/.github/workflows/verify-tbd.yml
+++ b/.github/workflows/verify-tbd.yml
@@ -1,0 +1,37 @@
+name: Verify TBD invariants
+
+on:
+  pull_request:
+    paths:
+      - 'docs/**'
+      - 'tbd_macros.py'
+      - 'hooks/verify_tbd.py'
+      - '.github/workflows/verify-tbd.yml'
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+      - 'tbd_macros.py'
+      - 'hooks/verify_tbd.py'
+
+permissions:
+  contents: read
+  issues: read
+
+concurrency:
+  group: verify-tbd-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify-tbd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+      - name: Run hooks/verify_tbd.py
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python3 hooks/verify_tbd.py

--- a/docs/jeep_lj/01-power-systems/01-power-generation/01-batteries.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/01-batteries.md
@@ -110,7 +110,10 @@ Accessories and high-draw auxiliary loads:
 
 ## Outstanding Items
 
-- [x] ~~Order Dakota Lithium DL+ 135Ah battery (~$999)~~ → Purchased
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Backorder Barnes 4WD battery box (Group 24 compatible, ~$67)
 - [ ] Powdercoat or paint battery box before installation
 
@@ -119,3 +122,4 @@ Accessories and high-draw auxiliary loads:
 [odyssey-pc1500]: https://www.odysseybattery.com/products/odx-agm34-battery-34-pc1500t/
 [dakota-135ah]: https://dakotalithium.com/product/dl-plus-12v-135ah-dual-purpose-1000cca-starter-car-truck-battery-plus-deep-cycle-performance/
 [installation-checklist]: ../../09-installation/01-power-systems-checklist.md#phase-1-foundations
+

--- a/docs/jeep_lj/01-power-systems/01-power-generation/02-alternator.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/02-alternator.md
@@ -69,6 +69,10 @@ See [START Battery Load Analysis][start-load-analysis] for complete scenario det
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Determine alternator positive output terminal size (for 1/0 AWG lug selection) — see [Vendor Inquiry](#vendor-inquiry) below
 - [ ] Verify alternator voltage regulator set point (14.2–14.4V is the correct AGM target;[^agm-target] confirm the HO-C28 actually regulates there) — see [Vendor Inquiry](#vendor-inquiry) below
 

--- a/docs/jeep_lj/01-power-systems/01-power-generation/03-bcdc.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/03-bcdc.md
@@ -41,7 +41,7 @@ tags:
 | :-------------------- | :--------------- | :------------ | :---------------------------- | :--------------------------------------------------------------- |
 | Start Battery (+)     | Red              | M8            | START battery positive        | See [START Battery Distribution][starter-battery] for wire specs |
 | Auxiliary Battery (+) | Brown            | M8            | AUX battery positive          | See [AUX Battery Distribution][aux-battery] for wire specs       |
-| Solar (+)             | Yellow           | TBD           | Cascadia 4x4 80W panel        | See [Solar Charging][solar]                                      |
+| Solar (+)             | Yellow           | {{ tbd(108) }} | Cascadia 4x4 80W panel       | See [Solar Charging][solar]                                      |
 | Ground (-)            | Black            | M8            | AUX battery negative          | See [AUX Battery Distribution][aux-battery] for wire specs       |
 | Ignition              | Blue             | Spade         | PMU ignition sense tap        | 18 AWG - see [PMU Inputs][pmu-inputs]                            |
 | Battery Temp Sensor   | +/- (reversible) | 2-pin plug    | AUX battery positive terminal | **REQUIRED** - LiFePO4 temperature-compensated charging          |

--- a/docs/jeep_lj/01-power-systems/01-power-generation/04-solar.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/04-solar.md
@@ -148,6 +148,10 @@ For a passive (no electronics) solution, install 4-5 series rectifier diodes (10
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Order overvoltage protection relay module (DC 36V version, ~$15-25)
 - [ ] Determine mounting location for voltage module (near BCDC or inline with solar wiring)
 - [ ] Test and configure voltage thresholds before final installation (47V disconnect, 44V reconnect)
@@ -156,3 +160,4 @@ For a passive (no electronics) solution, install 4-5 series rectifier diodes (10
 [bcdc]: 03-bcdc.md
 [installation-checklist]: ../../09-installation/01-power-systems-checklist.md#phase-4-integration-wiring
 [overvoltage-module]: https://www.amazon.com/Over-Voltage-Under-Voltage-Protection-Monitoring-Adjustable/dp/B07Y2PTB4M
+

--- a/docs/jeep_lj/01-power-systems/01-power-generation/05-wire-distance-reference.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/05-wire-distance-reference.md
@@ -46,8 +46,8 @@ Wire gauges optimized for performance at measured routing distances:
 | **Alternator → START battery** | 8 ft                          | 2/0 AWG    | 270A                    | 2.81% @ 60°C                     | Charging system - temp derating applied                   |
 | **PMU24 Power Feed**           | 7 ft                          | 2/0 AWG    | 220A                    | 2.40% @ 60°C                     | Direct connection via 250A CB - upgraded from 1/0 AWG     |
 | **Starter Motor**              | 6 ft                          | 2/0 AWG    | 400-600A                | <3% @ 20°C                       | Brief cranking load - minimal temp effect                 |
-| **BCDC Inter-Battery**         | 5-6 ft                        | 4 AWG      | 50A                     | 0.94% @ 20°C                     | Rear wheel well to rear wheel well (cross-cab routing TBD - see [Wire Routing][wire-routing]) |
-| **Winch → AUX battery**        | 13 ft one-way (26 ft circuit) | 1/0 AWG    | 250A typical, 400A peak | 6.3% @ 250A, 10.1% @ 400A @ 20°C | Passenger rear wheel well to front bumper routing (path TBD - see [Wire Routing][wire-routing]) |
+| **BCDC Inter-Battery**         | 5-6 ft                        | 4 AWG      | 50A                     | 0.94% @ 20°C                     | Rear wheel well to rear wheel well (H3 cross-cab, see [Wire Routing][wire-routing]) |
+| **Winch → AUX battery**        | 13 ft one-way (26 ft circuit) | 1/0 AWG    | 250A typical, 400A peak | 6.3% @ 250A, 10.1% @ 400A @ 20°C | Passenger rear wheel well to front bumper routing — see {{ tbd(106) }} and [Wire Routing][wire-routing] |
 
 **Temperature Derating Notes:**
 

--- a/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/02-constant-bus.md
+++ b/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/02-constant-bus.md
@@ -48,7 +48,7 @@ The AUX battery has no local CONSTANT bus. Loads are distributed in two stages:
 
 | From                    | Cable     | Distance | Protection                | Voltage Drop @ 200A | Notes                                          |
 | :---------------------- | :-------- | :------- | :------------------------ | :------------------ | :--------------------------------------------- |
-| **AUX battery+**        | 2/0 AWG   | ~13 ft   | 300A CB at battery (<7") | ~2.0% @ 20°C        | Routed via cabin trunk (path TBD)              |
+| **AUX battery+**        | 2/0 AWG   | ~13 ft   | 300A CB at battery (<7") | ~2.0% @ 20°C        | Routed via cabin trunk — see {{ tbd(75) }}     |
 
 ## Load Distribution
 

--- a/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/03-body-pdu.md
+++ b/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/03-body-pdu.md
@@ -83,6 +83,10 @@ G1 GMRS Radio and STX Intercom are powered from [SafetyHub 150][safetyhub] (STAR
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Identify pinout for J301-J306 Metri-Pack connectors (military TM manual or reverse engineering)
 - [ ] Determine replacement 12V relay part numbers for K40, K42, K53 (currently 24V coils)
 

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/02-firewall-ingress.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/02-firewall-ingress.md
@@ -172,7 +172,7 @@ Radio grounds do NOT go through firewall - they route through cab floor to START
 | GMRS Radio ground (-) | 14 AWG | Midland G1 | START battery negative |
 | STX Intercom ground (-) | 14 AWG | STX | START battery negative |
 
-**Routing:** Radios (cabin) → under seat/floor → START battery negative (driver rear wheel well) - exact path TBD (avoid exposed frame rail)
+**Routing:** Radios (cabin) → under seat/floor → START battery negative (driver rear wheel well) - exact path: {{ tbd(82) }} (avoid exposed frame rail)
 
 ---
 

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/03-harness-inventory.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/03-harness-inventory.md
@@ -209,9 +209,12 @@ These were noted inline on the build sheets; consolidated here for review:
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Decide front bumper breakout connector style (Deutsch DT, AMP CPC, etc.)
 - [ ] Decide rear cargo bulkhead breakout connector style and pin count
-- [x] ~~Calculate HDP20 firewall pin budget — fits or needs upsize?~~ → **Resolved:** Upsized to HDP24-24-29 (29 size-16 contacts, 21 used + 8 future headroom). See [Pin Budget Audit][firewall-ingress] for full pin assignment. Forward-going SP loads use chassis ground locally (1 pin per output instead of 2).
 - [ ] Confirm SwitchPros front locker wire routing (front axle access)
 - [ ] Decide if ARB control wires merge into H5 (recommended) or run as H6 signal pair
 - [ ] Source connector + lug + heat shrink BOM totals

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/index.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/index.md
@@ -69,7 +69,7 @@ All wire runs require appropriate protection based on location and environment:
 | Circuit                                | Wire Gauge | Distance | Destination                                       | Current             | Notes                                                                |
 | :------------------------------------- | :--------- | :------- | :------------------------------------------------ | :------------------ | :------------------------------------------------------------------- |
 | **Warn ZEON 10-S Winch power**       | 1/0 AWG    | 13 ft    | TO Front bumper winch                             | 250A typ, 409A peak | Direct connection (no CB) - see [Recovery Systems][recovery-systems] |
-| **Warn ZEON 10-S Winch ground**      | 1/0 AWG    | 13 ft    | TO Winch motor ground                             | 250A typ, 409A peak | Return path - routing TBD                                            |
+| **Warn ZEON 10-S Winch ground**      | 1/0 AWG    | 13 ft    | TO Winch motor ground                             | 250A typ, 409A peak | Return path - routing {{ tbd(106) }}                                 |
 | **Forward feed (Firewall CONSTANT bus)** | 2/0 AWG  | ~13 ft   | TO Firewall CONSTANT Bus (cabin trunk)            | ~232A max           | Protected by 300A CB at battery - feeds SwitchPros, BODY PDU, Fusion |
 | **SafetyHub local feed**               | 2 AWG      | ~2 ft    | TO SafetyHub 150 (local in wheel well)            | ~100A max           | Protected by 150A CB at battery                                      |
 | **BCDC output**                        | 4 AWG      | Short    | FROM BCDC (local in wheel well)                   | 50A                 | Charging input to AUX battery                                        |
@@ -111,7 +111,7 @@ All wire runs require appropriate protection based on location and environment:
 | **AUX bat → JL Audio MV800/8i Amp**    | 4 AWG      | ~3-4 ft  | TO MV800/8i amp (under rear seat)          | Via 100A CB at AUX battery (not via firewall bus) |
 | **SwitchPros Ground Bus**              | 1 AWG      | ~3 ft    | TO chassis ground at firewall              | Lighting/aux load returns                       |
 | **SwitchPros control cable**           | Multi-pin  | ~5 ft    | TO SwitchPros panel on dash                | Standard SwitchPros cable                       |
-| **SwitchPros outputs (12 circuits)**   | Various    | TBD      | TO various loads (front/cabin/rear/roof)   | Mostly short forward fan-out from firewall      |
+| **SwitchPros outputs (12 circuits)**   | Various    | {{ tbd(107) }} | TO various loads (front/cabin/rear/roof) | Mostly short forward fan-out from firewall      |
 
 ---
 
@@ -122,7 +122,7 @@ All wire runs require appropriate protection based on location and environment:
 | Penetration | Location | Direction | Circuits | Wire Count | Notes |
 |:------------|:---------|:----------|:---------|:-----------|:------|
 | **Cummins Harness** | Factory location | Engine ↔ Cabin | Engine harness, J1939 CAN | Factory | Dedicated bulkhead connector |
-| **Deutsch HDP24-24-29** | TBD (near PMU) | Bidirectional | All custom wiring | 17 | Single weatherproof connector |
+| **Deutsch HDP24-24-29** | {{ tbd(61) }} (near PMU) | Bidirectional | All custom wiring | 17 | Single weatherproof connector |
 | **Temp Probe Grommet** | Near grille | Cabin → Grille | BIM-17-2 temp sensor | 2 (22 AWG) | Small grommet, twisted pair |
 
 !!! info "J1939 CAN Bus"
@@ -138,7 +138,7 @@ J1939 CAN High/Low wires tap into Cummins harness at firewall punch-through, the
 
 | Routing Path        | Circuits                              | Method      | Notes                      |
 | :------------------ | :------------------------------------ | :---------- | :------------------------- |
-| **Dash → Console**  | Switch panels, USB, radio             | TBD         | Under dash routing         |
+| **Dash → Console**  | Switch panels, USB, radio             | {{ tbd(62) }} | Under dash routing       |
 | **Firewall → Dash** | Dakota Digital cluster, CT4, controls | Behind dash | Main instrument panel area |
 
 **Dakota Digital Firewall Panel (Cabin Side):**
@@ -151,8 +151,8 @@ J1939 CAN High/Low wires tap into Cummins harness at firewall punch-through, the
 | BIM-17-2     | Compass/outside temp | Temp probe (through firewall to grille)         |
 | Main harness | BIM/IO cable         | Dakota Digital cluster in dash                  |
 
-**Panel Location:** TBD - firewall behind dashboard
-**Mounting:** TBD - HDPE sheet dimensions and fasteners
+**Panel Location:** {{ tbd(39) }} - firewall behind dashboard
+**Mounting:** {{ tbd(39) }} - HDPE sheet dimensions and fasteners
 
 ---
 
@@ -162,8 +162,8 @@ J1939 CAN High/Low wires tap into Cummins harness at firewall punch-through, the
 
 | Routing Path                     | Circuits                         | Method         | Notes                         |
 | :------------------------------- | :------------------------------- | :------------- | :---------------------------- |
-| **Cab → Cargo**                       | Rear lights, compressor, lockers | TBD | Under seats or floor channels |
-| **Passenger rear wheel well → Cargo** | SwitchPros rear outputs          | TBD | Rear auxiliary power (avoid exposed frame rail) |
+| **Cab → Cargo**                       | Rear lights, compressor, lockers | {{ tbd(63) }} | Under seats or floor channels |
+| **Passenger rear wheel well → Cargo** | SwitchPros rear outputs          | {{ tbd(63) }} | Rear auxiliary power (avoid exposed frame rail) |
 
 ---
 
@@ -173,7 +173,7 @@ J1939 CAN High/Low wires tap into Cummins harness at firewall punch-through, the
 
 | Routing Path       | Circuits                          | Method              | Notes                      |
 | :----------------- | :-------------------------------- | :------------------ | :------------------------- |
-| **Roof/Roll bar**  | Light bars, dome lights           | TBD                 | A-pillar or along roll bar |
+| **Roof/Roll bar**  | Light bars, dome lights           | {{ tbd(64) }}       | A-pillar or along roll bar |
 | **Front exterior** | Turn signals, offroad lights      | Engine bay to front | SwitchPros outputs         |
 | **Rear exterior**  | Tail/brake/reverse, license plate | Cargo to rear       | PMU and SwitchPros outputs |
 

--- a/docs/jeep_lj/02-engine-systems/01-starter.md
+++ b/docs/jeep_lj/02-engine-systems/01-starter.md
@@ -124,9 +124,7 @@ Engine starts → driver releases button → Cole Hersee de-energizes → Bendix
 
 ## Outstanding Items
 
-Starter-circuit-specific items are tracked in the [Keyless Ignition][keyless-ignition] doc and the [TBD Tracker][tbd-tracker], since the crank chain is sourced from the keyless ignition design.
-
-See [installation checklist][install-checklist] for build tasks.
+{{ tbds() }}
 
 [install-checklist]: ../09-installation/02-engine-systems-checklist.md
 

--- a/docs/jeep_lj/02-engine-systems/02-brake-booster.md
+++ b/docs/jeep_lj/02-engine-systems/02-brake-booster.md
@@ -35,7 +35,7 @@ tags:
 
 **Power Source:** PMU OUT1+10 (40A main), OUT19 (5A ignition signal)
 
-**Wiring Harness:** TBD - [Tulay's Gen 2][tulays-harness] vs [EVcreate Gen 2 kit][evcreate-donors]
+**Wiring Harness:** {{ tbd(105) }} - [Tulay's Gen 2][tulays-harness] vs [EVcreate Gen 2 kit][evcreate-donors]
 
 ///
 
@@ -88,7 +88,7 @@ Wilwood **260-15542**, **1.00" bore** — sized to the TJ Rubicon front calipers
 - **Chassis runs:** 3/16" **copper-nickel** (NiCopp / Cunifer) hardline off the MC's 1/2-20 IF outlets, 45° double (bubble) flare with inverted-flare fittings. DOT-approved for hydraulic brakes, will not corrode, and hand-bends/flares without a hydraulic bender.[^brakeline-material] Copper-nickel is softer than steel, so sleeve in stainless spring "gravel guard" armor at exposed points and route inside the frame rail where possible.[^brakeline-armor]
 - **Axle ends:** DOT-compliant (FMVSS 106) braided-stainless flex hose at each axle, extended length sized to full suspension droop. **Lengths are blocked on axle + suspension selection** (Section 10 TBDs) — do not cut to length until ride height/articulation is fixed.[^fmvss106]
 - **Hardline → flex transition:** bulkhead fittings at each axle.
-- **Proportioning:** the iBooster has no integral proportioning valve. Front disc + rear disc warrants an **adjustable proportioning valve** on the rear circuit (plus residual-pressure valves if needed); size on assembly. TBD.
+- **Proportioning:** the iBooster has no integral proportioning valve. Front disc + rear disc warrants an **adjustable proportioning valve** on the rear circuit (plus residual-pressure valves if needed); size on assembly. {{ tbd(60) }}
 
 **Alternative considered — full -3 AN PTFE braided throughout:** field-repairable and common on non-street comp rigs, but not chosen for a street LJ — FMVSS 106 certification attaches to the finished assembly (DIY bulk-hose builds aren't road-certified) and the braid hides the liner from inspection.[^fmvss106] The hybrid keeps inspectable hardline on the long runs and isolates flex to the axles.
 
@@ -109,12 +109,12 @@ Wilwood **260-15542**, **1.00" bore** — sized to the TJ Rubicon front calipers
 | Flexline (×2) | Wilwood 220-12993 | Summit / Jegs | Ready to order | 8" -3 AN, includes 11/16-20 adapter |
 | Firewall mount (engine side) | iBooster integral 4-stud flange | Included w/ iBooster | Ships with donor | Bolts directly to firewall — 60×80mm M8 pattern (80mm vertical), ~62mm body neck through firewall[^body-neck] |
 | Firewall reinforcement (cabin side) | SendCutSend custom — see [DXF][backing-plate-dxf] | ~$15-30 | ⚠️ DXF needs redesign for 60×80mm pattern (currently drawn 72×72mm — see Outstanding Items) | 3/16" A36 steel, 152×152mm, 12mm corner radius, 9mm M8 holes, 64mm center bore. Zinc yellow plating |
-| Wiring harness | TBD | Tulay's or EVcreate | Decision pending donor arrival | Choice depends on donor pigtail condition |
+| Wiring harness | {{ tbd(105) }} | Tulay's or EVcreate | Decision pending donor arrival | Choice depends on donor pigtail condition |
 | Brake hardline (caliper side) | 3/16" copper-nickel (NiCopp / Cunifer) coil | Summit / AGS / O'Reilly | Spec'd — order with fittings | DOT-approved; 45° double flare, 1/2-20 IF at MC; route inside frame rail |
 | Hardline armor | 3/16" stainless spring gravel guard | 4LifetimeLines / Eastwood | Spec'd | Slide on before flaring; exposed runs |
 | Inverted-flare fittings + bulkhead tees | 3/16" / -3 AN | Summit / Earl's / Wilwood | Spec'd | Hardline unions + hardline→flex transition at axles |
-| Axle flex hoses | DOT braided stainless, extended length (TBD) | Goodridge / Rock Krawler / Synergy / Rusty's | ⚠️ Length blocked on axle + suspension TBD (Section 10) | FMVSS 106; size to full droop |
-| Adjustable proportioning valve | TBD (Wilwood adjustable prop valve or equiv.) | Wilwood / Summit | TBD | Rear circuit — iBooster has no integral proportioning |
+| Axle flex hoses | DOT braided stainless, extended length ({{ tbd(86) }}) | Goodridge / Rock Krawler / Synergy / Rusty's | ⚠️ Length blocked on axle + suspension (Section 10) | FMVSS 106; size to full droop |
+| Adjustable proportioning valve | {{ tbd(60) }} (Wilwood adjustable prop valve or equiv.) | Wilwood / Summit | {{ tbd(60) }} | Rear circuit — iBooster has no integral proportioning |
 
 ## Wiring
 
@@ -220,14 +220,14 @@ See [tail/brake][tail-brake] (PMU lighting flow), [starter][starter] (crank chai
 
 ## Outstanding Items
 
-**Waiting on external action:**
+{{ tbds() }}
 
-- [x] ~~Confirm Back Bay Customs MC adapter compatibility with Wilwood 260-15542~~ — ✅ confirmed by vendor (Adam, 2026-05-30): adapter fits the 260-15542, is Honda-iBooster-only (not Tesla), and the remote reservoirs are fine. Blocker cleared.
-- [x] ~~Close iBooster eBay offer ($195 sent on $254 listing)~~ — ✅ offer accepted 2026-05-30 (listing #397546491129); part #s 46680-T3Z-A00 + 01469-TWA-A58 confirmed on listing
+## Build Tasks
+
+**Waiting on external action:**
 
 **MC bore — resolved:**
 
-- [x] ~~Recalculate the required MC bore from the brake-system hydraulics~~ — ✅ **1.00" → Wilwood 260-15542** (2026-05-30). Sized to TJ Rubicon front calipers + rear disc + standard/light pedal feel; factory-matched and agrees with the already-confirmed adapter fitment. See Master Cylinder section.
 - [ ] Bench-measure TJ auto-pedal ratio on assembly — **geometry/travel check only**: confirm the ratio leaves MC stroke headroom (no long/sinking pedal) and the iBooster input rod gets full travel + full return. Does not affect the bore; pedal *feel* is drive-and-decide, not bench-tuned.
 
 **Backing plate redesign (vendor revised the firewall pattern):**
@@ -237,7 +237,6 @@ See [tail/brake][tail-brake] (PMU lighting flow), [starter][starter] (crank chai
 
 **In progress:**
 
-- [x] ~~Source 03-06 TJ/LJ automatic brake pedal assembly~~ — ordered; verify donor checks (switch + clip, pushrod hole bushing, pedal arm condition) on arrival
 - [ ] 3D-print PLA prototype of the **revised** backing plate ([DXF][backing-plate-dxf]) for trial fit; verify the 60×80mm hole spacing against donor studs and clearance for cabin-side hardware
 
 **Pending donor arrival** (purchased 2026-05-30, listing #397546491129):

--- a/docs/jeep_lj/02-engine-systems/03-hvac.md
+++ b/docs/jeep_lj/02-engine-systems/03-hvac.md
@@ -61,7 +61,7 @@ The CM2220 ECM used by the R2.8 has no A/C request input pin, so PMU-to-ECM A/C 
 
 ## Outstanding Items
 
-None - design complete. See [installation checklist][install-checklist] for build tasks.
+{{ tbds() }}
 
 ## Related Documentation
 

--- a/docs/jeep_lj/02-engine-systems/04-wipers.md
+++ b/docs/jeep_lj/02-engine-systems/04-wipers.md
@@ -53,7 +53,7 @@ See [PMU Outputs][pmu-outputs] for PMU configuration.
 
 ## Outstanding Items
 
-None - design complete. See [installation checklist][install-checklist] for build tasks.
+{{ tbds() }}
 
 ## Related Documentation
 

--- a/docs/jeep_lj/02-engine-systems/05-horn.md
+++ b/docs/jeep_lj/02-engine-systems/05-horn.md
@@ -66,7 +66,7 @@ START battery CONSTANT → PMU → Out 18 → PIAA Horns (5.4A) → Chassis Grou
 
 ## Outstanding Items
 
-None - design complete. See [installation checklist][install-checklist] for build tasks.
+{{ tbds() }}
 
 [install-checklist]: ../09-installation/02-engine-systems-checklist.md
 

--- a/docs/jeep_lj/02-engine-systems/06-radiator-fan.md
+++ b/docs/jeep_lj/02-engine-systems/06-radiator-fan.md
@@ -63,7 +63,7 @@ See [PMU Outputs][pmu-outputs] for complete configuration and [PMU Programming][
 
 ## Outstanding Items
 
-None - design complete. See [installation checklist][install-checklist] for build tasks.
+{{ tbds() }}
 
 ## Related Documentation
 

--- a/docs/jeep_lj/02-engine-systems/07-grid-heater.md
+++ b/docs/jeep_lj/02-engine-systems/07-grid-heater.md
@@ -103,7 +103,7 @@ flowchart LR
 
 ## Outstanding Items
 
-None - design complete. See [installation checklist][install-checklist] for build tasks.
+{{ tbds() }}
 
 ## Related Documentation
 

--- a/docs/jeep_lj/02-engine-systems/08-fuel-system.md
+++ b/docs/jeep_lj/02-engine-systems/08-fuel-system.md
@@ -57,7 +57,7 @@ Use the manual hand pump on the fuel filter/water separator to prime the system 
 
 ## Outstanding Items
 
-None - fuel system is straightforward mechanical design with no electrical integration required.
+{{ tbds() }}
 
 ## Related Documentation
 

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/01-hdx-control.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/01-hdx-control.md
@@ -122,6 +122,10 @@ All BIM modules connect via single daisy-chain harness from HDX control 3.5mm po
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Determine 4WD/4LO indicator signal types (NP241 Rubicon transfer case outputs)
 - [ ] Determine brake indicator source (brake switch vs CT4 output)
 - [ ] Bench-verify WAIT/EX polarity at HDX input — Cummins manual specifies active-low sink-circuit, but HDX docs list "active high"; resolve before final wiring

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/02-dashboard-cluster.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/02-dashboard-cluster.md
@@ -74,6 +74,10 @@ Speedometer is legally required for on-road vehicle operation. GPS-50-2 module p
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Verify oil pressure/temp data available via J1939 from Cummins R2.8
 
 ## Related Documentation

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/03-bim-j1939.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/03-bim-j1939.md
@@ -107,6 +107,10 @@ Specific J1939 parameters vary by ECM configuration and vehicle application. Cum
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Confirm all J1939 parameters available from Cummins R2.8 ECM configuration
 
 ## Related Documentation

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/04-bim-gps.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/04-bim-gps.md
@@ -79,6 +79,10 @@ GPS speedometer is legally required for on-road operation. Ensure antenna has cl
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Determine GPS antenna mounting location (dash top vs windshield)
 - [ ] Determine if using SEN-15-1 temp probe with GPS-50-2 or separate BIM-17-2
 

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/05-bim-tpms.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/05-bim-tpms.md
@@ -74,6 +74,10 @@ Wireless TPMS module displaying real-time tire pressure for all four wheels on H
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Confirm TPMS sensor compatibility with wheel/tire setup (valve stem hole size)
 - [ ] Determine sensor battery life and replacement procedure
 

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/06-bim-compass.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/06-bim-compass.md
@@ -88,6 +88,10 @@ tags:
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Determine outside temperature probe mounting location in grille area
 - [ ] Determine primary compass source (BIM-17-2 vs GPS-50-2)
 

--- a/docs/jeep_lj/02-engine-systems/11-runaway-protection.md
+++ b/docs/jeep_lj/02-engine-systems/11-runaway-protection.md
@@ -156,6 +156,10 @@ Both upgrades preserve the manual cable as the always-available backup.
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Verify R2.8 turbo inlet tube outside diameter (2.5" suspected; 2.8" AMOT body is closest available)
 - [ ] Source NPT-to-hose adapter fittings sized to match turbo inlet
 - [ ] Select dash T-handle mounting location (within reach belted, away from accidental contact)

--- a/docs/jeep_lj/03-lighting-systems/02-headlights.md
+++ b/docs/jeep_lj/03-lighting-systems/02-headlights.md
@@ -65,6 +65,10 @@ tags:
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Plan wire routing from CT4 to headlight buckets (engine bay, 14 AWG)
 - [ ] Verify headlight aim after installation (LP6 DOT is compliant, just needs aiming)
 

--- a/docs/jeep_lj/03-lighting-systems/03-turn-signals.md
+++ b/docs/jeep_lj/03-lighting-systems/03-turn-signals.md
@@ -58,7 +58,10 @@ Rear turn signals are fed from the CT4 splice (see distribution table above):
 
 ## Outstanding Items
 
-- [x] ~~Plan wire routing from CT4 to fender turn signal locations~~ → Via firewall grommet
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Measure wire distance: CT4 → firewall → fenders (see [Wire Distance Reference][wire-distance])
 
 [wire-distance]: ../01-power-systems/01-power-generation/05-wire-distance-reference.md

--- a/docs/jeep_lj/03-lighting-systems/04-tail-brake-reverse.md
+++ b/docs/jeep_lj/03-lighting-systems/04-tail-brake-reverse.md
@@ -95,6 +95,10 @@ See [DRL/Parking Lights][drl-parking-lights] for circuit details.
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Plan wire routing from CT4 to rear tail lights
 - [ ] Plan wire routing from PMU Out 21/22 to rear tail lights
 

--- a/docs/jeep_lj/03-lighting-systems/05-drl-parking.md
+++ b/docs/jeep_lj/03-lighting-systems/05-drl-parking.md
@@ -86,6 +86,10 @@ END
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Plan wire routing from ignition switch RUN to PMU Pin 7 (splits to CT4, SwitchPros)
 - [ ] Plan wire routing from CT4 SW3 to PMU In 7 (DRL cutoff logic)
 - [ ] Create PMU programming configuration with DRL auto-off logic

--- a/docs/jeep_lj/03-lighting-systems/06-dome-lights.md
+++ b/docs/jeep_lj/03-lighting-systems/06-dome-lights.md
@@ -53,6 +53,10 @@ Physical switch on KC #6337 bracket for rear dome control independent of SwitchP
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Plan wire routing from SwitchPros to roll bar mounts
 
 ## Related Documentation

--- a/docs/jeep_lj/04-offroad-lighting/01-ditch-lights.md
+++ b/docs/jeep_lj/04-offroad-lighting/01-ditch-lights.md
@@ -63,6 +63,10 @@ Driving/Combo pattern provides peripheral illumination for:
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Plan wire routing from SwitchPros to A-pillars
 
 ## Related Documentation

--- a/docs/jeep_lj/04-offroad-lighting/03-roof-lights.md
+++ b/docs/jeep_lj/04-offroad-lighting/03-roof-lights.md
@@ -57,6 +57,10 @@ See [SwitchPros SP-1200][switchpros-sp-1200] for wiring details.
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Plan wire routing from SwitchPros to roof rack (passenger A-pillar to roof)
 - [ ] Confirm roof rack mounting points for XL Linkable brackets
 

--- a/docs/jeep_lj/04-offroad-lighting/06-rock-lights.md
+++ b/docs/jeep_lj/04-offroad-lighting/06-rock-lights.md
@@ -52,6 +52,10 @@ See [SwitchPros SP-1200][switchpros-sp-1200] for wiring details.
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Plan wire routing from SwitchPros to wheel wells and bumpers
 
 ## Related Documentation

--- a/docs/jeep_lj/04-offroad-lighting/09-footwell-lights.md
+++ b/docs/jeep_lj/04-offroad-lighting/09-footwell-lights.md
@@ -69,6 +69,10 @@ See [Audio Systems][audio-systems] for MLC-RW details.
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Confirm LED4Life pod wire colors match table above
 
 ## Related Documentation

--- a/docs/jeep_lj/04-offroad-lighting/index.md
+++ b/docs/jeep_lj/04-offroad-lighting/index.md
@@ -51,7 +51,7 @@ Lighting organized by [Baja Designs Zone System][bd-zones], optimized for specif
 
 ## Outstanding Items
 
-None - design complete. See individual product pages for component-specific items and [installation checklist][install-checklist] for build tasks.
+{{ tbds() }}
 
 ## Related Documentation
 

--- a/docs/jeep_lj/05-control-interfaces/02-switchpros-sp1200.md
+++ b/docs/jeep_lj/05-control-interfaces/02-switchpros-sp1200.md
@@ -194,6 +194,10 @@ Program TRIGGER-3 to activate compressor when tank pressure drops below 135 PSI:
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Determine exact SwitchPros power module mounting location at firewall (passenger cabin side, near BODY PDU)
 - [ ] Determine SwitchPros control panel mounting location on dash
 - [ ] Route 4 AWG logic ground wire from SwitchPros power module to chassis ground at firewall (short run, per manufacturer spec)

--- a/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
+++ b/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
@@ -289,6 +289,10 @@ END
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Determine GPS antenna mounting location (dash top or near windshield for best sky view)
 
 ## Related Documentation

--- a/docs/jeep_lj/05-control-interfaces/05-dashboard-controls.md
+++ b/docs/jeep_lj/05-control-interfaces/05-dashboard-controls.md
@@ -27,9 +27,9 @@ All dash-mounted physical switches use the **Toyota OEM cutout standard: 1.54" �
 | # | Switch | Status | Function | Power | Notes |
 |:-:|:-------|:-------|:---------|:------|:------|
 | 1 | **Winch IN/OUT** | ✓ Selected: CH4X4-TOY-D-WINIO | Dual-momentary push, IN and OUT | BODY PDU CB43 (10A) | See [Winch Control Switch](#winch-control-switch) below |
-| 2 | **Drive mode select** (transmission) | 🔴 TBD | 3-position mode select (Street / Default / Offroad) — exact action depends on TCU spec | TBD (likely BODY PDU) | Verify TCU input requirements before sourcing |
-| 3 | **Driver heated seat** | 🔴 TBD | ON/OFF latching (or momentary for Hi/Lo if available) | BODY PDU CB45 via relay K21 | Toyota-style equivalent needed |
-| 4 | **Passenger heated seat** | 🔴 TBD | ON/OFF latching | BODY PDU CB42 via relay K22 | Toyota-style equivalent needed |
+| 2 | **Drive mode select** (transmission) | {{ tbd(72) }} | 3-position mode select (Street / Default / Offroad) — exact action depends on TCU spec | {{ tbd(72) }} (likely BODY PDU) | Verify TCU input requirements before sourcing |
+| 3 | **Driver heated seat** | {{ tbd(73) }} | ON/OFF latching (or momentary for Hi/Lo if available) | BODY PDU CB45 via relay K21 | Toyota-style equivalent needed |
+| 4 | **Passenger heated seat** | {{ tbd(73) }} | ON/OFF latching | BODY PDU CB42 via relay K22 | Toyota-style equivalent needed |
 
 **Excluded from this panel** (different aesthetic/form factor by design):
 

--- a/docs/jeep_lj/05-control-interfaces/06-keyless-ignition.md
+++ b/docs/jeep_lj/05-control-interfaces/06-keyless-ignition.md
@@ -95,7 +95,7 @@ Unchanged from existing starter design. See [Starter System][starter].
 
 | Wire | Function | Source | Destination | Notes |
 | :--- | :------- | :----- | :---------- | :---- |
-| RED | +12V Battery | Critical Cabin PDU (CONSTANT) | PBS-I module | 14 AWG; ~50 mA standby (TBD verify) |
+| RED | +12V Battery | Critical Cabin PDU (CONSTANT) | PBS-I module | 14 AWG; ~50 mA standby ({{ tbd(84) }}) |
 | BLACK | Chassis Ground | Cabin ground bus | PBS-I module | 14 AWG |
 | PINK | 1st Ignition Out (60A) | PBS-I module | Ignition signal bus bar (cabin), Stud 1 | Does NOT drop during crank; bus bar Stud 2 outbounds to ECM Pin 41 via 5A inline fuse[^ecm-fuse] |
 | PURPLE | Starter Out (60A) | PBS-I module | WAIT-gate relay common (NC input) | Cranks while button held |
@@ -152,15 +152,17 @@ Normal engine shutdown (press brake + 2 sec button hold) drops PBS-I's PINK IGN 
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Confirm the WAIT-gate relay coil (~150 mA) in parallel with the dash WAIT lamp does not exceed the ECM lamp-driver sink rating (Pin 35 polarity itself is confirmed active-low per Cummins 5504137 — see [^wait-polarity]). If marginal, drive the relay from the lamp's keyswitch side or use a higher-impedance/solid-state relay
 - [ ] Order Digital Guard Dawg PBS-I kit (includes ICM, 2 fobs, Start Button, Programming Button, Bypass Card, harnesses)
-- [x] ~~Select WAIT-gate relay part~~ → **Bosch 0332209150** (5-pin SPDT changeover, superseded by 0986332400); wire COM (30) + NC (87a), leave NO (87) open. See [^wait-relay].
 - [ ] Add 5A inline fuse on the ignition (keyswitch) feed to ECM Pin 41 — pink wire, per Cummins 5504137 (see [^ecm-fuse])
 - [ ] Select PBS-I module mounting location (cabin under-dash, away from heat and water)
 - [ ] Select Start Button dash mounting position (within easy reach of driver)
 - [ ] Select Programming Button storage location (hidden but accessible)
 - [ ] Verify PBS-I quiescent current draw to add to START battery parasitic budget
-- [x] ~~Confirm Feature Programming defaults~~ → PBS-I has no DIP/jumper menu; **shipped Feature Programming defaults confirmed acceptable** for this build (no reprogramming required at install). Owner decision, 2026-06-03.
 
 ## Related Documentation
 

--- a/docs/jeep_lj/06-audio-systems/01-head-unit.md
+++ b/docs/jeep_lj/06-audio-systems/01-head-unit.md
@@ -79,7 +79,7 @@ Head unit has internal power management - draws full power when ignition sense i
 
 ## Outstanding Items
 
-None - all specifications determined.
+{{ tbds() }}
 
 ## Related Documentation
 

--- a/docs/jeep_lj/06-audio-systems/02-amplifier.md
+++ b/docs/jeep_lj/06-audio-systems/02-amplifier.md
@@ -145,6 +145,10 @@ The 100A external CB is intentionally above the 80A internal fuse — the intern
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] DSP configuration: corner frequencies, sub delay, channel gain matching (set during install with TüN software + measurement)
 
 ## Related Documentation

--- a/docs/jeep_lj/06-audio-systems/03-speakers.md
+++ b/docs/jeep_lj/06-audio-systems/03-speakers.md
@@ -107,7 +107,7 @@ Single cable run per speaker carries both audio and LED control.
 
 ## Outstanding Items
 
-- [x] ~~Determine front speaker mounting locations~~ → **In-door, custom Gatekeeper Offroad half-doors** (6.5" cutouts). Route speaker/LED cable through the door hinge into the body via a service grommet.
+{{ tbds() }}
 
 ## Related Documentation
 

--- a/docs/jeep_lj/06-audio-systems/04-subwoofer.md
+++ b/docs/jeep_lj/06-audio-systems/04-subwoofer.md
@@ -96,6 +96,10 @@ The single 12" M7-12IB option (600W RMS, 14" overall diameter, 7.94" mounting de
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Confirm exact mounting locations in rear quarter panels (clear of cage tubes and rear seatbelts)
 - [ ] Verify quarter panel material can support sub weight + mounting torque (may need backing plate)
 - [ ] Source M6-8IB-S product image (`docs/jeep_lj/images/jl-audio-m6-8ib-s-gmti-i-4.jpg`)

--- a/docs/jeep_lj/06-audio-systems/05-led-controller.md
+++ b/docs/jeep_lj/06-audio-systems/05-led-controller.md
@@ -108,6 +108,10 @@ See [Footwell Lights][footwell-lights] for pod details.
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Confirm LED4Life pod wire colors match MLC-RW pinout
 
 ## Related Documentation

--- a/docs/jeep_lj/06-audio-systems/06-bluetooth-tuning.md
+++ b/docs/jeep_lj/06-audio-systems/06-bluetooth-tuning.md
@@ -120,6 +120,10 @@ Press-and-hold the LED button 10 sec → Factory Reset (wipes paired-device list
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Decide BTC mounting surface — trans-tunnel cover vs amp-mounting-plate standoff vs A-pillar/under-dash (whatever balances RF clearance with status-LED visibility)
 - [ ] Source VXi-BTC product image (`docs/jeep_lj/images/jl-audio-vxi-btc.jpg`)
 

--- a/docs/jeep_lj/06-audio-systems/index.md
+++ b/docs/jeep_lj/06-audio-systems/index.md
@@ -42,7 +42,7 @@ MLC-RW LED Controller
 
 ## Outstanding Items
 
-None - see individual component pages for specific items.
+{{ tbds() }}
 
 ## Related Documentation
 

--- a/docs/jeep_lj/07-communication-systems/01-gmrs-radio.md
+++ b/docs/jeep_lj/07-communication-systems/01-gmrs-radio.md
@@ -79,7 +79,7 @@ tags:
 
 ## Outstanding Items
 
-None - all specifications determined.
+{{ tbds() }}
 
 ## Related Documentation
 

--- a/docs/jeep_lj/07-communication-systems/02-intercom.md
+++ b/docs/jeep_lj/07-communication-systems/02-intercom.md
@@ -82,7 +82,7 @@ tags:
 
 ## Outstanding Items
 
-None - all specifications determined.
+{{ tbds() }}
 
 ## Related Documentation
 

--- a/docs/jeep_lj/07-communication-systems/04-dash-camera.md
+++ b/docs/jeep_lj/07-communication-systems/04-dash-camera.md
@@ -85,7 +85,7 @@ Tap into reverse light circuit → route to WolfBox trigger input
 
 ## Outstanding Items
 
-None - all specifications determined.
+{{ tbds() }}
 
 ## Related Documentation
 

--- a/docs/jeep_lj/07-communication-systems/05-navigation.md
+++ b/docs/jeep_lj/07-communication-systems/05-navigation.md
@@ -75,7 +75,7 @@ The Tread 2 Overland has built-in inReach hardware but it is not activated — s
 
 ## Outstanding Items
 
-None - all specifications determined.
+{{ tbds() }}
 
 ## Related Documentation
 

--- a/docs/jeep_lj/07-communication-systems/index.md
+++ b/docs/jeep_lj/07-communication-systems/index.md
@@ -42,7 +42,7 @@ WolfBox Mirror Camera
 
 ## Outstanding Items
 
-None - see individual component pages for specific items.
+{{ tbds() }}
 
 ## Related Documentation
 

--- a/docs/jeep_lj/08-exterior-systems/01-winch.md
+++ b/docs/jeep_lj/08-exterior-systems/01-winch.md
@@ -116,7 +116,7 @@ See [AUX Battery Distribution][aux-battery] for wire specs (gauge, length, routi
 
 See [AUX Battery Distribution][aux-battery] for cable specs and routing path.
 
-- **Route:** Passenger rear wheel well → front bumper (~13 ft, exact path TBD - avoid exposed frame rail per offroad protection requirement)
+- **Route:** Passenger rear wheel well → front bumper (~13 ft, exact path: {{ tbd(106) }} - avoid exposed frame rail per offroad protection requirement)
 - **Protection:** Split loom over entire run
 - **Securing:** P-clamps every 18" along the chosen path
 - **Grommets:** Rubber grommets with sealant at body penetrations
@@ -152,7 +152,7 @@ See [AUX Battery Distribution][aux-battery] for cable specs and routing path.
 
 ## Outstanding Items
 
-None - all specifications determined.
+{{ tbds() }}
 
 ## Related Documentation
 

--- a/docs/jeep_lj/08-exterior-systems/02-air-compressor.md
+++ b/docs/jeep_lj/08-exterior-systems/02-air-compressor.md
@@ -183,6 +183,10 @@ Compressor fills tank to 150 PSI → pressure switch opens → compressor stops
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Verify ARB CKBLTA12 wiring harness connector pinout for motor 1, motor 2, and control terminals
 - [ ] Confirm under-seat mounting bracket/location for compressor and 1-gallon tank
 - [ ] Purchase ARB 171507 1-gallon aluminum air tank

--- a/docs/jeep_lj/08-exterior-systems/03-air-lockers.md
+++ b/docs/jeep_lj/08-exterior-systems/03-air-lockers.md
@@ -48,7 +48,7 @@ ARB RD116 air-operated locking differentials for front and rear Dana 44 axles.
 
 | Locker | SwitchPros Output | Wire   | Route                                               |
 | ------ | ----------------- | ------ | --------------------------------------------------- |
-| Front  | OUTPUT-17         | 18 AWG | Passenger rear wheel well → front axle (~12 ft, routing TBD) |
+| Front  | OUTPUT-17         | 18 AWG | Passenger rear wheel well → front axle (~12 ft, routing {{ tbd(81) }}) |
 | Rear   | OUTPUT-10         | 18 AWG | Passenger rear wheel well → rear axle (~6 ft)                |
 
 ### Wire Routing
@@ -115,6 +115,10 @@ ARB RD116 air-operated locking differentials for front and rear Dana 44 axles.
     - Ensure adequate air pressure before engaging lockers
 
 ## Outstanding Items
+
+{{ tbds() }}
+
+## Build Tasks
 
 - [ ] Verify ARB RD116 compatibility with Dana 44 30-spline 5.38 gear ratio
 - [ ] Order ARB air line installation kit with 1/4" fittings for front/rear lockers

--- a/docs/jeep_lj/08-exterior-systems/04-rear-air-chuck.md
+++ b/docs/jeep_lj/08-exterior-systems/04-rear-air-chuck.md
@@ -47,6 +47,10 @@ External air access plate mounted in the tailgate area for tire inflation and ai
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Select air chuck plate model/part number
 - [ ] Determine exact mounting location in tailgate area
 - [ ] Measure air line length from manifold to tailgate

--- a/docs/jeep_lj/08-exterior-systems/index.md
+++ b/docs/jeep_lj/08-exterior-systems/index.md
@@ -43,7 +43,7 @@ Recovery equipment and air systems for offroad capability.
 
 ## Outstanding Items
 
-See individual component pages for specific items.
+{{ tbds() }}
 
 ## Related Documentation
 

--- a/docs/jeep_lj/09-installation/02-engine-systems-checklist.md
+++ b/docs/jeep_lj/09-installation/02-engine-systems-checklist.md
@@ -149,7 +149,7 @@ Organized by installation order for efficient build workflow.
 
 ### Catch Can Installation
 
-- [ ] Confirm Mishimoto MMOCC-UB bracket mounted to selected engine bay location (TBD - intake side, away from exhaust)
+- [ ] Confirm Mishimoto MMOCC-UB bracket mounted to selected engine bay location ({{ tbd(58) }} - intake side, away from exhaust)
 - [ ] Confirm MMOCC-CBT catch can installed vertically with petcock at bottom
 - [ ] Confirm 5/8" hose from R2.8 valve cover breather to catch can INLET (worm clamps both ends)
 - [ ] Confirm 5/8" hose from catch can OUTLET to turbo inlet (worm clamps both ends)
@@ -166,8 +166,8 @@ Organized by installation order for efficient build workflow.
 
 ### Cable and T-Handle Installation
 
-- [ ] Confirm Midwest 30-144-TTL-BH-3 T-handle mounted at selected dash location (TBD)
-- [ ] Confirm cable conduit passes through dedicated firewall grommet (TBD - must not share with other cables)
+- [ ] Confirm Midwest 30-144-TTL-BH-3 T-handle mounted at selected dash location ({{ tbd(56) }})
+- [ ] Confirm cable conduit passes through dedicated firewall grommet ({{ tbd(57) }} - must not share with other cables)
 - [ ] Confirm cable secured every 12" with adel clamps; no sharp bends (≥6" radius)
 - [ ] Confirm cable end attaches to AMOT trip lever; pull stroke ≥0.5" past trip point
 - [ ] Confirm T-handle sits flush against dash bezel when AMOT is cocked open

--- a/docs/jeep_lj/09-installation/03-purchase-tracker.md
+++ b/docs/jeep_lj/09-installation/03-purchase-tracker.md
@@ -11,7 +11,7 @@ Components organized by estimated cost for purchase planning (Black Friday, sale
 | Status | Count | Est. Total |
 |:-------|------:|-----------:|
 | Purchased | 20+ | ~$12,200+ |
-| To Purchase | 40+ | TBD |
+| To Purchase | 40+ | ~$8,800–9,300 |
 
 ---
 
@@ -70,7 +70,7 @@ Major components - watch for sales, consider financing options.
 | Wilwood 260-16392 Remote Reservoir (×2) | Wilwood | ~$260-320 | High | 4oz anodized, -3 AN port - [iBooster][ibooster] |
 | Wilwood 250-16393 Dual Reservoir Bracket | Wilwood | ~$45-65 | High | Anodized billet - [iBooster][ibooster] |
 | Wilwood 220-12993 -3 AN Flexline (×2) | Wilwood | ~$50-70 | High | 8" w/ 11/16-20 adapter - [iBooster][ibooster] |
-| iBooster Wiring Harness | Tulay's or EVcreate | ~$60-150 | High | TBD: Gen 2 universal vs EVcreate kit - [Harness][tulays] |
+| iBooster Wiring Harness | Tulay's or EVcreate | ~$60-150 | High | {{ tbd(105) }}: Gen 2 universal vs EVcreate kit - [Harness][tulays] |
 | Firewall backing plate (cabin side) | SendCutSend | ~$15-30 | High | Flat 3/16" steel sandwich plate, donor bracket pattern + 62mm center - [iBooster][ibooster] |
 | JL Audio MV800/8i Amplifier (010-03339-00) | JL Audio (Garmin) | ~$900 | Medium | 8-ch w/ DSP, replaces Fusion AP61800 plan - [Amplifier][amplifier] |
 | JL Audio M6-8IB-S-GmTi-i-4 Subwoofer (×2) | JL Audio | ~$700 (pair) | Low | Replaces single M7-12IB plan - [Subwoofer][subwoofer] |

--- a/docs/jeep_lj/10-drivetrain/01-transmission.md
+++ b/docs/jeep_lj/10-drivetrain/01-transmission.md
@@ -186,9 +186,13 @@ The Turbolamik communicates with the Cummins R2.8 ECM via J1939 CAN for:
 | :----------------- | :----------------- | :------------------------------- |
 | Adapter Kit        | Custom             | R2.8 to 8HP70 (in progress)      |
 | Flexplate          | Adapted from AX15 kit | R2.8 to 8HP70 (custom adapter) |
-| Pilot Bearing      | TBD                | If required                      |
+| Pilot Bearing      | {{ tbd(91) }}      | If required                      |
 
 ## Outstanding Items
+
+{{ tbds() }}
+
+## Build Tasks
 
 - [ ] Order Turbolamik TCU 2.0 with basic wiring harness
 - [ ] Install Turbolamik TCU on 8HP70 mechatronic (soldering required)

--- a/docs/jeep_lj/10-drivetrain/02-transfer-case.md
+++ b/docs/jeep_lj/10-drivetrain/02-transfer-case.md
@@ -90,6 +90,10 @@ The 8HP *family* does pair with an NV241 from the factory — the JL Wrangler au
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Measure 8HP70 output-shaft protrusion (≤~96 mm, else order DomiWorks spacer plate or shorten)
 - [ ] Order: DomiWorks 24004001 adapter; 23-spline NV241 input gear (ZTNP22390 or equiv.); NV241 input bearing + front seal; grade-10.9 hardware
 - [ ] Confirm donor JK case input-gear spline before swapping to the 23-spline gear

--- a/docs/jeep_lj/10-drivetrain/03-driveshafts.md
+++ b/docs/jeep_lj/10-drivetrain/03-driveshafts.md
@@ -7,18 +7,22 @@ Both driveshafts are custom units built to measured length by Tom Woods Custom D
 | Specification | Value |
 | :------------ | :---- |
 | Type | Custom (Tom Woods Custom Drive Shafts) |
-| Length | TBD — measure at final ride height |
-| U-Joint | TBD — per Tom Woods build spec |
+| Length | {{ tbd(93) }} — measure at final ride height |
+| U-Joint | {{ tbd(93) }} — per Tom Woods build spec |
 
 ## Rear Driveshaft
 
 | Specification | Value |
 | :------------ | :---- |
 | Type | Custom (Tom Woods Custom Drive Shafts) |
-| Length | TBD — measure at final ride height |
-| U-Joint | TBD — per Tom Woods build spec |
+| Length | {{ tbd(94) }} — measure at final ride height |
+| U-Joint | {{ tbd(94) }} — per Tom Woods build spec |
 
 ## Outstanding Items
+
+{{ tbds() }}
+
+## Build Tasks
 
 - [ ] Measure front driveshaft length at final ride height and order from Tom Woods
 - [ ] Measure rear driveshaft length at final ride height and order from Tom Woods

--- a/docs/jeep_lj/10-drivetrain/06-suspension.md
+++ b/docs/jeep_lj/10-drivetrain/06-suspension.md
@@ -23,8 +23,8 @@ tags:
 | :------------ | :---- |
 | Wheelbase | 110.5" (stretched from 103.4" stock) |
 | Approach Angle | 87.1° |
-| Departure Angle | TBD |
-| Breakover Angle | TBD |
+| Departure Angle | {{ tbd(102) }} |
+| Breakover Angle | {{ tbd(102) }} |
 | Type | Coilover bypass struts |
 | Front Travel | 14" |
 | Rear Travel | 16" |
@@ -35,24 +35,28 @@ tags:
 | Component | Specification |
 | :-------- | :------------ |
 | Struts | ORI 14" |
-| Coil Rate | TBD |
-| Bypass Valving | TBD |
-| Control Arms | TBD |
-| Track Bar | TBD |
-| Sway Bar | TBD |
+| Coil Rate | {{ tbd(97) }} |
+| Bypass Valving | {{ tbd(97) }} |
+| Control Arms | {{ tbd(97) }} |
+| Track Bar | {{ tbd(97) }} |
+| Sway Bar | {{ tbd(97) }} |
 
 ## Rear Suspension
 
 | Component | Specification |
 | :-------- | :------------ |
 | Struts | ORI 16" |
-| Coil Rate | TBD |
-| Bypass Valving | TBD |
-| Control Arms | TBD |
-| Track Bar | TBD |
-| Sway Bar | TBD |
+| Coil Rate | {{ tbd(98) }} |
+| Bypass Valving | {{ tbd(98) }} |
+| Control Arms | {{ tbd(98) }} |
+| Track Bar | {{ tbd(98) }} |
+| Sway Bar | {{ tbd(98) }} |
 
 ## Outstanding Items
+
+{{ tbds() }}
+
+## Build Tasks
 
 - [ ] Document ORI strut part numbers
 - [ ] Document coil rates

--- a/docs/jeep_lj/10-drivetrain/07-steering.md
+++ b/docs/jeep_lj/10-drivetrain/07-steering.md
@@ -27,8 +27,8 @@ Component part numbers below come from the PSC **FHK400TJ** kit — the 1997-200
 | Kit | PSC FHK400TJ (TJ/LJ Extreme Series, 2.75" double-ended) |
 | Steering Control Valve | PSC 160cc orbital (in FHA160-S accessory kit) |
 | Ram | PSC SC2227K1 (2.75" × 8.0" double-ended) |
-| Pump | Cummins-specific PSC pump TBD (kit PK40JP2-FH is 4.0L-only) |
-| Reservoir | Remote (included with pump kit) — model TBD |
+| Pump | Cummins-specific PSC pump — {{ tbd(99) }} (kit PK40JP2-FH is 4.0L-only) |
+| Reservoir | Remote (included with pump kit) — model {{ tbd(103) }} |
 | Cooler | Mishimoto fluid cooler + fan (180 °F inline thermostat) |
 | Fluid | PSC 715 (SWEPCO 715) |
 
@@ -41,10 +41,10 @@ Component part numbers below come from the PSC **FHK400TJ** kit — the 1997-200
 | Specification | Value |
 | :------------ | :---- |
 | Manufacturer | PSC Motorsports |
-| Model | TBD — Cummins R2.8 pump + bracket (NOT the kit's PK40JP2-FH) |
-| Flow Rate | TBD |
-| Pressure | TBD |
-| Drive | TBD (belt vs. Cummins gear-drive) |
+| Model | {{ tbd(99) }} — Cummins R2.8 pump + bracket (NOT the kit's PK40JP2-FH) |
+| Flow Rate | {{ tbd(99) }} |
+| Pressure | {{ tbd(99) }} |
+| Drive | {{ tbd(99) }} (belt vs. Cummins gear-drive) |
 
 ### Steering Control Valve
 
@@ -68,8 +68,8 @@ Component part numbers below come from the PSC **FHK400TJ** kit — the 1997-200
 | Specification | Value |
 | :------------ | :---- |
 | Type | Remote (included with PSC pump kit) |
-| Capacity | TBD |
-| Location | TBD |
+| Capacity | {{ tbd(103) }} |
+| Location | {{ tbd(103) }} |
 
 ### Cooler
 
@@ -78,7 +78,7 @@ Component part numbers below come from the PSC **FHK400TJ** kit — the 1997-200
 | Unit | Mishimoto fluid cooler |
 | Fan | Mishimoto (matched to cooler) |
 | Control | 180 °F inline thermostat |
-| Fan Current Draw | TBD (confirm fits PMU Out 8 ~15A budget) |
+| Fan Current Draw | {{ tbd(101) }} (confirm fits PMU Out 8 ~15A budget) |
 | Fan Power Source | PMU Out 8 (~15A, thermostat-switched) — see [PMU Outputs][pmu-outputs] |
 
 ## Fluid Specifications
@@ -86,9 +86,13 @@ Component part numbers below come from the PSC **FHK400TJ** kit — the 1997-200
 | Specification | Value |
 | :------------ | :---- |
 | Fluid Type | PSC 715 (SWEPCO 715) |
-| Capacity | TBD (kit ships ~4 qt; confirm system fill) |
+| Capacity | {{ tbd(103) }} (kit ships ~4 qt; confirm system fill) |
 
 ## Outstanding Items
+
+{{ tbds() }}
+
+## Build Tasks
 
 - [ ] Source a Cummins R2.8-compatible PSC pump + bracket (kit PK40JP2-FH is 4.0L-only)
 - [ ] Confirm pump drive type (belt vs Cummins gear-drive), flow rate, and pressure
@@ -100,7 +104,6 @@ Component part numbers below come from the PSC **FHK400TJ** kit — the 1997-200
 - [ ] Document hydraulic line routing
 
 [^steering-config]: Owner decision, 2026-05-30 — full-hydro kit is PSC pump + PSC orbital valve + PSC double-ended ram; Busted Knuckle Off-Road steering stops limit ram stroke to Dana 44 spec; Artec Industries Dana 60 ram mount cut down to the Dana 44; Mishimoto fluid cooler + fan on a 180 °F inline thermostat. Model numbers, bore/stroke values, flow/pressure, and fluid specs remain pending.
-
 [^psc-kit]: PSC Motorsports **FHK400TJ** — 1997-2006 Jeep TJ/LJ Extreme Series full hydraulic kit, 2.75" double-ended cylinder (PSC Motorsports / pscsteering.com, accessed 2026-05-31). Kit boxes: **FHA160-S** (160cc full-hydraulic accessory kit w/ orbital valve), **PK40JP2-FH** (high-flow pump kit — **Jeep 4.0L bracket**, not used here), **SC2227K1** (2.75" × 8.0" double-ended cylinder); fluid PSC/SWEPCO 715. Smaller-tire variant is **FHK100TJ** (2.5" bore / 125cc valve, 35-42"). Pump bracket is 4.0L-specific, so it does not fit this build's Cummins R2.8 — valve and cylinder carry over.
 
 ## Related Documentation

--- a/docs/jeep_lj/10-drivetrain/index.md
+++ b/docs/jeep_lj/10-drivetrain/index.md
@@ -45,6 +45,10 @@ Complete drivetrain system documentation for the Jeep LJ build.
 
 ## Outstanding Items
 
+{{ tbds() }}
+
+## Build Tasks
+
 - [ ] Document driveshaft specifications
 
 ## Related Documentation

--- a/docs/jeep_lj/CLAUDE.md
+++ b/docs/jeep_lj/CLAUDE.md
@@ -165,7 +165,25 @@ grep -rn "TBD" docs/jeep_lj --include="*.md" | grep -v "tbd-tracker" | grep -v "
 gh issue list -R sob/drawings --label tbd --state open --limit 200
 ```
 
-Run `/verify-tbd` to reconcile source TBD markers against open issues.
+Run `/verify-tbd` to reconcile source TBD markers against open issues, or run
+`python3 hooks/verify_tbd.py` for the non-interactive version (this is what
+CI runs via `.github/workflows/verify-tbd.yml` — a PR touching `docs/**` or
+`tbd_macros.py` fails the check if any source TBD is untracked, any open
+issue's `Source:` file is missing, or any open issue is missing a required
+label facet).
+
+**Macros (in `tbd_macros.py`):**
+
+- `{{ tbds() }}` — list open `tbd` issues for the current page's project+area,
+  grouped by priority. Auto-derives scope from the page path.
+- `{{ tbds(scope='project', layout='github') }}` — filterable list of all open
+  issues for the vehicle (used on `tbd-tracker.md`).
+- `{{ tbds_resolved(scope='project', since='90d') }}` — closed `tbd` issues in
+  the window, with the closing comment as the resolution (replaces the
+  hand-maintained RECENTLY RESOLVED table).
+- `{{ tbd(N) }}` — inline marker for a single spec cell. Renders `TBD #N` as a
+  link while open; flips to the resolution snippet when the issue closes, so
+  cells become self-resolving without a source edit.
 
 **Priority Levels (`priority/*` labels):**
 

--- a/docs/jeep_lj/tbd-tracker.md
+++ b/docs/jeep_lj/tbd-tracker.md
@@ -21,9 +21,17 @@ _Live from GitHub issues labeled `tbd`, generated at build time. Filter with Git
 
 ---
 
-## RECENTLY RESOLVED
+## Recently Resolved
 
-Items completed since last update.
+_Closed `tbd` issues from the last 90 days, rendered live. Full history lives in
+[closed GitHub issues](https://github.com/sob/drawings/issues?q=is%3Aissue+is%3Aclosed+label%3Atbd)._
+
+{{ tbds_resolved(scope='project', since='90d') }}
+
+## Historical Archive (pre-migration)
+
+Resolutions captured before TBD tracking moved to GitHub Issues. New
+resolutions appear in the table above (rendered live from closed issues).
 
 | Item                          | Resolution                                                                                                                    | Date       |
 | :---------------------------- | :---------------------------------------------------------------------------------------------------------------------------- | :--------- |

--- a/hooks/verify_tbd.py
+++ b/hooks/verify_tbd.py
@@ -1,0 +1,189 @@
+#!/usr/bin/env python3
+"""Verify TBD invariants between source files and GitHub Issues.
+
+Fails (exit 1) if any of:
+- A `TBD` marker exists in source but no open `tbd` issue covers that file.
+- An open `tbd` issue's `Source:` path doesn't exist (file moved/deleted).
+- An open `tbd` issue is missing any of the required label facets:
+  `tbd`, `project/*`, `priority/*`, `area/*`.
+
+Read-only: never modifies issues or files. Designed to run in CI; an optional
+`GITHUB_TOKEN` lifts the API rate limit.
+
+Usage:
+  python3 hooks/verify_tbd.py                 # full check (default)
+  python3 hooks/verify_tbd.py --root docs     # alternate doc root
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.request
+
+DEFAULT_ROOT = "docs/jeep_lj"
+DEFAULT_REPO = "sob/drawings"
+REQUIRED_FACETS = ("tbd", "project/", "priority/", "area/")
+
+# Files within the doc root that intentionally talk *about* TBD tracking
+# without being source TBDs themselves.
+SOURCE_SKIPS = {
+    "CLAUDE.md",
+    "tbd-tracker.md",
+}
+# Substrings: skip any file path containing these
+PATH_SKIP_SUBSTR = ("/.claude/", "/ANALYZE/")
+
+# Lines that mention "TBD" but aren't a source-TBD marker (purely narrative).
+NARRATIVE_PATTERNS = [
+    re.compile(r"TBD\s*Tracker", re.IGNORECASE),
+    re.compile(r"^\s*##.*\bTBD\b", re.IGNORECASE),  # section heading
+    re.compile(r"\bTo\s*Be\s*Determined\b", re.IGNORECASE),
+    re.compile(r"\bSection\s+\d+\s+TBDs\b", re.IGNORECASE),
+    re.compile(r"\bsee\s+\[TBD\s+Tracker", re.IGNORECASE),
+    re.compile(r"mark as TBD", re.IGNORECASE),
+]
+
+
+def _http(url, token):
+    headers = {"Accept": "application/vnd.github+json", "User-Agent": "verify-tbd"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    req = urllib.request.Request(url, headers=headers)
+    return urllib.request.urlopen(req, timeout=30)
+
+
+def fetch_open_tbds(repo, token):
+    issues = []
+    url = (f"https://api.github.com/repos/{repo}/issues"
+           "?labels=tbd&state=open&per_page=100")
+    for _ in range(20):
+        with _http(url, token) as resp:
+            page = json.load(resp)
+            link = resp.headers.get("Link", "")
+        for it in page:
+            if "pull_request" in it:
+                continue
+            issues.append(it)
+        m = re.search(r'<([^>]+)>;\s*rel="next"', link)
+        if not m:
+            break
+        url = m.group(1)
+    return issues
+
+
+def source_path_from_body(body):
+    """Find the first `Source: <path>` line in an issue body."""
+    for line in (body or "").splitlines():
+        m = re.match(r"\s*Source:\s*(.+)", line)
+        if m:
+            # strip trailing "(line N)" or similar
+            return re.sub(r"\s*\(.*\)\s*$", "", m.group(1).strip())
+    return None
+
+
+def is_narrative(line):
+    return any(p.search(line) for p in NARRATIVE_PATTERNS)
+
+
+def scan_source_tbds(root):
+    """Return {path: [line_numbers]} for non-narrative TBD occurrences."""
+    found = {}
+    for dirpath, _, files in os.walk(root):
+        if any(s in dirpath for s in PATH_SKIP_SUBSTR):
+            continue
+        for f in sorted(files):
+            if not f.endswith(".md") or f in SOURCE_SKIPS:
+                continue
+            path = os.path.join(dirpath, f)
+            with open(path) as fh:
+                lines = fh.readlines()
+            for i, line in enumerate(lines, start=1):
+                if "TBD" not in line:
+                    continue
+                # If the line uses the {{ tbd(N) }} macro, it's tracked
+                if "{{ tbd(" in line or "{{ tbds(" in line or "{{ tbds_resolved(" in line:
+                    continue
+                if is_narrative(line):
+                    continue
+                found.setdefault(path, []).append((i, line.rstrip()))
+    return found
+
+
+def main(argv=None):
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--root", default=DEFAULT_ROOT)
+    ap.add_argument("--repo", default=os.environ.get("TBD_REPO", DEFAULT_REPO))
+    args = ap.parse_args(argv)
+
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    try:
+        issues = fetch_open_tbds(args.repo, token)
+    except (urllib.error.URLError, TimeoutError, ValueError) as exc:
+        print(f"::error::Could not fetch issues: {exc}")
+        return 2
+
+    # Build label and source maps
+    files_with_issue = set()  # files covered by at least one open tbd issue
+    label_problems = []        # (issue_number, missing_facets)
+    stale_sources = []         # (issue_number, source_path)
+
+    for it in issues:
+        labels = {l["name"] for l in it.get("labels", [])}
+        missing = [f.rstrip("/") for f in REQUIRED_FACETS
+                   if not any(n == f.rstrip("/") or n.startswith(f) for n in labels)]
+        if missing:
+            label_problems.append((it["number"], it["title"], missing))
+
+        src = source_path_from_body(it.get("body", ""))
+        if src:
+            files_with_issue.add(src)
+            if not os.path.exists(src):
+                stale_sources.append((it["number"], it["title"], src))
+
+    untracked = []
+    source_hits = scan_source_tbds(args.root)
+    for path, lines in source_hits.items():
+        if path not in files_with_issue:
+            untracked.append((path, lines))
+
+    failed = False
+
+    if untracked:
+        failed = True
+        print("\n::error::Untracked source TBDs (no open issue covers these files):")
+        for path, lines in untracked:
+            print(f"  {path}")
+            for ln, content in lines[:5]:
+                print(f"    line {ln}: {content[:100]}")
+            if len(lines) > 5:
+                print(f"    ... and {len(lines) - 5} more")
+
+    if stale_sources:
+        failed = True
+        print("\n::error::Open `tbd` issues whose Source: file no longer exists:")
+        for num, title, src in stale_sources:
+            print(f"  #{num} {title}")
+            print(f"    Source: {src}")
+
+    if label_problems:
+        failed = True
+        print("\n::error::Open `tbd` issues missing required label facets:")
+        for num, title, missing in label_problems:
+            print(f"  #{num} {title}")
+            print(f"    Missing: {', '.join(missing)}")
+
+    if not failed:
+        print(f"OK — {len(issues)} open tbd issues, "
+              f"{sum(len(v) for v in source_hits.values())} source TBD markers, "
+              f"all reconciled.")
+        return 0
+    print("\nSee docs/jeep_lj/CLAUDE.md §6 for the TBD workflow.")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tbd_macros.py
+++ b/tbd_macros.py
@@ -42,7 +42,15 @@ PRIORITY_META = {
 PRIORITY_ORDER = sorted(PRIORITY_META, key=lambda k: PRIORITY_META[k][3])
 
 # Build-lifetime cache. None == not fetched yet; a list == fetched (possibly empty).
-_CACHE = {"issues": None}
+_CACHE = {"issues": None, "closed": None, "comments": {}}
+
+
+def _http_headers():
+    h = {"Accept": "application/vnd.github+json", "User-Agent": "tbd-macros"}
+    tok = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if tok:
+        h["Authorization"] = f"Bearer {tok}"
+    return h
 
 
 def _repo_slug():
@@ -69,8 +77,8 @@ def _next_link(link_header):
     return None
 
 
-def _fetch_tbds():
-    """Open issues labeled `tbd` via the GitHub REST API. None on failure.
+def _fetch_tbds(state="open"):
+    """Issues labeled `tbd` via the GitHub REST API. None on failure.
 
     Uses urllib (stdlib) so it runs anywhere the build runs -- including
     Cloudflare Pages, which has no `gh` CLI. The repo is public, so anonymous
@@ -79,13 +87,10 @@ def _fetch_tbds():
     repo = _repo_slug()
     if not repo:
         return None
-    headers = {"Accept": "application/vnd.github+json", "User-Agent": "tbd-macros"}
-    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
+    headers = _http_headers()
 
     url = (f"https://api.github.com/repos/{repo}/issues"
-           "?labels=tbd&state=open&per_page=100")
+           f"?labels=tbd&state={state}&per_page=100")
     issues = []
     try:
         for _ in range(20):  # pagination safety bound
@@ -113,7 +118,10 @@ def _fetch_tbds():
                     "areas": {n.split("/", 1)[1] for n in names if n.startswith("area/")},
                     "priority": priority,
                     "created": it.get("created_at", ""),
+                    "closed": it.get("closed_at", ""),
                     "author": (it.get("user") or {}).get("login", ""),
+                    "comments_url": it.get("comments_url", ""),
+                    "comments_count": it.get("comments", 0),
                 })
             if not url:
                 break
@@ -122,10 +130,72 @@ def _fetch_tbds():
     return issues
 
 
+def _fetch_last_comment(comments_url):
+    """Fetch the last comment on an issue. '' on failure or no comments.
+
+    Cached per URL so re-renders within a single build are free.
+    """
+    if not comments_url:
+        return ""
+    if comments_url in _CACHE["comments"]:
+        return _CACHE["comments"][comments_url]
+    body = ""
+    try:
+        req = urllib.request.Request(comments_url + "?per_page=100",
+                                     headers=_http_headers())
+        with urllib.request.urlopen(req, timeout=30) as resp:
+            comments = json.load(resp)
+        if comments:
+            body = (comments[-1].get("body") or "").strip()
+    except (urllib.error.URLError, TimeoutError, ValueError, OSError):
+        body = ""
+    _CACHE["comments"][comments_url] = body
+    return body
+
+
 def _issues():
     if _CACHE["issues"] is None:
-        _CACHE["issues"] = _fetch_tbds()
+        _CACHE["issues"] = _fetch_tbds("open")
     return _CACHE["issues"]
+
+
+def _closed_issues():
+    if _CACHE["closed"] is None:
+        _CACHE["closed"] = _fetch_tbds("closed")
+    return _CACHE["closed"]
+
+
+_SINCE_RE = re.compile(r"^\s*(\d+)\s*([dwmy]?)\s*$", re.IGNORECASE)
+
+
+def _parse_since(spec):
+    """Parse a 'since' spec ('90d', '6m', '1y', '2026-01-01', None) -> aware datetime or None."""
+    if not spec:
+        return None
+    if isinstance(spec, datetime.datetime):
+        return spec
+    m = _SINCE_RE.match(str(spec))
+    if m:
+        n = int(m.group(1))
+        unit = (m.group(2) or "d").lower()
+        days = n * {"d": 1, "w": 7, "m": 30, "y": 365}[unit]
+        return datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=days)
+    # ISO date fallback
+    try:
+        return datetime.datetime.strptime(str(spec)[:10], "%Y-%m-%d").replace(
+            tzinfo=datetime.timezone.utc)
+    except ValueError:
+        return None
+
+
+def _parse_iso(iso):
+    if not iso:
+        return None
+    try:
+        return datetime.datetime.strptime(iso[:19], "%Y-%m-%dT%H:%M:%S").replace(
+            tzinfo=datetime.timezone.utc)
+    except ValueError:
+        return None
 
 
 def _first_line(body):
@@ -222,6 +292,111 @@ def define_env(env):
 
         return _admonition(None, sel) if (sel or show_empty) else _none_note()
 
+    @env.macro
+    def tbd(n, label="TBD"):
+        """Inline cell-level marker linked to GitHub issue #n.
+
+        Open issue   -> '<label> #N' as a link.
+        Closed issue -> first sentence/line of the resolution (last comment),
+                        with a small clickable '#N' suffix pointing to the
+                        closed issue.
+        Missing      -> '<label> #N' linked, with a warning marker.
+        """
+        if not isinstance(n, int):
+            try:
+                n = int(n)
+            except (TypeError, ValueError):
+                return f"{label} (#?)"
+
+        # Search open issues first
+        for it in (_issues() or []):
+            if it["number"] == n:
+                return (f'<a href="{html.escape(it["url"])}" target="_blank" '
+                        f'rel="noopener">{html.escape(label)} #{n}</a>')
+        # Then closed
+        for it in (_closed_issues() or []):
+            if it["number"] == n:
+                resolution = ""
+                if it.get("comments_count"):
+                    resolution = _fetch_last_comment(it["comments_url"])
+                if not resolution:
+                    resolution = it.get("desc") or it["title"]
+                # First sentence (or first 200 chars)
+                snippet = re.split(r"(?<=[.!?])\s+", resolution.strip(), maxsplit=1)[0]
+                if len(snippet) > 200:
+                    snippet = snippet[:197].rstrip() + "…"
+                snippet = snippet.replace("|", "\\|")
+                return (f'{snippet} '
+                        f'<a href="{html.escape(it["url"])}" target="_blank" '
+                        f'rel="noopener" title="Closed issue #{n}">#{n}</a>')
+        # Not found in either list
+        repo = _repo_slug() or "sob/drawings"
+        return (f'<a href="https://github.com/{repo}/issues/{n}" '
+                f'target="_blank" rel="noopener" '
+                f'title="Issue not found in tbd-labeled list">⚠️ {html.escape(label)} #{n}</a>')
+
+    @env.macro
+    @jinja2.pass_context
+    def tbds_resolved(ctx, since="90d", project=None, area=None, scope=None,
+                      limit=None):
+        """Render closed `tbd` issues as a markdown table: Item | Resolution | Date.
+
+        `since` is a window like '90d' / '6m' / '1y' or an ISO date; pass None
+        for full history. Resolution is the last comment on the issue (which
+        is what `gh issue close -c "..."` posts).
+        """
+        items = _closed_issues()
+        if items is None:
+            return ('!!! failure "Resolved TBDs unavailable"\n\n'
+                    "    Could not reach the GitHub issues API at build time.\n")
+
+        # auto-derive project/area like tbds() does
+        d_project, d_area = _derive(_page_src_uri(ctx))
+        if project is None:
+            project = d_project
+        if scope in ("project", "all"):
+            area = None
+        elif area is None:
+            area = d_area
+        if scope == "all":
+            project = None
+
+        cutoff = _parse_since(since)
+        sel = []
+        for it in items:
+            if project and project not in it["projects"]:
+                continue
+            if area and area not in it["areas"]:
+                continue
+            closed_dt = _parse_iso(it["closed"])
+            if cutoff and (closed_dt is None or closed_dt < cutoff):
+                continue
+            sel.append(it)
+
+        sel.sort(key=lambda it: it["closed"], reverse=True)
+        if limit:
+            sel = sel[: int(limit)]
+
+        if not sel:
+            return ('!!! success "No resolved TBDs in window"\n\n'
+                    "    Nothing has been closed in this window.\n")
+
+        rows = ["| Item | Resolution | Date |", "| :--- | :--------- | :--- |"]
+        for it in sel:
+            resolution = ""
+            if it.get("comments_count"):
+                resolution = _fetch_last_comment(it["comments_url"])
+            if not resolution:
+                resolution = it.get("desc") or "_(closed without comment)_"
+            # Collapse newlines and pipes so we don't break the table.
+            resolution = re.sub(r"\s*\n+\s*", " ", resolution).replace("|", "\\|")
+            title_link = (f'<a href="{html.escape(it["url"])}" target="_blank" '
+                          f'rel="noopener">{html.escape(it["title"])} '
+                          f'(#{it["number"]})</a>')
+            date = _fmt_date(it["closed"]) or it["closed"][:10]
+            rows.append(f"| {title_link} | {resolution} | {date} |")
+        return "\n".join(rows)
+
 
 def _admonition(level, items):
     if level is None:
@@ -233,7 +408,10 @@ def _admonition(level, items):
     if items:
         for it in items:
             dash = f" — {it['desc']}" if it["desc"] else ""
-            lines.append(f"    - [{it['title']} (#{it['number']})]({it['url']}){dash}")
+            link = (f'<a href="{html.escape(it["url"])}" target="_blank" '
+                    f'rel="noopener">{html.escape(it["title"])} '
+                    f'(#{it["number"]})</a>')
+            lines.append(f"    - {link}{dash}")
     else:
         lines.append("    _No open items._")
     return "\n".join(lines)
@@ -381,7 +559,8 @@ def _github(items):
             f'data-created="{html.escape(it["created"])}">'
             f'{_OPEN_ICON}'
             f'<div class="ghi-main">'
-            f'<a class="ghi-title" href="{html.escape(it["url"])}">'
+            f'<a class="ghi-title" href="{html.escape(it["url"])}" '
+            f'target="_blank" rel="noopener">'
             f'{html.escape(it["title"])}</a> '
             f'<span class="ghi-labels">{pills}</span>'
             f'<div class="ghi-meta">{html.escape(sub)}</div>'


### PR DESCRIPTION
## Summary

Static TBD content scattered across the Jeep LJ docs is replaced with live rendering from GitHub Issues. Closing a `tbd` issue now updates every page that references it — no source edits required.

- **`tbd_macros.py`** — adds two macros:
  - `tbds_resolved(since='90d')` renders closed `tbd` issues as a table with the closing comment as the resolution.
  - `tbd(N)` is an inline cell marker that shows `TBD #N` while the issue is open and flips to the resolution snippet when it closes.
  - Issue links open in a new tab (`target="_blank"`).
- **~55 component pages swept** (`docs/jeep_lj/**/*.md`) — `## Outstanding Items` lists are dropped in favor of `{{ tbds() }}`; legitimate install/build steps are preserved under `## Build Tasks`; completed `[x]` lines removed (history is in git).
- **~30 literal `TBD` cells** in spec tables converted to `{{ tbd(N) }}` so each cell self-resolves when its issue closes.
- **`docs/jeep_lj/tbd-tracker.md`** — hand-maintained RECENTLY RESOLVED table replaced with `{{ tbds_resolved(scope='project', since='90d') }}`. Pre-migration entries kept under a clearly-labeled `## Historical Archive`.
- **CI guardrail** (`hooks/verify_tbd.py` + `.github/workflows/verify-tbd.yml`) — read-only check that fails PRs introducing untracked source TBDs, stale `Source:` paths, or label gaps. Currently green: `OK — 56 open tbd issues, 0 source TBD markers, all reconciled.`
- **`docs/jeep_lj/CLAUDE.md`** §6 documents the new macros and CI hook.

## Test plan

- [ ] `python3 hooks/verify_tbd.py` reports `OK — 56 open tbd issues, 0 source TBD markers, all reconciled.`
- [ ] Build the docs site (`mkdocs build` or Zensical) and spot-check three pages:
  - [ ] `tbd-tracker.md` shows the filterable open-issue list, the live "Recently Resolved" table, and the frozen historical archive.
  - [ ] `02-engine-systems/02-brake-booster.md` shows live engine-systems open issues under `## Outstanding Items` and the preserved install steps under `## Build Tasks`. Cells for harness, prop valve, flex hose render `TBD #N` linked to the issue.
  - [ ] `10-drivetrain/06-suspension.md` shows the suspension spec table with `TBD #97` / `TBD #98` / `TBD #102` linked.
- [ ] Click any issue link — it opens in a new browser tab.
- [ ] Close one open `tbd` issue locally (or pick a recently-closed one): on the next build, its row in `tbd-tracker.md` moves into the resolved table, and any `{{ tbd(N) }}` cells flip to the resolution snippet.
- [ ] The verify-tbd workflow runs on this PR and stays green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)