### PR TITLE
Trim install checklists to check-off items

### DIFF
--- a/docs/jeep_lj/05-control-interfaces/02-switchpros-sp1200.md
+++ b/docs/jeep_lj/05-control-interfaces/02-switchpros-sp1200.md
@@ -198,27 +198,24 @@ Program TRIGGER-3 to activate compressor when tank pressure drops below 135 PSI:
 
 ## Build Tasks
 
-- [ ] Determine exact SwitchPros power module mounting location at firewall (passenger cabin side, near BODY PDU)
-- [ ] Determine SwitchPros control panel mounting location on dash
-- [ ] Route 4 AWG logic ground wire from SwitchPros power module to chassis ground at firewall (short run, per manufacturer spec)
-- [ ] Mount [SwitchPros Ground Bus][switchpros-ground-bus] (Blue Sea 2105 MaxiBus) at firewall near SwitchPros power module for output load returns
-- [ ] Connect ignition signal from ignition switch RUN terminal to SwitchPros Pin 3 (IGNITION - LT BLUE)
-  - 18 AWG wire, splits from main ignition signal distribution (see [PMU24][pmu-inputs])
-- [ ] Determine parking lights signal source for SwitchPros Pin 4 (LIGHTS - WHITE) for DRL integration
-- [ ] Order 5 ft control panel cable (firewall power module to dash panel - short run)
-- [ ] Wire driver door switch + passenger door switch in parallel to TRIGGER-1 (Pin 7, PINK)
-- [ ] Configure Button 4 programming: OUTPUT-4 OR TRIGGER-1 activates dome lights
-- [ ] Install rear cargo rocker switch and wire to TRIGGER-2 (Pin 8, PINK)
-- [ ] Determine rear cargo rocker switch mounting location (accessible from tailgate)
-- [ ] Configure TRIGGER-2 programming: TRIGGER-2 → OUTPUT-13 (cargo light)
-- [ ] Route cargo light wiring from SwitchPros OUTPUT-13 to cargo area
-- [ ] Route ditch light wiring from SwitchPros OUTPUT-2 to A-pillar/hood mounts
-- [ ] Wire ARB pressure switch signal to TRIGGER-3 (Pin 17, PINK)
-  - 18 AWG wire from air manifold (under passenger seat) to SwitchPros TRIGGER-3
-  - Route through cabin or under vehicle to engine bay SwitchPros power module
-- [ ] Configure SwitchPros: TRIGGER-3 OR Button 11 → OUTPUT-11 (compressor auto/manual control)
-- [ ] Test automatic pressure control: verify compressor activates at 135 PSI and stops at 150 PSI
-- [ ] Assign spare outputs: OUTPUT-9 (30A), OUTPUT-14, OUTPUT-15, OUTPUT-16 (all 15A)
+Check-off items only. Pin assignments and wire gauges live in the
+[Wiring Pinout](#wiring-pinout) section above; controller mounting, power feed,
+and ground bus install are tracked in the [Power Systems Checklist][power-checklist].
+
+**Triggers & Programming:**
+
+- [ ] Confirm ignition signal → SwitchPros Pin 3 (IGNITION)
+- [ ] Determine parking-lights signal source for Pin 4 (LIGHTS) for DRL integration
+- [ ] Order control panel cable (power module to dash)
+- [ ] Confirm driver + passenger door switches → TRIGGER-1
+- [ ] Program Button 4: OUTPUT-4 OR TRIGGER-1 → dome lights
+- [ ] Install rear cargo rocker switch → TRIGGER-2 (determine tailgate-accessible location)
+- [ ] Program TRIGGER-2 → OUTPUT-13 (cargo light)
+- [ ] Confirm cargo light wiring (OUTPUT-13) and ditch light wiring (OUTPUT-2)
+- [ ] Confirm ARB pressure switch → TRIGGER-3
+- [ ] Program TRIGGER-3 OR Button 11 → OUTPUT-11 (compressor auto/manual)
+- [ ] Test automatic pressure control (compressor on/off at setpoints)
+- [ ] Assign spare outputs: OUTPUT-9, 14, 15, 16
 
 ## Related Documentation
 
@@ -230,7 +227,7 @@ Program TRIGGER-3 to activate compressor when tank pressure drops below 135 PSI:
 [aux-battery]: ../01-power-systems/03-aux-battery-distribution/index.md
 [firewall-bus]: ../01-power-systems/03-aux-battery-distribution/02-constant-bus.md
 [air-system-arb-compressor-lockers]: ../08-exterior-systems/02-air-compressor.md
-[pmu-inputs]: ../01-power-systems/04-pmu/02-pmu-inputs.md
 [control-interfaces-overview]: 01-overview.md
 [offroad-auxiliary-lighting]: ../04-offroad-lighting/index.md
 [switchpros-ground-bus]: ../01-power-systems/05-grounding/03-switchpros-ground-bus.md
+[power-checklist]: ../09-installation/01-power-systems-checklist.md

--- a/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
+++ b/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
@@ -195,105 +195,58 @@ END
 
 ## Installation Checklist
 
-### Power & Ground
+Check-off items only. Wire gauges, pin assignments, and tail-light color codes
+live in the [Wiring](#wiring) section above and the linked light pages.
+Controller power feed (PMU Out 13) and ignition-signal distribution are tracked
+in the [Power Systems Checklist][power-checklist].
 
-- [ ] Route PMU Out 13 wire to steering column location (CT4 12V supply)
-- [ ] Connect CT4 ground to chassis ground or firewall ground stud
+### Power, Ground & Ignition
 
-### Ignition Signal
-
-- [ ] Connect CT4 ignition signal to ignition switch RUN output (Y-split shared with PMU Pin 7, SwitchPros)
-- [ ] Route ignition signal wire from ignition switch to steering column (18 AWG)
-- [ ] Verify SW3/SW4 (headlights) are disabled when ignition is off
+- [ ] Confirm CT4 12V supply (PMU Out 13) landed at steering column
+- [ ] Confirm CT4 ground connected
+- [ ] Confirm CT4 ignition signal connected (shared Y-split with PMU Pin 7, SwitchPros)
+- [ ] Verify SW3/SW4 (headlights) disabled when ignition off
 - [ ] Verify SW1/SW2 (turn signals/hazards) work with ignition off (safety feature)
 
-### Turn Signal Wiring
+### Lighting Wiring
 
-- [ ] Route CT4 SW1 (right turn) wire from steering column to:
-  - Front right 2" LED side marker
-  - Rear right Maxbilt tail light (YELLOW wire - brake/turn)
-- [ ] Route CT4 SW2 (left turn) wire from steering column to:
-  - Front left 2" LED side marker
-  - Rear left Maxbilt tail light (YELLOW wire - brake/turn)
-- [ ] Use 14 AWG wire from CT4 to junction points
-- [ ] Use 16 AWG wire from junction to each individual light
-- [ ] Wire Maxbilt tail lights per wiring table:
-  - BLACK wire → Ground (chassis ground)
-  - WHITE wire → Reverse lights (PMU Out 18)
-  - YELLOW wire → Brake/Turn (CT4 turn signal output + PMU Out 17 via diodes)
-  - RED wire → Marker/parking lights (PMU Out 23)
-- [ ] Verify turn signals flash front and rear simultaneously
-- [ ] Test lane change feature (< 0.5 sec press = 3 flashes)
-- [ ] Verify brake lights work independently of turn signals
+- [ ] Confirm CT4 SW1 (right turn) → front right marker + rear right tail light
+- [ ] Confirm CT4 SW2 (left turn) → front left marker + rear left tail light
+- [ ] Confirm Maxbilt tail lights wired per page wiring table
+- [ ] Confirm CT4 SW3 → LP6 low beam (both lights)
+- [ ] Confirm CT4 SW4 → LP6 high beam (both lights)
+- [ ] Confirm CT4 SW3 tapped to DRL cutoff relay coil
+- [ ] Confirm CT4 SW3 tapped to PMU In 7 (headlight status)
+- [ ] Confirm PMU Out 23 → DRL/parking junction (license plate, LP6 DRL, markers, tail markers)
 
-### Headlight Wiring
+### GPS Module
 
-- [ ] Route ignition signal from ignition switch RUN output (18 AWG) to CT4 ignition input (splits to PMU Pin 7, SwitchPros, CT4)
-- [ ] Route CT4 main power from PMU Out 13 to CT4 12V supply
-- [ ] Route CT4 SW3 output wire to LP6 Pin 1 (low beam, both lights in parallel, 14 AWG)
-- [ ] Route CT4 SW4 output wire to LP6 Pin 4 (high beam, both lights in parallel, 14 AWG)
-- [ ] Tap CT4 SW3 output wire to DRL cutoff relay coil (to disable DRL when headlights on)
-- [ ] Verify headlight control (SW3 pull to turn on/off low beams)
-- [ ] Test high beam control (SW4 push to switch between low and high beams)
-- [ ] Verify CT4 provides mutual exclusivity (high beam disables low beam automatically)
-- [ ] Verify headlights disabled when ignition off (ignition signal working correctly)
-- [ ] Verify turn signals/hazards work with ignition off (hazard safety feature)
-
-### DRL/Parking Light Wiring
-
-- [ ] Tap CT4 SW3 output (low beam circuit) to PMU In 7 for headlight status monitoring
-- [ ] Configure PMU Out 23 DRL auto-off logic (see PMU programming section)
-- [ ] Route 14 AWG wire from PMU Out 23 to DRL junction
-- [ ] Route 16 AWG wire from junction to each light:
-  - License plate lights
-  - LP6 Headlight Pin 3 (DRL input) - both left and right
-  - Front 2" LED side markers (parking function) - both left and right
-  - Maxbilt tail light RED wire (marker/parking) - both left and right
-- [ ] Verify all DRL/parking lights illuminate when ignition is turned on
-- [ ] Verify DRL automatically turns off when headlights are activated (CT4 SW3)
-- [ ] Verify DRL turns back on when headlights are turned off
-- [ ] Test total current draw on DRL circuit via PMU diagnostics (should be ~2.6A)
-
-### GPS Module Installation
-
-- [ ] Mount GPS antenna on dash top or near windshield for clear sky view
-- [ ] Route GPS antenna cable to CT4 controller at steering column
-- [ ] Connect GPS antenna to CT4 GPS input port
-- [ ] Secure GPS antenna cable to prevent interference with controls
-- [ ] Verify GPS antenna has unobstructed view of sky
+- [ ] Determine GPS antenna mounting location (clear sky view)
+- [ ] Confirm GPS antenna connected to CT4 GPS input
+- [ ] Perform GPS calibration drive per CT4 manual
 
 ### Programming
 
-- [ ] Program CT4 to battery control mode (not ignition control) for all switches
-- [ ] Program CT4 to GPS turn signal mode (automatic cancellation based on speed/steering)
-- [ ] Program SW3 (Headlights) to ON-OFF latching mode
-- [ ] Program SW4 (High Beams) to momentary or ON-OFF (choose preferred behavior)
+- [ ] Program all switches to battery control mode
+- [ ] Program GPS turn signal mode (auto-cancel)
+- [ ] Program SW3 (Headlights) to ON-OFF latching
+- [ ] Program SW4 (High Beams) to preferred behavior
 - [ ] Enable low voltage disconnect for all switches
-- [ ] Disable flash/strobe (turn signals use built-in pattern, headlights should be solid)
-- [ ] Disable switch memory
-- [ ] Perform GPS calibration drive per CT4 manual instructions
+- [ ] Disable flash/strobe and switch memory
 
 ### Testing
 
-- [ ] Test hazard function works with ignition off (verify battery power configuration)
-- [ ] Verify turn signals flash at correct rate (front and rear synchronized)
-- [ ] Test built-in audio module sounds when turn signals are active
-- [ ] Test GPS auto-cancel by making several turns at various speeds
-- [ ] Verify manual cancel still works (move lever to center or opposite direction)
-- [ ] Test lane change mode (quick press <0.5 sec flashes 3 times, then auto-cancels)
-- [ ] Test headlight control (SW3 pull to turn on/off low beams)
-- [ ] Test high beam control (SW4 push to switch between low and high beams)
-- [ ] Verify DRL automatically turns off when headlights are activated
-- [ ] Verify DRL turns back on when headlights are turned off
-- [ ] Test low voltage disconnect prevents over-discharge
+- [ ] Verify turn signals flash front and rear in sync, at correct rate
+- [ ] Verify hazards work with ignition off
+- [ ] Verify lane-change mode (short press = 3 flashes, auto-cancel)
+- [ ] Verify GPS auto-cancel and manual cancel
+- [ ] Verify headlight control (SW3 low beam, SW4 high beam mutual exclusivity)
+- [ ] Verify DRL auto-off when headlights active, back on when off
+- [ ] Verify brake lights work independently of turn signals
 
 ## Outstanding Items
 
 {{ tbds() }}
-
-## Build Tasks
-
-- [ ] Determine GPS antenna mounting location (dash top or near windshield for best sky view)
 
 ## Related Documentation
 
@@ -305,3 +258,4 @@ END
 [vehicle-lighting-overview]: ../03-lighting-systems/01-lighting-overview.md
 [pmu-power-distribution]: ../01-power-systems/04-pmu/index.md
 [drl-parking]: ../03-lighting-systems/05-drl-parking.md
+[power-checklist]: ../09-installation/01-power-systems-checklist.md

--- a/docs/jeep_lj/05-control-interfaces/06-keyless-ignition.md
+++ b/docs/jeep_lj/05-control-interfaces/06-keyless-ignition.md
@@ -21,7 +21,7 @@ Push-button ignition for the Cummins R2.8 + 8HP70 build. Replaces the factory ke
 
 **Type:** Self-contained RFID push-button start/stop; onboard 60A relays (IGN, START, ACC1, ACC2)
 
-**Mounting:** Cabin, under dash (vendor mandate: not in engine bay)
+**Mounting:** On the Dakota Digital HDPE panel under the dash, co-located with the HDX control module (vendor mandate: cabin only, never engine bay)
 
 **Product Page:** [Digital Guard Dawg PBS-I][pbs-i]
 
@@ -43,7 +43,7 @@ Push-button ignition for the Cummins R2.8 + 8HP70 build. Replaces the factory ke
 | Auto-arm | 60 sec after fob leaves range |
 | Module Dimensions | ~5.5" × 3" × 1.25" |
 | Wiring | Heavy-duty Molex high-current connectors, 12 GA bus wiring |
-| Mounting | **Cabin, under dash** (vendor mandate: do NOT mount in engine bay) |
+| Mounting | **Dakota Digital HDPE panel, under dash** — co-located with the HDX control module (shares the ECM Pin 35 WAIT tap; panel detailed in the [HDX Control][hdx-control] plan). Vendor mandate: cabin only, never engine bay |
 | Kit Contents | ICM + 2 iTag fobs + Start Button (36" pre-wired harness) + Programming Button + Bypass Card + 4-digit PIN |
 
 ### WAIT-gate Relay
@@ -113,7 +113,7 @@ Unchanged from existing starter design. See [Starter System][starter].
 
 | Connector | Connection | Notes |
 | :-------- | :--------- | :---- |
-| Start Button | Pre-wired 36" harness → PBS-I side port | Dash mount; included in kit |
+| Start Button | Pre-wired 36" harness → PBS-I side port | Mounts at the factory keyswitch location on the dash (within the 36" harness reach of the panel); included in kit |
 | Programming Button | Pre-wired harness → PBS-I side port | Stash under dash or in trunk; needed only for fob-learn and emergency bypass PIN entry |
 
 ### WAIT-Gate Relay

--- a/docs/jeep_lj/09-installation/01-power-systems-checklist.md
+++ b/docs/jeep_lj/09-installation/01-power-systems-checklist.md
@@ -1,6 +1,8 @@
 # Section 1: Power Systems - Installation Checklist
 
-Organized by installation order for efficient build workflow.
+Organized by installation order for efficient build workflow. Each item is a
+check-off confirmation — wire gauges, lengths, torque values, and part numbers
+live in the linked source docs, not here.
 
 ---
 
@@ -9,41 +11,35 @@ Organized by installation order for efficient build workflow.
 ### Battery Compartments
 
 - [ ] Install Odyssey PC1500 (START) in driver rear wheel well with access panel
-- [ ] Build enclosed compartment in passenger rear wheel well with access panel (AUX)
-- [ ] Install Barnes 4WD battery box (Group 24) in passenger rear wheel well - powdercoat before install
-- [ ] Install Dakota Lithium 135Ah LiFePO4 (AUX) in Barnes battery box
+- [ ] Build enclosed AUX compartment in passenger rear wheel well with access panel
+- [ ] Install Barnes 4WD battery box in passenger rear wheel well
+- [ ] Install Dakota Lithium (AUX) in Barnes battery box
 
 ### Grounding System
 
 **Ground Bus Bars:**
 
-- [ ] Mount Engine Bay Ground Bus (Blue Sea 2107 PowerBar, 600A) on firewall (engine bay side) near PMU
-- [ ] Mount Firewall Stud Bus (Blue Sea 2105 MaxiBus, 250A) on firewall (cabin side)
-- [ ] Mount SwitchPros Ground Bus (Blue Sea 2105 MaxiBus, 250A) near SwitchPros controller
+- [ ] Mount Engine Bay Ground Bus on firewall (engine bay side) near PMU
+- [ ] Mount Firewall Stud Bus on firewall (cabin side)
+- [ ] Mount SwitchPros Ground Bus near SwitchPros controller
 
 **Frame Rail Grounds:**
 
-- [ ] Confirm front frame rail ground point location (clean metal-to-metal)
-- [ ] Confirm rear frame rail ground point location (clean metal-to-metal)
-- [ ] Confirm 2/0 AWG: START battery- → Engine Bay Ground Bus Stud 1
-- [ ] Confirm 2/0 AWG: Engine Bay Ground Bus Stud 2 → Engine block
-- [ ] Confirm 2/0 AWG: Engine Bay Ground Bus Stud 3 → Front frame rail
-- [ ] Confirm 2/0 AWG: AUX battery- → Rear frame rail (~3 ft)
-- [ ] Confirm 4 AWG: Firewall Stud Bus Stud 1 → Chassis ground (~2 ft)
-- [ ] Confirm 1/0 AWG: SwitchPros Ground Bus Stud 1 → Chassis/frame rail
-
-**Battery Ground Reference:**
-
-- [ ] Confirm 1/0 AWG: Engine Bay Ground Bus Stud 4 → AUX battery- (5-6 ft, 75A capacity)
+- [ ] Confirm front frame rail ground point located
+- [ ] Confirm rear frame rail ground point located
+- [ ] Confirm START battery- → Engine Bay Ground Bus
+- [ ] Confirm Engine Bay Ground Bus → engine block
+- [ ] Confirm Engine Bay Ground Bus → front frame rail
+- [ ] Confirm AUX battery- → rear frame rail
+- [ ] Confirm Firewall Stud Bus → chassis ground
+- [ ] Confirm SwitchPros Ground Bus → chassis/frame rail
+- [ ] Confirm Engine Bay Ground Bus → AUX battery- (cross-battery reference)
 
 **Ground Testing:**
 
-- [ ] Verify <0.1V drop: START battery- to front frame rail (engine @ 2000 RPM)
-- [ ] Verify <0.1V drop: AUX battery- to rear frame rail (engine @ 2000 RPM)
-- [ ] Verify <0.05V drop: START battery- to AUX battery- (engine @ 2000 RPM)
-- [ ] Verify <0.05V drop: START battery- to AUX battery- (BCDC charging @ 25A)
-- [ ] Verify <0.2V drop: START battery- to AUX battery- (winch operation @ 400A)
-- [ ] Verify ground bus stud torque: 100-120 in-lb (3/8"-16 studs on PowerBar)
+- [ ] Verify ground voltage drop within spec on all battery-to-frame paths (engine @ 2000 RPM)
+- [ ] Verify cross-battery ground drop within spec under BCDC charging
+- [ ] Verify cross-battery ground drop within spec under winch load
 
 ---
 
@@ -51,142 +47,112 @@ Organized by installation order for efficient build workflow.
 
 ### START Battery Circuit Breakers
 
-**Circuit Breakers (mount within 7" of battery):**
-
-- [ ] Mount Mechanical Products 174-S2-250-2 250A CB (PMU main power)
-- [ ] Mount Mechanical Products 174-S2-080-2 80A CB (BCDC input)
-
-**START Battery Positive Wiring:**
-
-- [ ] Confirm 2/0 AWG: START battery+ → 250A CB → PMU main power (~7 ft, temp-derated for 60°C)
-- [ ] Confirm 4 AWG: START battery+ → 80A CB → BCDC input (~6 ft)
-
-**PMU Ground Reference:**
-
-- [ ] Confirm PMU Pin 25 connected to Engine Bay Ground Bus Stud 5 (per harness, <100mA logic/CAN reference)
+- [ ] Mount 250A circuit breaker (PMU main power) within reach of START battery
+- [ ] Mount 80A circuit breaker (BCDC input) within reach of START battery
+- [ ] Confirm START battery+ → 250A CB → PMU main power
+- [ ] Confirm START battery+ → 80A CB → BCDC input
+- [ ] Confirm PMU ground reference (Pin 25) → Engine Bay Ground Bus
 
 **Direct Battery Connections (No Circuit Breaker):**
 
-- [ ] Confirm ECM power/ground connected directly to START battery terminals (per Cummins harness)
+- [ ] Confirm ECM power/ground connected directly to START battery (per Cummins harness)
 - [ ] Confirm grid heater relay powered from START battery+ (via integrated fusible link)
 - [ ] Confirm grid heater ground connected directly to START battery-
 
 **Radio Grounds (RF Noise Isolation):**
 
-- [ ] Confirm 10 AWG: GMRS Radio ground → START battery- (route through floor/frame, ~8 ft)
-- [ ] Confirm 10 AWG: STX Intercom ground → START battery- (route through floor/frame, ~8 ft)
+- [ ] Confirm GMRS Radio ground → START battery- (direct run for RF isolation)
+- [ ] Confirm STX Intercom ground → START battery- (direct run for RF isolation)
 
 **Testing:**
 
-- [ ] Verify PMU main power always on (via 250A CB)
-- [ ] Verify voltage drop across main power cables under load (<3% at 60°C)
-- [ ] Verify ground resistance: Engine Bay Ground Bus to battery- (<0.1Ω)
+- [ ] Verify PMU main power always on
+- [ ] Verify main power cable voltage drop within spec under load
 
 ### AUX Battery Inline CBs & Firewall CONSTANT Bus
 
-**Inline CBs at AUX battery (mount within 7" of battery on wheel well bracket):**
-
-- [ ] Mount Mechanical Products 174-S2-300-2 300A CB (forward feed to firewall bus)
-- [ ] Mount Mechanical Products 174-S2-150-2 150A CB (SafetyHub local feed)
-- [ ] Confirm AUX battery+ has 4 stacked ring lugs: Winch (1/0), BCDC output (4 AWG), 300A CB input (2/0), 150A CB input (2 AWG)
-
-**Battery-Side Protected Feeds:**
-
-- [ ] Confirm 2/0 AWG: AUX battery+ → 300A CB → Firewall CONSTANT Bus (~13 ft via cabin trunk)
-- [ ] Confirm 2 AWG: AUX battery+ → 150A CB → SafetyHub 150 (~2 ft local)
+- [ ] Mount 300A circuit breaker (forward feed to firewall bus) within reach of AUX battery
+- [ ] Mount 150A circuit breaker (SafetyHub local feed) within reach of AUX battery
+- [ ] Confirm AUX battery+ ring lugs landed: Winch, BCDC output, 300A CB, 150A CB
+- [ ] Confirm AUX battery+ → 300A CB → Firewall CONSTANT Bus
+- [ ] Confirm AUX battery+ → 150A CB → SafetyHub 150
 
 **Firewall CONSTANT Bus:**
 
-- [ ] Mount Blue Sea 2105 MaxiBus (250A) on firewall (passenger cabin side, near BODY PDU mounting area)
-- [ ] Confirm 2/0 AWG forward feed terminates at bus input stud
-
-**Firewall-Side CBs (mount within 7" of Firewall CONSTANT Bus):**
-
-- [ ] Mount Mechanical Products 174-S2-150-2 150A CB (SwitchPros)
-- [ ] Mount Mechanical Products 174-S2-100-2 100A CB (BODY PDU)
-- [ ] Mount Blue Sea 187-100A 100A CB (JL Audio MV800/8i Amp) — note this CB is on the battery-side bracket, not at the firewall bus
-
-**Firewall CONSTANT Bus Wiring:**
-
-- [ ] Confirm 2 AWG: Firewall CONSTANT Bus → 150A CB → SwitchPros power module (~2 ft)
-- [ ] Confirm 2 AWG: Firewall CONSTANT Bus → 100A CB → BODY PDU power studs (~2 ft)
-- [ ] Confirm 4 AWG: AUX battery+ → 100A CB → JL Audio MV800/8i Amp (~3-4 ft, under rear seat — direct AUX feed, not via firewall bus)
+- [ ] Mount Firewall CONSTANT Bus on firewall (cabin side, near BODY PDU)
+- [ ] Confirm forward feed terminates at bus input stud
+- [ ] Mount 150A circuit breaker (SwitchPros) at Firewall CONSTANT Bus
+- [ ] Mount 100A circuit breaker (BODY PDU) at Firewall CONSTANT Bus
+- [ ] Mount 100A circuit breaker (JL Audio amp) at AUX battery bracket
+- [ ] Confirm Firewall CONSTANT Bus → 150A CB → SwitchPros power module
+- [ ] Confirm Firewall CONSTANT Bus → 100A CB → BODY PDU power studs
+- [ ] Confirm AUX battery+ → 100A CB → JL Audio amp (direct AUX feed, not via firewall bus)
 
 **Direct AUX Battery Connections (No Circuit Breaker):**
 
-- [ ] Confirm 1/0 AWG: AUX battery+ → Winch positive (13 ft one-way, direct connection per WARN spec)
-- [ ] Confirm 1/0 AWG: AUX battery- → Winch negative (13 ft one-way, matches positive path)
-- [ ] Confirm 4 AWG: AUX battery- → JL Audio MV800/8i amplifier ground (~3-4 ft)
+- [ ] Confirm AUX battery+ → Winch positive (direct connection per WARN spec)
+- [ ] Confirm AUX battery- → Winch negative
+- [ ] Confirm AUX battery- → JL Audio amp ground
 
 ### BCDC Alpha 50 Installation
 
-- [ ] Mount BCDC in passenger rear wheel well (water-protected, LED visibility access)
-- [ ] Confirm 4 AWG: START battery+ → 80A CB → BCDC input (red terminal, M8, ~6 ft)
-- [ ] Confirm 4 AWG: BCDC output (brown terminal, M8) → AUX battery+
-- [ ] Confirm 4 AWG: BCDC negative (black terminal, M8) → AUX battery-
-- [ ] Confirm 18 AWG: Ignition signal (blue spade terminal) → PMU ignition sense tap
+- [ ] Mount BCDC in passenger rear wheel well (water-protected, LED visible)
+- [ ] Confirm START battery+ → 80A CB → BCDC input
+- [ ] Confirm BCDC output → AUX battery+
+- [ ] Confirm BCDC negative → AUX battery-
+- [ ] Confirm ignition signal → PMU ignition sense tap
 
 **Battery Temperature Sensor (REQUIRED for LiFePO4):**
 
-- [ ] Install BCDC temp sensor ring terminal on AUX battery positive terminal bolt
-- [ ] Route sensor cable to BCDC (short run - both in passenger rear wheel well)
-- [ ] Plug sensor into BCDC temperature sensor port (2-pin connector, polarity reversible)
+- [ ] Install BCDC temp sensor on AUX battery positive terminal
+- [ ] Plug temp sensor into BCDC sensor port
 
 **BCDC Configuration & Testing:**
 
 - [ ] Configure Green Power Priority via RedArc app
 - [ ] Test jump start assist function
-- [ ] Verify BCDC LED status indicates proper charging mode
+- [ ] Verify BCDC LED indicates proper charging mode
 
 ### Alternator
 
 - [ ] Install 270A alternator (Premier Power Welder HO-C28)
-- [ ] Confirm 2/0 AWG: Alternator output → START battery+ (shortest path, ~8 ft)
+- [ ] Confirm alternator output → START battery+
 - [ ] Confirm alternator case grounded through engine block mounting
 
 ---
 
 ## Phase 3: Controllers - Physical Installation & Main Power
 
-### PMU24 Physical Installation
+### PMU24
 
 - [ ] Mount PMU on firewall or inner fender (accessible for LED/USB diagnostics)
-- [ ] Confirm PMU ground reference Pin 25 connected to Engine Bay Ground Bus Stud 5
+- [ ] Confirm PMU ground reference (Pin 25) → Engine Bay Ground Bus
 
-### SafetyHub 150 Physical Installation
+### SafetyHub 150
 
-- [ ] Mount SafetyHub 150 in passenger rear wheel well (co-located with AUX battery and inline CBs)
-- [ ] Confirm 2 AWG: AUX battery+ → 150A CB → SafetyHub input (~2 ft local)
-- [ ] Verify SafetyHub internal ground bus connected to chassis ground (rear frame rail)
+- [ ] Mount SafetyHub 150 in passenger rear wheel well (co-located with AUX battery)
+- [ ] Confirm AUX battery+ → 150A CB → SafetyHub input
+- [ ] Confirm SafetyHub ground bus → chassis ground
 
-### BODY PDU Physical Installation
+### BODY PDU
 
 - [ ] Verify all circuit breakers and relays functional in LR-2 unit
-- [ ] Replace 24V relays (K40, K42, K53) with 12V relays (determine part numbers)
-- [ ] Mount LR-2 on firewall (body side, passenger side, near Firewall CONSTANT Bus)
-- [ ] Confirm 2 AWG: Firewall CONSTANT Bus → 100A CB → BODY PDU power studs (~2 ft)
-- [ ] Confirm 14 AWG: BODY PDU ground → Firewall Stud Bus Terminal 3 (relay coil/logic only)
-- [ ] Create custom wiring harnesses to adapt J301-J306 military connectors to civilian loads
+- [ ] Replace 24V relays (K40, K42, K53) with 12V relays ({{ tbd(70) }})
+- [ ] Mount LR-2 on firewall (body side, near Firewall CONSTANT Bus)
+- [ ] Confirm Firewall CONSTANT Bus → 100A CB → BODY PDU power studs
+- [ ] Confirm BODY PDU ground → Firewall Stud Bus
+- [ ] Build harnesses to adapt J301-J306 connectors to civilian loads ({{ tbd(69) }})
 - [ ] Route heated seat dash switches to LR-2 relay control inputs (K21, K22)
-- [ ] Label repurposed circuits on LR-2 enclosure (match CB positions to new functions)
+- [ ] Label repurposed circuits on LR-2 enclosure
 
-### SwitchPros RCR-Force 12 Physical Installation
+### SwitchPros RCR-Force 12
 
-- [ ] Mount SwitchPros power module on firewall (cabin side, passenger area, next to BODY PDU)
-- [ ] Mount SwitchPros Ground Bus (Blue Sea 2105 MaxiBus) at firewall near power module
-- [ ] Confirm 2 AWG: Firewall CONSTANT Bus → 150A CB → SwitchPros power input (~2 ft)
-- [ ] Confirm 4 AWG: SwitchPros logic ground → chassis ground at firewall (short run)
-- [ ] Mount SwitchPros control panel on dash; order 5 ft control cable (firewall to dash)
-
-**SwitchPros Custom Harness Note:**
-
-!!! info "Custom Delphi Harness Design"
-Create 12 custom 2-pin Delphi harnesses at SwitchPros:
-
-    - Each SwitchPros output → 2-pin Delphi plug (power + ground combined)
-    - Each light → matching 2-pin Delphi plug
-    - Back of SwitchPros: ~12 Delphi connectors for plug-and-play lighting
-    - Eliminates individual wire routing - each light is single plug connection
+- [ ] Mount SwitchPros power module on firewall (cabin side, next to BODY PDU)
+- [ ] Mount SwitchPros Ground Bus at firewall near power module
+- [ ] Confirm Firewall CONSTANT Bus → 150A CB → SwitchPros power input
+- [ ] Confirm SwitchPros logic ground → chassis ground at firewall
+- [ ] Mount SwitchPros control panel on dash; order control cable
+- [ ] Build custom 2-pin Delphi harnesses for each output (plug-and-play lighting)
 
 ---
 
@@ -194,121 +160,98 @@ Create 12 custom 2-pin Delphi harnesses at SwitchPros:
 
 ### Firewall Bulkhead Connector
 
-**Deutsch HDP24-24-29 Installation:**
-
-- [ ] Drill 1.5" diameter hole in firewall for bulkhead connector
-- [ ] Mount HDP24-24-21PE-L015 receptacle (flange mount, engine side)
-- [ ] Assemble HDP26-24-21SE plug (cabin side)
-- [ ] Crimp size 16 contacts (0460-202-16141 pins, 0462-201-16141 sockets) for 17 wires
-- [ ] Install sealing plugs (114017/114018) in unused cavities
-- [ ] Verify IP67/IP68 seal engagement with bayonet coupling
-
-**Pin Assignment Verification:**
-
-- [ ] Confirm Pin 1-6 (Engine→Cabin): Radio power (3), PMU lighting outputs (3)
-- [ ] Confirm Pin 7-17 (Cabin→Engine): CT4 outputs (4), switch signals (5), winch control (2)
-- [ ] Install ferrite chokes on radio power leads at radio end (RF mitigation)
+- [ ] Drill firewall hole for bulkhead connector
+- [ ] Mount Deutsch HDP24-24-29 receptacle (engine side)
+- [ ] Assemble Deutsch plug (cabin side)
+- [ ] Crimp contacts for all 17 wires
+- [ ] Install sealing plugs in unused cavities
+- [ ] Verify bulkhead connector seal engagement
+- [ ] Confirm Pin 1-6 assignments (Engine→Cabin): radio power, PMU lighting outputs
+- [ ] Confirm Pin 7-17 assignments (Cabin→Engine): CT4 outputs, switch signals, winch control
+- [ ] Install ferrite chokes on radio power leads (RF mitigation)
 
 ### Ignition Signal Distribution
 
-- [ ] Confirm 14 AWG: PBS-I PINK IGN (cabin) → Ignition signal bus bar Stud 1
-- [ ] Confirm ignition signal bus bar Stud 2 → Deutsch connector Pin 12 (outbound to engine bay)
-- [ ] Install 5A inline fuse at ignition signal bus bar Stud 2 — Cummins-mandated ECM Pin 41 protection per 5504137 (the only overcurrent device between the PBS-I 60A relay and the ECM feed)
-- [ ] Confirm engine-bay junction off Pin 12 → ECM 12V supply + PMU Pin 7
-- [ ] Confirm bus bar terminals split to: CT4, SwitchPros, Fusion Radio, BCDC
-- [ ] Verify total ignition signal current <500mA for all bus bar taps
+- [ ] Confirm PBS-I PINK IGN (cabin) → ignition signal bus bar
+- [ ] Confirm ignition signal bus bar → Deutsch connector (outbound to engine bay)
+- [ ] Install inline fuse on ECM ignition feed (Cummins-mandated ECM Pin 41 protection per 5504137)
+- [ ] Confirm engine-bay junction → ECM 12V supply + PMU Pin 7
+- [ ] Confirm bus bar taps split to: CT4, SwitchPros, Fusion Radio, BCDC
+- [ ] Verify total ignition signal current within spec
 
 ### PMU Input Wiring
 
-- [ ] Confirm 18 AWG: Ignition RUN (from engine-bay distribution off Pin 12) → PMU Pin 7
-- [ ] Confirm horn button → PMU In 1 (via Deutsch connector Pin 11)
-- [ ] Confirm brake pedal switch → PMU In 2 (via Deutsch connector Pin 13)
-- [ ] Confirm reverse signal → PMU In 3 (Turbolamik aux output, Reverse gear)
-- [ ] Confirm A/C request → PMU In 9 (via Deutsch connector Pin 14)
-- [ ] Confirm CT4 SW3 (headlight status) → PMU In 7 (tap on engine bay side of connector)
-- [ ] PMU In 4, In 5, In 6, In 8 — Available for future expansion (no current wiring)
+- [ ] Confirm ignition RUN → PMU Pin 7
+- [ ] Confirm horn button → PMU In 1
+- [ ] Confirm brake pedal switch → PMU In 2
+- [ ] Confirm reverse signal → PMU In 3 (Turbolamik aux output)
+- [ ] Confirm A/C request → PMU In 9
+- [ ] Confirm CT4 SW3 (headlight status) → PMU In 7
+- [ ] PMU In 4, 5, 6, 8 — reserved for future expansion (no wiring)
 
 ### PMU Output Wiring
 
-**High-Current Outputs (Combined):**
-
-- [ ] Confirm iBooster main power → OUT1+10 combined (46A @ 40°C capacity, non-adjacent)
-- [ ] Confirm radiator fan → OUT2+3+4 combined (75A total capacity)
-
-**25A Outputs:**
-
-- [ ] Confirm HVAC blower → OUT5 (20A max) - ground: factory HVAC ground
-- [ ] Confirm GMRS Radio → OUT6 (15A) - ground: direct to START battery-
-- [ ] Confirm oil cooler fan → OUT7 (15A) - ground: Engine Bay Bus Stud 8
-- [ ] Confirm PS cooler fan → OUT8 (15A) - ground: Engine Bay Bus Stud 8
-- [ ] Confirm Dakota Digital system → OUT9 (25A) - ground: Firewall Stud Bus T4-5
-
-**15A Outputs:**
-
-- [ ] Confirm wipers (WS-51C) → OUT11 (15A) - ground: Firewall Stud Bus T2
-- [ ] Confirm CT4 → OUT13 (9A, CONSTANT) - ground: Firewall Stud Bus T1
-- [ ] Confirm winch contactor trigger → OUT15 (1A) - control signal only
-
-**7A Outputs:**
-
-- [ ] Confirm A/C clutch → OUT17 (5A) - ground: factory A/C ground
-- [ ] Confirm horn → OUT18 (5.4A) - ground: Engine Bay Bus Stud 6
-- [ ] Confirm iBooster ignition signal → OUT19 (5A) - ground: Engine Bay Bus Stud 7
-- [ ] Confirm STX Intercom → OUT20 (5A) - ground: direct to START battery-
-- [ ] Confirm brake lights → OUT21 (3A) - ground: SwitchPros Ground Bus T4
-- [ ] Confirm reverse lights → OUT22 (5A) - ground: SwitchPros Ground Bus T4
-- [ ] Confirm DRL/parking → OUT23 (~2.6A) - ground: SwitchPros Ground Bus T5
-- [ ] OUT24 — Available for future expansion (no current wiring)
+- [ ] Confirm iBooster main power → OUT1+10 (combined)
+- [ ] Confirm radiator fan → OUT2+3+4 (combined)
+- [ ] Confirm HVAC blower → OUT5
+- [ ] Confirm GMRS Radio → OUT6
+- [ ] Confirm oil cooler fan → OUT7
+- [ ] Confirm PS cooler fan → OUT8
+- [ ] Confirm Dakota Digital system → OUT9
+- [ ] Confirm wipers (WS-51C) → OUT11
+- [ ] Confirm CT4 → OUT13
+- [ ] Confirm winch contactor trigger → OUT15
+- [ ] Confirm A/C clutch → OUT17
+- [ ] Confirm horn → OUT18
+- [ ] Confirm iBooster ignition signal → OUT19
+- [ ] Confirm STX Intercom → OUT20
+- [ ] Confirm brake lights → OUT21
+- [ ] Confirm reverse lights → OUT22
+- [ ] Confirm DRL/parking → OUT23
+- [ ] OUT24 — reserved for future expansion (no wiring)
 
 ### PMU CAN Bus Integration
 
-- [ ] Confirm J1939 CAN High T-tap → PMU Pin 23/24 (18-20 AWG twisted pair, <12" stub)
-- [ ] Confirm J1939 CAN Low T-tap → PMU Pin 36/37 (18-20 AWG twisted pair, <12" stub)
-- [ ] Disable PMU internal CAN termination in software (bus already terminated at ECM + harness end)
-- [ ] Verify 60Ω resistance across CAN High/Low at ECM connector (harness disconnected, ignition off)
-- [ ] Configure PMU to read J1939 SPNs: 100 (oil pressure), 110 (coolant temp), 175 (oil temp), 190 (RPM)
+- [ ] Confirm J1939 CAN High T-tap → PMU Pin 23/24
+- [ ] Confirm J1939 CAN Low T-tap → PMU Pin 36/37
+- [ ] Disable PMU internal CAN termination in software
+- [ ] Verify CAN bus termination resistance at ECM connector
+- [ ] Configure PMU to read J1939 SPNs: 100, 110, 175, 190
 
 ### BODY PDU Circuit Wiring
 
-- [ ] Confirm Fusion Radio memory → CB30 (15A, 14 AWG, CONSTANT)
-- [ ] Confirm USB ports → CB48 (20A, 14 AWG, CONSTANT) - 2× Powerwerx PanelUSB-75W (7.5A fuse ea)
-- [ ] Confirm WolfBox camera → CB39 (10A, 16 AWG, CONSTANT)
-- [ ] Confirm driver heated seat → CB45 (15A, 14 AWG) via relay K21 - 5A peak, 2A sustained
-- [ ] Confirm passenger heated seat → CB42 (20A, 14 AWG) via relay K22 - 5A peak, 2A sustained
-- [ ] Confirm cargo lights → CB20 (10A, 16 AWG) - switch on rear wheel well top
-- [ ] Confirm winch control → CB43 (10A, 18 AWG) - dash rocker + remote parallel control
-
-**Verification:**
-
-- [ ] Verify Fusion radio current draw matches fuse ratings
-- [ ] Verify WolfBox model and 10A fuse adequate
-- [ ] Verify all BODY PDU load grounds route to individual load ground points (high-side switching)
+- [ ] Confirm Fusion Radio memory → CB30 (CONSTANT)
+- [ ] Confirm USB ports → CB48 (CONSTANT)
+- [ ] Confirm WolfBox camera → CB39 (CONSTANT)
+- [ ] Confirm driver heated seat → CB45 via relay K21
+- [ ] Confirm passenger heated seat → CB42 via relay K22
+- [ ] Confirm cargo lights → CB20
+- [ ] Confirm winch control → CB43
 
 ### SafetyHub Circuit Wiring
 
-- [ ] Confirm ARB compressor motor 1 → MIDI-1 (60A, 6 AWG, ~12 ft to under passenger seat)
-- [ ] Confirm ARB compressor motor 2 → MIDI-2 (60A, 6 AWG, ~12 ft to under passenger seat)
-- [ ] Confirm winch contactor trigger → ATC-1 (15A, 14 AWG, ~13 ft to front bumper)
+- [ ] Confirm ARB compressor motor 1 → MIDI-1
+- [ ] Confirm ARB compressor motor 2 → MIDI-2
+- [ ] Confirm winch contactor trigger → ATC-1
 
 ### Solar Panel Installation
 
-- [ ] Install Cascadia 4x4 80W panel on hood per manufacturer instructions (SolarClasp adhesive)
-- [ ] Route wiring: Hood → Firewall → BCDC (~10-12 ft, MC4 connectors)
-- [ ] Confirm solar positive → BCDC solar input (yellow terminal)
-- [ ] Confirm solar negative → Chassis ground (NOT BCDC negative)
-- [ ] **CRITICAL:** Verify polarity before connection - reverse polarity damages BCDC
+- [ ] Install Cascadia 4x4 80W panel on hood per manufacturer instructions
+- [ ] Route solar wiring: hood → firewall → BCDC
+- [ ] Confirm solar positive → BCDC solar input
+- [ ] Confirm solar negative → chassis ground (NOT BCDC negative)
+- [ ] **CRITICAL:** Verify polarity before connection — reverse polarity damages BCDC
 
 **Optional Overvoltage Protection (cold weather):**
 
-- [ ] Mount overvoltage relay module near BCDC (weatherproof location)
-- [ ] Configure overvoltage threshold: 47V disconnect, 44V reconnect
-- [ ] Configure trip delay: 1-2 seconds (ignore brief spikes)
+- [ ] Mount overvoltage relay module near BCDC
+- [ ] Configure overvoltage thresholds and trip delay
 - [ ] Test threshold settings before final installation
 
 **Solar Testing:**
 
-- [ ] Monitor BCDC LED in daylight to verify solar charging
-- [ ] Verify solar input voltage within range (9-48V) at operating temperature
+- [ ] Verify solar charging via BCDC LED in daylight
+- [ ] Verify solar input voltage within range at operating temperature
 
 ---
 
@@ -316,53 +259,37 @@ Create 12 custom 2-pin Delphi harnesses at SwitchPros:
 
 ### PMU Programming
 
-**Output Combining:**
-
-- [ ] Configure iBooster combining (OUT1+10, non-adjacent terminals)
-- [ ] Configure radiator fan combining (OUT2+3+4, PWM variable speed)
-
-**Logic Programming:**
-
-- [ ] Program DRL auto-off when headlights active (In 7 CT4 SW3 → OUT23 disable)
-- [ ] Program A/C clutch engagement logic (In 9 → OUT17)
-- [ ] Program horn activation (In 1 → OUT18)
-- [ ] Program brake light activation (In 2 → OUT21)
-- [ ] Program reverse light activation (In 3 → OUT22)
-- [ ] Program oil cooler fan based on SPN 175 (220-230°F hysteresis) → OUT7
-- [ ] Program PS cooler fan based on SPN 110 (210-220°F hysteresis) → OUT8
-- [ ] Configure sequential load startup delays (0.5s, 1.0s, 1.5s)
-
-**Backup:**
-
-- [ ] Export/backup configuration (.pmu format) to git repository
-- [ ] Print critical logic (DRL, fan control) for emergency recovery
+- [ ] Configure iBooster output combining (OUT1+10)
+- [ ] Configure radiator fan output combining (OUT2+3+4, PWM)
+- [ ] Program DRL auto-off when headlights active
+- [ ] Program A/C clutch engagement logic
+- [ ] Program horn activation
+- [ ] Program brake light activation
+- [ ] Program reverse light activation
+- [ ] Program oil cooler fan from SPN 175
+- [ ] Program PS cooler fan from SPN 110
+- [ ] Configure sequential load startup delays
+- [ ] Export/backup configuration to git repository
 
 ### PMU Testing
 
-- [ ] Verify J1939 communication and data accuracy (SPNs 100, 110, 175, 190)
-- [ ] Test DRL auto-off logic (verify OUT23 disables when headlights active)
-- [ ] Test A/C clutch engagement (verify OUT17 activates with In 9)
-- [ ] Test CAN-based fan controls at threshold temps (OUT7, OUT8)
+- [ ] Verify J1939 communication and data accuracy
+- [ ] Test DRL auto-off logic
+- [ ] Test A/C clutch engagement
+- [ ] Test CAN-based fan controls at threshold temps
 - [ ] Test sequential load startup timing
 - [ ] Verify LED diagnostics show correct states
-- [ ] Verify iBooster CONSTANT power (OUT1+10 always on)
-
-### Ground Bus Testing
-
-- [ ] Verify Engine Bay Ground Bus stud torque: 100-120 in-lb
-- [ ] Verify Firewall Stud Bus terminal torque per Blue Sea spec
-- [ ] Verify SwitchPros Ground Bus terminal torque per Blue Sea spec
-- [ ] Verify all ground bus connections have clean metal-to-metal contact
+- [ ] Verify iBooster power always on
 
 ### System Integration Testing
 
-- [ ] Verify all PMU outputs operate correctly (test each output individually)
-- [ ] Test all BODY PDU circuits (CB30, CB48, CB39, CB45, CB42, CB20, CB43)
-- [ ] Test SafetyHub circuits (MIDI-1/2 ARB, ATC-1 winch trigger)
+- [ ] Verify all PMU outputs operate correctly
+- [ ] Test all BODY PDU circuits
+- [ ] Test SafetyHub circuits
 - [ ] Verify SwitchPros Delphi connectors and outputs
 - [ ] Verify Deutsch bulkhead connector seal integrity
-- [ ] Final voltage drop measurements under load (<3% at operating temp)
-- [ ] Final ground resistance verification (<0.1Ω all paths)
+- [ ] Final voltage drop measurements under load (within spec)
+- [ ] Final ground resistance verification (within spec)
 
 ---
 

--- a/docs/jeep_lj/09-installation/02-engine-systems-checklist.md
+++ b/docs/jeep_lj/09-installation/02-engine-systems-checklist.md
@@ -8,53 +8,27 @@ tags:
 
 # Section 2: Engine Systems - Installation Checklist
 
-Organized by installation order for efficient build workflow.
-
----
-
-## Procurement
-
-### iBooster
-
-- [ ] Source 03-06 TJ/LJ automatic brake pedal assembly (donor)
-- [ ] Source new stop-lamp switch + clip if donor pedal lacks them (Mopar 56045043AB)
-- [x] ~~Source Bosch iBooster Gen 2 unit~~ — ✅ purchased 2026-05-30 (Honda Accord Hybrid donor, listing #397546491129; OEM 46680-T3Z-A00 + 01469-TWA-A58 confirmed on listing; MC pull included will be discarded)
-- [ ] Order Back Bay Customs Wilwood MC adapter (260-15542 fitment confirmed by vendor 2026-05-30 — Honda iBooster only)
-- [ ] Order Wilwood 260-15542 Tandem Compact master cylinder (1.00" bore — sized to TJ Rubicon front calipers)
-- [ ] Order Wilwood 260-16392 remote reservoirs (×2) + 250-16393 dual bracket
-- [ ] Order Wilwood 220-12993 -3 AN flexlines (×2) - confirm length after firewall mockup
-- [ ] Select iBooster wiring harness: [Tulay's Gen 2][tulays-harness] vs EVcreate Gen 2 kit
-- [ ] Redesign backing-plate DXF to 60×80mm hole pattern (was 72×72mm), then order SendCutSend cabin-side backing plate (3/16" steel, 4× M8 clearance holes at 60×80mm, 80mm vertical + 62mm center pass-through) — booster mounts directly via integral studs, no separate bracket needed
-
-### Wipers
-
-- [ ] Order Ron Francis WS-51C wiper controller module
-
-### Runaway Protection
-
-- [ ] Order Mishimoto MMOCC-CBT catch can + MMOCC-UB bracket
-- [ ] Order AMOT 4261M02A027-AA air shutoff valve (2.8", manual/pneumatic, NPT)
-- [ ] Order Midwest Control 30-144-TTL-BH-3 push-pull cable + T-handle
-- [ ] Measure R2.8 turbo inlet OD and order matching NPT-to-hose adapters
-- [ ] Source 2 ft of 5/8" oil-resistant hose + worm clamps for catch can plumbing
+Organized by installation order for efficient build workflow. Each item is a
+check-off confirmation — specs and part numbers live in the linked source docs;
+parts to buy live in the [Purchase Tracker][purchase-tracker].
 
 ---
 
 ## Phase 1: Starter System
 
-- [ ] Confirm starter motor (DB Electrical 410-52442) mounted to engine block
-- [ ] Confirm 2/0 AWG cable from START battery+ to starter battery post
-- [ ] Confirm Cole Hersee 24213 solenoid mounted on firewall (engine bay side)
-- [ ] Confirm 10 AWG from starter battery post to Cole Hersee input
-- [ ] Confirm 10 AWG from Cole Hersee output to starter switch post
-- [ ] Confirm PBS-I module mounted under-dash (cabin), powered from Critical Cabin PDU
-- [ ] Confirm PBS-I PURPLE START output wired to WAIT-gate relay COM terminal (cabin)
-- [ ] Confirm WAIT-gate relay coil wired to ECM WAIT signal tap (shared with HDX WAIT/EX input)
-- [ ] Confirm WAIT-gate relay NC contact routed through firewall Pin 15 → Cole Hersee 24213 coil+ in engine bay
+- [ ] Confirm starter motor mounted to engine block
+- [ ] Confirm START battery+ → starter battery post
+- [ ] Confirm Cole Hersee solenoid mounted on firewall (engine bay side)
+- [ ] Confirm starter battery post → Cole Hersee input
+- [ ] Confirm Cole Hersee output → starter switch post
+- [ ] Confirm PBS-I module mounted under-dash, powered from Critical Cabin PDU
+- [ ] Confirm PBS-I PURPLE START → WAIT-gate relay COM
+- [ ] Confirm WAIT-gate relay coil → ECM WAIT signal tap (shared with HDX WAIT/EX input)
+- [ ] Confirm WAIT-gate relay NC contact → firewall Pin 15 → Cole Hersee coil+
 - [ ] Confirm Cole Hersee coil- grounded to engine bay ground bus
-- [ ] Confirm PBS-I PINK IGN routed through cabin ignition signal bus bar → firewall Pin 12 → ECM 12V supply + PMU Pin 7
-- [ ] Confirm Start Button (included in PBS-I kit) mounted on dash, 36" harness plugged into PBS-I side port
-- [ ] Confirm Programming Button stashed accessibly for tag-learn / Emergency Bypass PIN entry
+- [ ] Confirm PBS-I PINK IGN → cabin ignition bus bar → firewall Pin 12 → ECM 12V + PMU Pin 7
+- [ ] Confirm Start Button mounted on dash, harness plugged into PBS-I
+- [ ] Confirm Programming Button stashed accessibly for tag-learn / Emergency Bypass
 
 ---
 
@@ -62,48 +36,47 @@ Organized by installation order for efficient build workflow.
 
 ### Pre-Install Fab + Bench Test
 
-- [ ] Bench test donor iBooster: apply 12V ignition signal, verify motor cycles and pedal rod assists
+- [ ] Bench test donor iBooster: apply ignition signal, verify motor cycles and pedal rod assists
 - [ ] Discard factory Honda master cylinder
-- [ ] Install Back Bay Customs adapter + Wilwood 260-15542 MC (1.00" bore) onto iBooster (pushrod pre-set)
-- [ ] Mock up donor bracket + iBooster + Wilwood MC assembly against LJ firewall (cardboard/3D-print) - verify engine-bay clearance BEFORE drilling
-- [ ] Drill LJ firewall: 4× M8 clearance holes (60×80mm pattern, 80mm vertical) + 62mm center bore (factory booster holes abandoned)
-- [ ] Mock up reservoir standoff location 4-6" above MC flange, verify hood clearance
+- [ ] Install Back Bay Customs adapter + Wilwood MC onto iBooster
+- [ ] Mock up iBooster + MC assembly against firewall — verify engine-bay clearance BEFORE drilling
+- [ ] Drill firewall for iBooster mounting (factory booster holes abandoned)
+- [ ] Mock up reservoir standoff location, verify hood clearance
 
 ### Brake Pedal Swap
 
-- [ ] Remove factory manual-trans pedal assembly (clutch + brake)
-- [ ] Verify donor 03-06 auto pedal: stop-lamp switch + clip present, pushrod hole bushing OK, arm not bent
-- [ ] Install 03-06 auto brake pedal assembly (BTSI boss left empty)
+- [ ] Remove factory manual-trans pedal assembly
+- [ ] Verify donor auto pedal: stop-lamp switch + clip present, bushing OK, arm not bent
+- [ ] Install 03-06 auto brake pedal assembly
 - [ ] Reconnect stop-lamp switch wiring: PMU In 2, Pin 15 crank-chain tap, Turbolamik brake input
-- [ ] Plug clutch master cylinder firewall hole (~1.25" block-off plate or weld closure)
-- [ ] Bench-measure pedal pivot-to-pushrod distance vs factory manual pedal (confirm pedal ratio — geometry/travel check for MC stroke headroom + iBooster rod travel, not a feel-tuning step)
-- [ ] Re-measure iBooster pushrod length after pedal install; adjust per harness vendor instructions before bleeding
+- [ ] Plug clutch master cylinder firewall hole
+- [ ] Bench-measure pedal ratio vs factory pedal (confirm MC stroke + iBooster rod travel headroom)
+- [ ] Re-measure iBooster pushrod length after pedal install; adjust per harness vendor instructions
 
 ### iBooster Installation
 
 - [ ] Confirm factory vacuum brake booster removed
 - [ ] Confirm custom firewall bracket installed at factory booster location
 - [ ] Confirm iBooster + Wilwood MC assembly mounted to firewall bracket
-- [ ] Confirm iBooster mounting bolts torqued to 16.5 Nm (12 ft-lb) - 2x nyloc nuts
-- [ ] Confirm secondary front support bracket installed (cantilever brace)
-- [ ] Confirm Wilwood 250-16393 dual bracket + 2× 260-16392 reservoirs mounted on standoff
-- [ ] Confirm 2× Wilwood 220-12993 flexlines installed: reservoir (-3 AN) → MC (11/16-20)
-- [ ] Confirm brake hardlines routed from Wilwood MC to front/rear brakes
-- [ ] Confirm iBooster wiring harness connected (Tulay's or EVcreate, per selection)
-- [ ] Confirm iBooster main power connected (10 AWG red from PMU OUT1+10)
-- [ ] Confirm iBooster ignition signal connected (20 AWG green from PMU OUT19)
-- [ ] Confirm iBooster ground connected to engine bay ground bus stud 7 (10 AWG black)
-- [ ] Bleed brake system; verify no leaks at flexlines, MC ports, or hardline unions
+- [ ] Confirm secondary front support bracket installed
+- [ ] Confirm Wilwood dual bracket + reservoirs mounted on standoff
+- [ ] Confirm flexlines installed: reservoir → MC
+- [ ] Confirm brake hardlines routed from MC to front/rear brakes
+- [ ] Confirm iBooster wiring harness connected ({{ tbd(105) }}: Tulay's or EVcreate)
+- [ ] Confirm iBooster main power connected (PMU OUT1+10)
+- [ ] Confirm iBooster ignition signal connected (PMU OUT19)
+- [ ] Confirm iBooster ground connected to engine bay ground bus
+- [ ] Bleed brake system; verify no leaks
 
 ---
 
 ## Phase 3: Grid Heater
 
-- [ ] Confirm ECM pins 46/21 wired to grid heater relay coil (Cummins 5467024)
-- [ ] Confirm fusible link installed from START battery+ to grid heater relay
-- [ ] Confirm grid heater relay ground connected to START battery- or NEGATIVE bus
-- [ ] Confirm grid heater relay mounted in engine bay near intake manifold
-- [ ] Verify grid heater element resistance ~0.15Ω (confirms 80A @ 12V design)
+- [ ] Confirm ECM pins 46/21 → grid heater relay coil
+- [ ] Confirm fusible link from START battery+ to grid heater relay
+- [ ] Confirm grid heater relay ground → START battery- or NEGATIVE bus
+- [ ] Confirm grid heater relay mounted near intake manifold
+- [ ] Verify grid heater element resistance confirms design current ({{ tbd(42) }})
 
 ---
 
@@ -111,26 +84,26 @@ Organized by installation order for efficient build workflow.
 
 - [ ] Confirm factory TJ HVAC system complete and functional
 - [ ] Confirm vacuum system installed: R2.8 manifold → check valve → reservoir → firewall → dash
-- [ ] Verify vacuum system holds vacuum (no leaks)
+- [ ] Verify vacuum system holds vacuum
 
 ---
 
 ## Phase 5: Wipers
 
 - [ ] Confirm WS-51C wiper controller mounted in dash
-- [ ] Confirm PMU OUT11 connected to WS-51C power input (14 AWG)
-- [ ] Confirm WS-51C ground connected to firewall ground (14 AWG)
-- [ ] Confirm WS-51C low/high outputs connected to factory wiper motor
-- [ ] Confirm wiper motor park switch connected to WS-51C park input
-- [ ] Confirm WS-51C washer output connected to factory washer pump
+- [ ] Confirm PMU OUT11 → WS-51C power input
+- [ ] Confirm WS-51C ground connected
+- [ ] Confirm WS-51C low/high outputs → factory wiper motor
+- [ ] Confirm wiper motor park switch → WS-51C park input
+- [ ] Confirm WS-51C washer output → factory washer pump
 
 ---
 
 ## Phase 6: Radiator Fan
 
 - [ ] Confirm GM 84100128 fan mounted to radiator shroud
-- [ ] Confirm PMU OUT2+3+4 connected to fan motor (4 AWG)
-- [ ] Confirm fan ground connected to engine bay ground bus (4 AWG)
+- [ ] Confirm PMU OUT2+3+4 → fan motor
+- [ ] Confirm fan ground connected to engine bay ground bus
 - [ ] Confirm PMU programmed with temperature-based PWM control
 
 ---
@@ -138,10 +111,10 @@ Organized by installation order for efficient build workflow.
 ## Phase 7: Horn
 
 - [ ] Confirm PIAA 85115 horns mounted in engine bay
-- [ ] Confirm PMU OUT18 connected to horns (14 AWG)
-- [ ] Confirm horns grounded to engine bay ground bus (Stud 6)
-- [ ] Confirm horn button trigger wire routed through firewall to PMU In 1
-- [ ] Confirm PMU programmed: In 1 closes → OUT18 activates
+- [ ] Confirm PMU OUT18 → horns
+- [ ] Confirm horns grounded to engine bay ground bus
+- [ ] Confirm horn button trigger routed through firewall to PMU In 1
+- [ ] Confirm PMU programmed: In 1 → OUT18
 
 ---
 
@@ -149,29 +122,28 @@ Organized by installation order for efficient build workflow.
 
 ### Catch Can Installation
 
-- [ ] Confirm Mishimoto MMOCC-UB bracket mounted to selected engine bay location ({{ tbd(58) }} - intake side, away from exhaust)
-- [ ] Confirm MMOCC-CBT catch can installed vertically with petcock at bottom
-- [ ] Confirm 5/8" hose from R2.8 valve cover breather to catch can INLET (worm clamps both ends)
-- [ ] Confirm 5/8" hose from catch can OUTLET to turbo inlet (worm clamps both ends)
+- [ ] Confirm catch can bracket mounted ({{ tbd(58) }} — intake side, away from exhaust)
+- [ ] Confirm catch can installed vertically with petcock at bottom
+- [ ] Confirm hose from valve cover breather → catch can INLET
+- [ ] Confirm hose from catch can OUTLET → turbo inlet
 - [ ] Verify catch can petcock closed before first engine start
-- [ ] Verify no hose chafing against engine, exhaust, or moving parts
 
 ### AMOT Air Shutoff Installation
 
-- [ ] Confirm AMOT 4261M02A027-AA installed in pre-turbo intake tract (between air filter outlet and turbo inlet)
+- [ ] Confirm AMOT installed in pre-turbo intake tract
 - [ ] Confirm NPT-to-hose adapters secure on both AMOT ports
-- [ ] Confirm AMOT butterfly cocks fully open and latches; verify lever orientation matches cable pull direction
-- [ ] Confirm intake clamps torqued on both sides of AMOT (no boost or vacuum leaks)
-- [ ] Confirm AMOT body oriented so the trip lever clears engine bay obstructions through full motion
+- [ ] Confirm AMOT butterfly cocks open and latches; lever orientation matches cable pull
+- [ ] Confirm intake clamps secured (no boost or vacuum leaks)
+- [ ] Confirm AMOT body oriented so trip lever clears obstructions through full motion
 
 ### Cable and T-Handle Installation
 
-- [ ] Confirm Midwest 30-144-TTL-BH-3 T-handle mounted at selected dash location ({{ tbd(56) }})
-- [ ] Confirm cable conduit passes through dedicated firewall grommet ({{ tbd(57) }} - must not share with other cables)
-- [ ] Confirm cable secured every 12" with adel clamps; no sharp bends (≥6" radius)
-- [ ] Confirm cable end attaches to AMOT trip lever; pull stroke ≥0.5" past trip point
+- [ ] Confirm T-handle mounted at dash location ({{ tbd(56) }})
+- [ ] Confirm cable conduit passes through dedicated firewall grommet ({{ tbd(57) }})
+- [ ] Confirm cable secured along run; no sharp bends
+- [ ] Confirm cable end attaches to AMOT trip lever; pull stroke clears trip point
 - [ ] Confirm T-handle sits flush against dash bezel when AMOT is cocked open
-- [ ] Confirm T-handle is labeled `EMERGENCY ENGINE SHUTOFF — PULL TO STOP`
+- [ ] Confirm T-handle labeled `EMERGENCY ENGINE SHUTOFF — PULL TO STOP`
 
 ---
 
@@ -179,66 +151,63 @@ Organized by installation order for efficient build workflow.
 
 ### iBooster Testing
 
-- [ ] Verify 12V CONSTANT at iBooster main power (ignition OFF)
-- [ ] Verify 12V CONSTANT at iBooster main power (ignition ON)
-- [ ] Verify 12V at iBooster ignition signal (ignition RUN only)
-- [ ] Verify iBooster ground continuity <0.1Ω to battery negative
+- [ ] Verify iBooster main power present (ignition OFF and ON)
+- [ ] Verify iBooster ignition signal present (RUN only)
+- [ ] Verify iBooster ground continuity to battery negative
 - [ ] Verify brake pedal feel with iBooster powered
-- [ ] Verify fail-safe mode works (disconnect ignition signal, confirm basic assist)
-- [ ] Verify standby current ~12mA (ignition OFF)
+- [ ] Verify fail-safe mode (disconnect ignition signal, confirm basic assist)
+- [ ] Verify iBooster standby current within spec (ignition OFF)
 - [ ] Road test: light braking, hard braking, engine-off coasting
 
 ### HVAC Testing
 
 - [ ] Verify temperature control (hot/cold blend)
 - [ ] Verify mode control (defrost/vent/floor)
-- [ ] Verify blower speeds (all settings)
+- [ ] Verify blower speeds
 - [ ] Verify A/C clutch engagement
 - [ ] Verify heater output
 
 ### Wiper Testing
 
 - [ ] Verify wiper speeds: Off / Mist / Delay / Low / High
-- [ ] Verify wiper park position (returns to rest)
+- [ ] Verify wiper park position
 - [ ] Verify washer pump activates
 - [ ] Verify auto-wipe triggers after washer spray
 
 ### Starter Testing
 
-- [ ] Verify starter does NOT crank when brake pedal is released (PBS-I brake interlock blocks PURPLE START)
-- [ ] Verify starter does NOT crank when Start Button is not pressed
-- [ ] Verify starter does NOT crank without valid PBS-I iTag fob in range (Start Button LED off)
-- [ ] Verify starter cranks when fob + Start Button + brake all asserted (engine off, warm engine - WAIT lamp not lit)
-- [ ] Verify cold-start sequence: brake + hold button → WAIT lamp illuminates → starter waits → WAIT extinguishes → starter cranks
-- [ ] Verify engine shutoff: brake + 2-second button hold → engine stops
-- [ ] Verify Emergency Bypass: with fob absent, Programming Button + 4-digit PIN authorizes start
-- [ ] Verify fob auto-arm: 60 seconds after fob leaves range, Start Button has no effect
+- [ ] Verify starter does NOT crank with brake released (PBS-I brake interlock)
+- [ ] Verify starter does NOT crank when Start Button not pressed
+- [ ] Verify starter does NOT crank without valid iTag fob in range
+- [ ] Verify starter cranks when fob + Start Button + brake all asserted (warm engine)
+- [ ] Verify cold-start sequence: WAIT lamp illuminates → extinguishes → starter cranks
+- [ ] Verify engine shutoff: brake + button hold → engine stops
+- [ ] Verify Emergency Bypass: Programming Button + PIN authorizes start with fob absent
+- [ ] Verify fob auto-arm after fob leaves range
 
 ### Grid Heater Testing
 
-- [ ] Verify grid heater activates in cold conditions (<50°F ambient)
+- [ ] Verify grid heater activates in cold conditions
 - [ ] Verify "Wait to Start" lamp illuminates during preheat
 
 ### Horn Testing
 
-- [ ] Verify horn sounds when button pressed (ignition OFF)
-- [ ] Verify horn sounds when button pressed (ignition ON)
+- [ ] Verify horn sounds when button pressed (ignition OFF and ON)
 
 ### Radiator Fan Testing
 
-- [ ] Verify voltage at fan terminals >13V under load (engine running)
+- [ ] Verify voltage at fan terminals under load
 - [ ] Verify fan activates at temperature setpoints
 - [ ] Verify inverted duty cycle behavior (high duty = low speed)
 - [ ] Tune temperature setpoints for R2.8 under real-world conditions
 
 ### Runaway Protection Testing
 
-- [ ] Static test: engine OFF, pull T-handle, verify AMOT butterfly snaps fully closed (visual through air filter housing)
-- [ ] Reset test: re-cock AMOT manually, push T-handle to flush, verify butterfly returns fully open
-- [ ] Cable freedom: pull T-handle through full 3" stroke, verify no binding in conduit
-- [ ] Functional test (with engine running at idle, away from people/objects): pull T-handle, verify engine stalls within 2 seconds
-- [ ] Catch can drain check: after first 100 miles, drain petcock and inspect for oil collection (confirms PCV flow)
-- [ ] Visual inspection: verify catch can hoses, AMOT cable, and conduit show no chafing or heat damage
+- [ ] Static test: engine OFF, pull T-handle, verify AMOT butterfly snaps fully closed
+- [ ] Reset test: re-cock AMOT, push T-handle to flush, verify butterfly returns open
+- [ ] Cable freedom: pull T-handle through full stroke, verify no binding
+- [ ] Functional test (engine idling, clear area): pull T-handle, verify engine stalls
+- [ ] Catch can drain check after first 100 miles (confirms PCV flow)
 
 ---
 
@@ -252,8 +221,8 @@ Organized by installation order for efficient build workflow.
 - **Horn:** [Horn System][horn]
 - **Radiator Fan:** [Radiator Fan System][radiator-fan]
 - **Runaway Protection:** [Diesel Runaway Protection][runaway-protection]
+- **Parts to buy:** [Purchase Tracker][purchase-tracker]
 
-[tulays-harness]: https://tulayswirewerks.com/product/bosch-ibooster-gen-2-universal-wire-harness/
 [starter]: ../02-engine-systems/01-starter.md
 [ibooster]: ../02-engine-systems/02-brake-booster.md
 [grid-heater]: ../02-engine-systems/07-grid-heater.md
@@ -262,3 +231,4 @@ Organized by installation order for efficient build workflow.
 [horn]: ../02-engine-systems/05-horn.md
 [radiator-fan]: ../02-engine-systems/06-radiator-fan.md
 [runaway-protection]: ../02-engine-systems/11-runaway-protection.md
+[purchase-tracker]: 03-purchase-tracker.md

--- a/docs/jeep_lj/09-installation/03-purchase-tracker.md
+++ b/docs/jeep_lj/09-installation/03-purchase-tracker.md
@@ -146,6 +146,10 @@ _(Most electrical distribution components already purchased - see Purchased Item
 | Midwest Control 30-144-TTL-BH-3 Push-Pull Cable | Midwest Control | ~$60-80 | High | 144" turn-to-lock T-handle, 3" travel - [Runaway Protection][runaway-protection] |
 | 5/8" Oil-Resistant Hose (2 ft) + Worm Clamps | Generic | ~$15 | High | Catch can plumbing - [Runaway Protection][runaway-protection] |
 | NPT-to-Hose Adapter Fittings (AMOT to intake) | Generic | ~$25 | High | Size per measured turbo inlet - [Runaway Protection][runaway-protection] |
+| 3/16" Copper-Nickel Brake Hardline + Fittings + Armor | Generic / AGS | ~$60-90 | High | Caliper-side hybrid: armored hardline routed inside frame rail + 1/2-20 IF inverted-flare fittings at MC; axle-side flex length separate ({{ tbd(86) }}) - [iBooster][ibooster] |
+| Heated Seat Switches (2× Toyota-style ON/OFF) | Generic | ~$20-30 | Medium | 1.54"×0.83" cutout; wire to BODY PDU CB45/CB42 via K21/K22 relays - [Dashboard][dashboard] |
+| Driver-side Firewall Grommet (heavy power) | Steele Rubber or equiv | ~$10-20 | High | ~1.5" OD bundle (3× 2/0 AWG H2 cables); new driver-side penetration - [Firewall Ingress][firewall-ingress] |
+| Passenger-side Firewall Grommet (H1) | Steele Rubber or equiv | ~$15-25 | High | Sealed 2-piece, ~1.5" OD H1 bundle (~1.75" hole), continuous run - [Firewall Ingress][firewall-ingress] |
 
 ---
 


### PR DESCRIPTION
## What

Audit of the **installation tasks** across the docs (and the related TBD tracker). The install checklists had drifted into mini–spec-sheets, restating wire gauges, lengths, temperature-derating, torque values, and part numbers that already live (authoritatively) in the component docs. The repo's own `CLAUDE.md` calls this out — §1 *BE SUCCINCT* and §5 *INSTALLATION BY WORKFLOW ORDER* say checklists should not duplicate manufacturer instructions, restate specs, or include obvious practices.

This PR reduces every install task to a **verifiable check-off item** (detail stays in the linked source docs), resolves two install decisions that were sitting in the tracker, and prunes procurement/duplicate items off the TBD tracker.

## Doc changes (3 commits, 6 files, −152 net lines)

**Checklist trim:**

| File | Before | After | Notes |
|---|---:|---:|---|
| `09-installation/01-power-systems-checklist.md` | 182 | 169 | Stripped AWG/length/temp-derating/torque/part-#s from each task; dropped obvious-practice lines (clean metal-to-metal, stud-torque verifications); tied "determine 12V relay P/Ns" and "J301-J306 pinout" to issues #70/#69 via `tbd()` macros |
| `09-installation/02-engine-systems-checklist.md` | 133 | 113 | Removed the **Procurement** section (duplicated the purchase tracker); stripped specs/torque/part-#s; tied grid-heater current to #42 |
| `05-control-interfaces/03-command-touch-ct4.md` | 57 | 29 | Collapsed the embedded install checklist that duplicated the page's own `## Wiring` table and the power-systems checklist |
| `05-control-interfaces/02-switchpros-sp1200.md` | 18 | 12 | Same dedup for the embedded "Build Tasks" list |

**Decisions recorded + procurement migrated:**

| File | Change |
|---|---|
| `05-control-interfaces/06-keyless-ignition.md` | PBS-I module co-locates on the Dakota Digital HDPE under-dash panel (shares the ECM Pin 35 WAIT tap with the HDX); Start Button at the factory keyswitch location |
| `09-installation/03-purchase-tracker.md` | Added brake hardline + heated-seat switches + two firewall grommets (migrated off the TBD tracker as procurement) |

Example: `Confirm 2/0 AWG: START battery+ → 250A CB → PMU main power (~7 ft, temp-derated for 60°C)` → `Confirm START battery+ → 250A CB → PMU main power`

## TBD tracker cleanup (8 issues closed, 56 → 48 open)

Same over-tracking pattern, in the issue tracker:

- **Procurement, not specs** (already/now in the Purchase Tracker): #49 (PBS-I kit), #59 (brake hardline), #73/#74/#75 (switches, grommets)
- **Already decided** (now recorded in docs): #52 (PBS-I location → folded into #39), #53 (Start Button location)
- **Duplicate:** #89 → #117 (same ECM Pin 35 sink-rating question)

Each closure has an explanatory comment; #39 carries a note that the panel now also hosts the PBS-I module. The remaining **48** `tbd` issues are genuine unknowns (measurements, vendor confirmations, routing decisions, unmade part selections) and were left as-is.

## Validation

`zensical build --clean` passes (exit 0; warning count went **down** by one). `verify-tbd` reconciles (0 literal source TBDs, all macro-tracked). Cloudflare Pages preview deployed green for all three commits.

https://claude.ai/code/session_015QRBZ8h7fZmF3pWEthFTDg

---
_Generated by [Claude Code](https://claude.ai/code/session_015QRBZ8h7fZmF3pWEthFTDg)_