### PR TITLE
docs: nightly tidiness — trim verbosity (2026-06-03)

### DIFF
--- a/docs/jeep_lj/01-power-systems/05-grounding/01-engine-bay-ground-bus.md
+++ b/docs/jeep_lj/01-power-systems/05-grounding/01-engine-bay-ground-bus.md
@@ -57,8 +57,6 @@ tags:
 
 [^bus-torque]: Blue Sea Systems' published terminal torque for the 2107 PowerBar's **3/8"-16 studs is 140 in-lb**. Corrected from the earlier 100-120 in-lb (that 120 in-lb figure is Blue Sea's spec for 5/16"-18 studs — a smaller stud — so the original value undertorqued these 3/8"-16 studs). Source: [Blue Sea Systems 2107 PowerBar 600A BusBar](https://www.bluesea.com/products/2107/PowerBar_600A_BusBar_-_Eight_3_8in-16_Studs__). Verified 2026-05-30.
 
-**Critical:** Clean metal-to-metal connections - remove paint/rust before installation, apply dielectric grease after assembly
-
 ## Related Documentation
 
 - [Grounding Architecture Overview][grounding-architecture]

--- a/docs/jeep_lj/01-power-systems/05-grounding/02-firewall-stud-bus.md
+++ b/docs/jeep_lj/01-power-systems/05-grounding/02-firewall-stud-bus.md
@@ -57,8 +57,6 @@ tags:
 
 **Ground Path:** Bus → chassis ground (4 AWG, handles ~50A total load) → START battery negative bus (via 2/0 AWG main chassis ground)
 
-**Critical:** Clean metal-to-metal connection to firewall/chassis, protected from water/moisture
-
 ## Related Documentation
 
 - [Grounding Architecture Overview][grounding-architecture]

--- a/docs/jeep_lj/02-engine-systems/03-hvac.md
+++ b/docs/jeep_lj/02-engine-systems/03-hvac.md
@@ -39,16 +39,6 @@ Factory 2005 TJ HVAC system retained. Uses vacuum-operated mode doors, cable-ope
 
 See [PMU Outputs][pmu-outputs] for complete configuration.
 
-## Control Methods
-
-| Function                  | Control Type               | PMU Involvement     |
-| :------------------------ | :------------------------- | :------------------ |
-| Blower Speed              | Electrical (resistor pack) | OUT5 provides power |
-| A/C On/Off                | Electrical (PMU switched)  | In 9 triggers OUT17 |
-| Temperature               | Mechanical (cable)         | None                |
-| Mode (defrost/vent/floor) | Vacuum                     | None                |
-| Recirculation             | Vacuum                     | None                |
-
 ## Vacuum System
 
 **Source:** R2.8 intake manifold → check valve → reservoir → firewall → factory HVAC controls

--- a/docs/jeep_lj/03-lighting-systems/01-lighting-overview.md
+++ b/docs/jeep_lj/03-lighting-systems/01-lighting-overview.md
@@ -65,12 +65,6 @@ This section covers all street-legal DOT-required lighting circuits controlled b
 | Brake Lights        | PMU Out 21             | 7A       | ~3A     |
 | Reverse Lights      | PMU Out 22             | 7A       | ~5A     |
 
-## Key Features
-
-- **GPS Auto-Cancel:** Turn signals cancel after turns
-- **DRL Auto-Off:** PMU programming disables DRL when headlights activate
-- **Diode Isolation:** Turn signals and brake lights integrated without backfeed
-
 ## Related Documentation
 
 - [Command Touch CT4][command-touch-ct4] - Controller specifications and programming

--- a/docs/jeep_lj/04-offroad-lighting/01-ditch-lights.md
+++ b/docs/jeep_lj/04-offroad-lighting/01-ditch-lights.md
@@ -53,14 +53,6 @@ Both LP4 Pro pods run on SwitchPros OUTPUT-2 via 2-pin Delphi connectors (power 
 
 See [SwitchPros SP-1200][switchpros-sp-1200] for wiring details.
 
-## Zone 2 Purpose
-
-Driving/Combo pattern provides peripheral illumination for:
-
-- Trail obstacle visibility on sides
-- Ditch and shoulder illumination
-- Tight maneuvering situations
-
 ## Outstanding Items
 
 {{ tbds() }}

--- a/docs/jeep_lj/06-audio-systems/02-amplifier.md
+++ b/docs/jeep_lj/06-audio-systems/02-amplifier.md
@@ -134,13 +134,9 @@ The 100A external CB is intentionally above the 80A internal fuse — the intern
 
 **Under rear seat (driver side or center, mounted to floor with clearance for Class-D thermals)**
 
-- Power feed ~3-4 ft direct from AUX battery+ (short feed, low loss)
 - Ground return ~3-4 ft to AUX battery−. All system grounds (head unit + amp) should land at the same point per the manual to avoid ground loops.[^specs-manual]
 - Centroid to all 4 speakers + 2 subs — minimizes speaker wire runs
 - RCA + remote bundled together from head unit through trans tunnel (~10-12 ft, high-quality shielded RCA required to avoid alternator whine)
-- Mounting plate with at least **1" (2.5 cm) clear air space above the shell** (manual requirement for enclosed-compartment mounting); convection-cooled, no fan
-- Orient with connections pointing downward where practical (preserves IPX2 rating)
-- Keyhole mounting screws — insert screws first, then drop amp onto them and slide
 - USB access (front of chassis) needed for TüN DSP tuning — leave service loop
 
 ## Outstanding Items


### PR DESCRIPTION
Nightly tidiness pass per `docs/jeep_lj/CLAUDE.md` **BE SUCCINCT** rules.
32 lines deleted across 6 files, 0 lines added. MkDocs `--strict` build passes.

---

## Changes

| File | Lines before → after | What was cut | Persona it failed |
| :--- | :------------------- | :----------- | :---------------- |
| `02-engine-systems/03-hvac.md` | 72 → 62 | "Control Methods" table (9 lines + heading) — duplicates the PMU Integration table above and the Overview sentence ("vacuum-operated mode doors, cable-operated temperature blend door") | Mechanic: table is redundant; Owner: same info already in Overview |
| `04-offroad-lighting/01-ditch-lights.md` | 80 → 72 | "Zone 2 Purpose" section (7 lines + heading) — duplicates product name "Ditch Lights" and intro sentence; beam pattern already in Specs table | All personas: content is obvious from product name and adjacent specs |
| `03-lighting-systems/01-lighting-overview.md` | 89 → 83 | "Key Features" section (5 lines + heading) — GPS auto-cancel already in Turn Signals subsection; DRL auto-off already in DRL subsection and headlight bullet; diode isolation already in Tail/Brake subsection | Mechanic/Owner: triple-redundant with preceding subsections |
| `06-audio-systems/02-amplifier.md` | 170 → 166 | 4 Mounting Location bullets: power-feed distance (duplicates Wiring table + product-info block), clearance spec (duplicates Specs table "Convection... 1″ free space"), IPX2 orientation (duplicates Specs table "IPX2 mounted vertically, connections down"), keyhole-screw assembly instruction (manufacturer manual step) | Mechanic: manual already linked; all four items in adjacent table/header |
| `01-power-systems/05-grounding/01-engine-bay-ground-bus.md` | 75 → 73 | "Critical: Clean metal-to-metal connections — remove paint/rust, apply dielectric grease" — textbook standard practice for any bolted electrical connection | Mechanic: universal shop knowledge |
| `01-power-systems/05-grounding/02-firewall-stud-bus.md` | 76 → 74 | "Critical: Clean metal-to-metal connection to firewall/chassis, protected from water/moisture" — same pattern | Mechanic: universal shop knowledge |

---

## Left for human judgment

- **`03-bcdc.md` "Why Required" section (lines 98–103):** Standard AGM temperature-compensation chemistry (overcharging → thermal runaway, undercharging → sulfation). Reads like textbook filler but also serves the Owner/Designer persona explaining why the sensor is mandatory. Left intact.
- **`03-hvac.md` line 60:** "A/C clutch engagement may cause a slight idle dip but not enough to require compensation." Hedging language, but also a genuine R2.8 ECM integration note. Left intact.
- **`03-aux-battery-distribution/04-safetyhub.md` lines 62/64:** "Utilization: 100A / 150A = 67%" and "Future Capacity: 50A additional..." duplicate the admonition at the top of the same page. Modest redundancy, left for owner to decide whether the summary is worth keeping after the table.
- **`06-audio-systems/02-amplifier.md` line 138 (first clause):** "Ground return ~3-4 ft to AUX battery−" duplicates the Wiring table, but the second clause ("all system grounds should land at the same point per the manual to avoid ground loops") is non-obvious. Left the full line intact.
- **Pre-existing markdownlint errors:** 995 MD060/MD036/MD053 errors across the tree predate this PR. The MD053 on `03-hvac.md` (unused `[install-checklist]` reference definition) was already orphaned before this run.

> **Label note:** The `tidiness` label does not yet exist in this repo. Please create it and apply it to this PR.

---
_Generated by [Claude Code](https://claude.ai/code/session_01VeMZDhVhcR4RDyyUBvDbqR)_