### PR TITLE
docs(lj): number Standards Exceptions as 1.9 (end of Power Systems)

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+# Cloudflare Pages build entrypoint.
+#
+# Zensical does not honor MkDocs `exclude_docs`, so it renders every *.md under
+# docs_dir — including the AI-only CLAUDE.md navigation guides that MkDocs skips.
+# We can't exclude them at build time, so we build the full site and then prune
+# the published CLAUDE pages from the output. (They're also kept out of the
+# search index via `search: { exclude: true }` frontmatter in each CLAUDE.md.)
+#
+# Set the Cloudflare Pages "Build command" to:  bash build.sh
+set -euo pipefail
+
+# Install the generator (Cloudflare provides Python; pin nothing so we track the
+# same version the dashboard installs today).
+pip install --quiet zensical
+
+zensical build
+
+# Remove published CLAUDE.md pages (directory-URL output -> ".../CLAUDE/").
+SITE_DIR="${ZENSICAL_SITE_DIR:-site}"
+pruned=0
+while IFS= read -r -d '' dir; do
+  rm -rf "$dir"
+  pruned=$((pruned + 1))
+done < <(find "$SITE_DIR" -type d -name CLAUDE -print0)
+# Defensive: also handle non-directory-URL output (".../CLAUDE.html").
+find "$SITE_DIR" -type f -name 'CLAUDE.html' -delete
+
+echo "build.sh: pruned ${pruned} CLAUDE page(s) from ${SITE_DIR}/"

--- a/build.sh
+++ b/build.sh
@@ -10,11 +10,11 @@
 # Set the Cloudflare Pages "Build command" to:  bash build.sh
 set -euo pipefail
 
-# Install the generator (Cloudflare provides Python; pin nothing so we track the
-# same version the dashboard installs today).
-pip install --quiet zensical
+# Install the generator + plugins (Cloudflare provides Python). Keep this list
+# in sync with the plugins referenced by mkdocs.yml.
+pip install --quiet zensical mkdocs-print-site-plugin
 
-zensical build
+zensical build --clean
 
 # Remove published CLAUDE.md pages (directory-URL output -> ".../CLAUDE/").
 SITE_DIR="${ZENSICAL_SITE_DIR:-site}"

--- a/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/CLAUDE.md
+++ b/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/CLAUDE.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # START battery Distribution - Navigation Guide
 
 ## What's Here

--- a/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/CLAUDE.md
+++ b/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/CLAUDE.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # AUX battery Distribution - Navigation Guide
 
 ## What's Here

--- a/docs/jeep_lj/01-power-systems/04-pmu/CLAUDE.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/CLAUDE.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # PMU24 - Navigation Guide
 
 ## What's Here

--- a/docs/jeep_lj/01-power-systems/05-grounding/CLAUDE.md
+++ b/docs/jeep_lj/01-power-systems/05-grounding/CLAUDE.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Grounding Architecture - Navigation Guide
 
 ## What's Here

--- a/docs/jeep_lj/01-power-systems/CLAUDE.md
+++ b/docs/jeep_lj/01-power-systems/CLAUDE.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Section 1: Power Systems - Navigation Guide
 
 ## Section Overview

--- a/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
+++ b/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
@@ -1,4 +1,4 @@
-# Standards Exceptions & Design Decisions
+# 1.9 Standards Exceptions & Design Decisions {#standards-exceptions}
 
 This document tracks intentional deviations from general electrical standards where manufacturer specifications, automotive practice, or engineering analysis support alternative approaches.
 

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/CLAUDE.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/CLAUDE.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Dakota Digital HDX Gauge System - Navigation Guide
 
 ## What's Here

--- a/docs/jeep_lj/09-installation/CLAUDE.md
+++ b/docs/jeep_lj/09-installation/CLAUDE.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Installation Section - Navigation Guide
 
 ## What's Here

--- a/docs/jeep_lj/CLAUDE.md
+++ b/docs/jeep_lj/CLAUDE.md
@@ -174,6 +174,7 @@ label facet).
 
 **Macros (in `tbd_macros.py`):**
 
+{% raw %}
 - `{{ tbds() }}` — list open `tbd` issues for the current page's project+area,
   grouped by priority. Auto-derives scope from the page path.
 - `{{ tbds(scope='project', layout='github') }}` — filterable list of all open
@@ -184,6 +185,7 @@ label facet).
 - `{{ tbd(N) }}` — inline marker for a single spec cell. Renders `TBD #N` as a
   link while open; flips to the resolution snippet when the issue closes, so
   cells become self-resolving without a source edit.
+{% endraw %}
 
 **Priority Levels (`priority/*` labels):**
 

--- a/docs/jeep_lj/CLAUDE.md
+++ b/docs/jeep_lj/CLAUDE.md
@@ -1,3 +1,8 @@
+---
+search:
+  exclude: true
+---
+
 # Agent Instructions: Jeep LJ Electrical System Documentation
 
 ## Your Role

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -111,7 +111,6 @@ nav:
     - TBD Tracker: jeep_lj/tbd-tracker.md
     - Power Systems:
       - jeep_lj/01-power-systems/index.md
-      - Standards Exceptions: jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
       - 1.1 - Power Generation:
         - jeep_lj/01-power-systems/01-power-generation/index.md
         - 1.1.1 - Batteries: jeep_lj/01-power-systems/01-power-generation/01-batteries.md
@@ -153,6 +152,7 @@ nav:
         - 1.8.1 - Scenarios: jeep_lj/01-power-systems/08-load-analysis/01-scenarios.md
         - 1.8.2 - START Battery: jeep_lj/01-power-systems/08-load-analysis/02-start-battery.md
         - 1.8.3 - AUX Battery: jeep_lj/01-power-systems/08-load-analysis/03-aux-battery.md
+      - 1.9 - Standards Exceptions: jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
     - Critical Systems:
       - jeep_lj/02-engine-systems/index.md
       - 2.1 - Starter System: jeep_lj/02-engine-systems/01-starter.md


### PR DESCRIPTION
## Summary

Number the **Standards Exceptions** doc to match its numbered Power Systems siblings (1.1–1.8) and move it to the end of the section.

The page was sitting unnumbered at the *top* of Power Systems, which looked inconsistent next to 1.1–1.8. Since its content is entirely electrical overcurrent-protection exceptions (winch/starter/grid-heater/alternator/BCDC/SwitchPros CB decisions), it stays nested under Power Systems and reads naturally as an appendix at the end.

## Changes

- `mkdocs.yml` — moved `Standards Exceptions` from the top of Power Systems to the end as **`1.9 - Standards Exceptions`** (after 1.8 Load Analysis).
- `docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md` — H1 now `# 1.9 Standards Exceptions & Design Decisions {#standards-exceptions}`.

## Notes / verification

- File path is unchanged, so all inbound links (safetyhub, winch, section CLAUDE.md — all path-only, no anchors) are unaffected.
- YAML structure checked: `1.9` sits at the same indent level as 1.1–1.8.
- `mkdocs build` not run — mkdocs isn't installed in the dev environment. Change is a nav reorder + heading prefix; CI build will confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)