### PR TITLE
docs(lj): split keyless-ignition build tasks into install steps vs TBDs

### DIFF
--- a/docs/jeep_lj/05-control-interfaces/06-keyless-ignition.md
+++ b/docs/jeep_lj/05-control-interfaces/06-keyless-ignition.md
@@ -154,16 +154,6 @@ Normal engine shutdown (press brake + 2 sec button hold) drops PBS-I's PINK IGN 
 
 {{ tbds() }}
 
-## Build Tasks
-
-- [ ] Confirm the WAIT-gate relay coil (~150 mA) in parallel with the dash WAIT lamp does not exceed the ECM lamp-driver sink rating (Pin 35 polarity itself is confirmed active-low per Cummins 5504137 — see [^wait-polarity]). If marginal, drive the relay from the lamp's keyswitch side or use a higher-impedance/solid-state relay
-- [ ] Order Digital Guard Dawg PBS-I kit (includes ICM, 2 fobs, Start Button, Programming Button, Bypass Card, harnesses)
-- [ ] Add 5A inline fuse on the ignition (keyswitch) feed to ECM Pin 41 — pink wire, per Cummins 5504137 (see [^ecm-fuse])
-- [ ] Select PBS-I module mounting location (cabin under-dash, away from heat and water)
-- [ ] Select Start Button dash mounting position (within easy reach of driver)
-- [ ] Select Programming Button storage location (hidden but accessible)
-- [ ] Verify PBS-I quiescent current draw to add to START battery parasitic budget
-
 ## Related Documentation
 
 - [Starter System][starter] - Cole Hersee 24213 and PBS-I PURPLE → WAIT-gate → coil chain

--- a/docs/jeep_lj/09-installation/01-power-systems-checklist.md
+++ b/docs/jeep_lj/09-installation/01-power-systems-checklist.md
@@ -213,6 +213,7 @@ Create 12 custom 2-pin Delphi harnesses at SwitchPros:
 
 - [ ] Confirm 14 AWG: PBS-I PINK IGN (cabin) → Ignition signal bus bar Stud 1
 - [ ] Confirm ignition signal bus bar Stud 2 → Deutsch connector Pin 12 (outbound to engine bay)
+- [ ] Install 5A inline fuse at ignition signal bus bar Stud 2 — Cummins-mandated ECM Pin 41 protection per 5504137 (the only overcurrent device between the PBS-I 60A relay and the ECM feed)
 - [ ] Confirm engine-bay junction off Pin 12 → ECM 12V supply + PMU Pin 7
 - [ ] Confirm bus bar terminals split to: CT4, SwitchPros, Fusion Radio, BCDC
 - [ ] Verify total ignition signal current <500mA for all bus bar taps

--- a/docs/jeep_lj/09-installation/03-purchase-tracker.md
+++ b/docs/jeep_lj/09-installation/03-purchase-tracker.md
@@ -77,6 +77,7 @@ Major components - watch for sales, consider financing options.
 | JL Audio VXi-BTC JLid Bluetooth Communicator (010-13543-00) | JL Audio (Garmin) | ~$100 | Low | Wireless TüN tuning of MV800/8i from phone/tablet - [Bluetooth Tuning][bt-tuning] |
 | JL Audio MLC-RW LED Controller | JL Audio | ~$250 | Low | [LED Controller][led-controller] |
 | Rugged Radios STX Intercom (4-place) | Rugged Radios | ~$400 | Medium | [Intercom][intercom] |
+| Digital Guard Dawg PBS-I Keyless Ignition Kit | Digital Guard Dawg | ~$200 (est., confirm w/ vendor) | High | ICM + 2 iTag fobs + Start Button + Programming Button + Bypass Card - [Keyless Ignition][keyless] |
 | ARB Aluminum Air Tank (171507, 1-gal 4-port) | ARB | ~$200 | Medium | [Air Compressor][air-compressor] |
 | WolfBox G900 TriPro Dash Camera | WolfBox | ~$200 | Low | [Dash Camera][dash-camera] |
 | DB Electrical 410-52442 Starter | DB Electrical | ~$200 | High | [Starter][starter] |
@@ -209,6 +210,7 @@ _(Most electrical distribution components already purchased - see Purchased Item
 [led-controller]: ../06-audio-systems/05-led-controller.md
 [bt-tuning]: ../06-audio-systems/06-bluetooth-tuning.md
 [intercom]: ../07-communication-systems/02-intercom.md
+[keyless]: ../05-control-interfaces/06-keyless-ignition.md
 [air-lockers]: ../08-exterior-systems/03-air-lockers.md
 [solar]: ../01-power-systems/01-power-generation/04-solar.md
 [dash-camera]: ../07-communication-systems/04-dash-camera.md


### PR DESCRIPTION
Closes #51

## Context

Started from the question: *is the 5A inline fuse on the ECM Pin 41 feed still valid with the keyless ignition, and should it move to the harness spec?*

**Answer:** The fuse is still valid — and now **more** necessary. With the factory keyswitch gone, the ECM Pin 41 feed is sourced from the PBS-I's onboard 60A relay through a 14 AWG bus bar run, so the 5A inline fuse at bus bar Stud 2 is the *only* overcurrent device between a 60A-capable source and the thin ECM/firewall wire. It does **not** belong in a harness build sheet (it sits at a cabin bus bar stud; the outbound wire crosses on the factory HDP24 Pin 12). The spec is already captured in `06-ignition-signal/index.md` and `06-keyless-ignition.md` (and `[^ecm-fuse]` marks it **Confirmed**) — what was missing was the install *action*.

That surfaced a broader issue: the keyless-ignition page's hand-maintained **"Build Tasks"** list mixed settled install notes with genuine TBDs, and duplicated work tracked elsewhere. This PR resolves each item to its proper home and removes the section, leaving the page's `{{ tbds() }}` Outstanding Items as the single open-item list.

## Changes

| Old "Build Task" | Resolution |
|---|---|
| Add 5A inline fuse | New install step in power-systems checklist → Ignition Signal Distribution (was a gap). Confirmed spec, not a TBD → **closes #51** |
| Order PBS-I kit | Added to purchase tracker (was missing) |
| Select PBS-I mounting location | Already in engine-systems checklist (line 50) — dropped duplicate |
| Select Start Button position | Already in engine-systems checklist (line 56) — dropped duplicate |
| Select Programming Button storage | Already in engine-systems checklist (line 57) — dropped duplicate |
| Verify PBS-I quiescent current | Already tracked by issue #84 — dropped duplicate |
| WAIT-gate coil vs ECM sink rating | Genuine verify-TBD, untracked → opened as #117 |

## Notes

- `mkdocs build --strict` passes; `verify_tbd.py` reconciles clean.
- Purchase-tracker price for the PBS-I kit is a rough **estimate (~$200, confirm w/ vendor)**, consistent with the tracker's other unsourced `~$` planning figures — not a sourced fabrication spec.
- **Not** addressed here (out of scope for this cleanup): the pink-vs-black wire-color discrepancy on the Pin 41 feed (`06-keyless-ignition.md` line 100 says pink, line 136 + `06-ignition-signal` Stud 2 say black; the Cummins source says pink). Happy to fix in a follow-up.

https://claude.ai/code/session_017eAQ139idqBVPHHvcKu29J