### PR TITLE
Resolve BCDC solar terminal size (M5) and correct main terminals

### DIFF
--- a/docs/jeep_lj/01-power-systems/01-power-generation/03-bcdc.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/03-bcdc.md
@@ -37,14 +37,16 @@ tags:
 
 ## Wiring
 
-| Connection            | Terminal Label   | Terminal Size | Source/Destination            | Notes                                                            |
-| :-------------------- | :--------------- | :------------ | :---------------------------- | :--------------------------------------------------------------- |
-| Start Battery (+)     | Red              | M8            | START battery positive        | See [START Battery Distribution][starter-battery] for wire specs |
-| Auxiliary Battery (+) | Brown            | M8            | AUX battery positive          | See [AUX Battery Distribution][aux-battery] for wire specs       |
-| Solar (+)             | Yellow           | {{ tbd(108) }} | Cascadia 4x4 80W panel       | See [Solar Charging][solar]                                      |
-| Ground (-)            | Black            | M8            | AUX battery negative          | See [AUX Battery Distribution][aux-battery] for wire specs       |
-| Ignition              | Blue             | Spade         | PMU ignition sense tap        | 18 AWG - see [PMU Inputs][pmu-inputs]                            |
-| Battery Temp Sensor   | +/- (reversible) | 2-pin plug    | AUX battery positive terminal | **REQUIRED** - LiFePO4 temperature-compensated charging          |
+| Connection            | Terminal Label   | Terminal Size            | Source/Destination            | Notes                                                            |
+| :-------------------- | :--------------- | :----------------------- | :---------------------------- | :--------------------------------------------------------------- |
+| Start Battery (+)     | Red              | M5[^bcdc-terminals]      | START battery positive        | See [START Battery Distribution][starter-battery] for wire specs |
+| Auxiliary Battery (+) | Brown            | M5[^bcdc-terminals]      | AUX battery positive          | See [AUX Battery Distribution][aux-battery] for wire specs       |
+| Solar (+)             | Yellow           | M5[^bcdc-terminals]      | Cascadia 4x4 80W panel        | M5 lug on 10 AWG - see [Solar Charging][solar]                  |
+| Ground (-)            | Black            | M5[^bcdc-terminals]      | AUX battery negative          | See [AUX Battery Distribution][aux-battery] for wire specs       |
+| Ignition              | Blue             | Spade                    | PMU ignition sense tap        | 18 AWG - see [PMU Inputs][pmu-inputs]                            |
+| Battery Temp Sensor   | +/- (reversible) | 2-pin plug               | AUX battery positive terminal | **REQUIRED** - LiFePO4 temperature-compensated charging          |
+
+[^bcdc-terminals]: RedArc *BCDC Alpha 50R Installation Guide* (INST185-2), terminal-connection section: "For the Ground, Auxiliary, Start Battery and Solar terminals, use M5 lugs or equivalent, with a barrel size to suit the required cable gauge." Screws are supplied with the unit (M5×10mm for these four terminals; M3×8mm for ignition); a maximum of two lugs may be connected per main-unit terminal. Supersedes the earlier unsourced M8 figure listed for the Red/Brown/Black terminals.
 
 See [START Battery Distribution][starter-battery] and [AUX Battery Distribution][aux-battery] for complete wire specifications (gauge, distance, routing, circuit breakers).
 


### PR DESCRIPTION
## Summary

Resolves the Solar (+) Yellow terminal size in the BCDC Alpha 50 wiring table (closes #108) and corrects an unsourced error on the other main terminals.

Per the RedArc **BCDC Alpha 50R Installation Guide** (INST185-2):

> "For the Ground, Auxiliary, Start Battery and Solar terminals, use M5 lugs or equivalent, with a barrel size to suit the required cable gauge."

- **Solar (+) Yellow → M5** (resolves the TBD; the 10 AWG solar wire was already settled 2026-05-30)
- **Red / Brown / Black → M5** — these were previously listed as **M8 with no source**. The manual specifies M5 for all four main-unit terminals, so the M8 figures were wrong. Corrected.
- Screws are **supplied** with the unit (M5×10mm for the four main terminals, M3×8mm for ignition); max two lugs per terminal.
- Added a citing footnote (`[^bcdc-terminals]`) per the project's "cite critical facts" rule.

## Note for reviewer (out of scope, not changed)

The same manual states the **Ignition** terminal uses an **M3 lug**, but the table currently lists it as **Spade** (18 AWG). I left this unchanged since it wasn't part of this TBD and you may have a spade adapter in mind — flag if you'd like it corrected to M3.

## Verification

- `mkdocs build` renders `03-bcdc.md` cleanly; the `{{ tbd(108) }}` macro is removed and the footnote resolves. (Remaining strict-mode warnings are pre-existing and unrelated to this file.)

https://claude.ai/code/session_01W31V5urvqep2hLoBiGyCUM

---
_Generated by [Claude Code](https://claude.ai/code/session_01W31V5urvqep2hLoBiGyCUM)_