### PR TITLE
Amp under-seat mount: vibration isolators + floor rivnuts (no fab plate)

### DIFF
--- a/docs/jeep_lj/06-audio-systems/02-amplifier.md
+++ b/docs/jeep_lj/06-audio-systems/02-amplifier.md
@@ -26,7 +26,7 @@ tags:
 
 **Manual:** [Owner's Manual / Install Guide][manual-link]
 
-**Mounting:** Under rear seat (mounting plate w/ clearance for Class-D thermals)
+**Mounting:** Under rear seat — vibration isolators on floor rivnuts (standoff air gap for Class-D convection; no fab plate)
 
 **Power Source:** AUX battery+ direct via 100A inline CB (~3-4 ft, short feed)
 
@@ -132,15 +132,16 @@ The 100A external CB is intentionally above the 80A internal fuse — the intern
 
 ## Mounting Location
 
-**Under rear seat (driver side or center, mounted to floor with clearance for Class-D thermals)**
+**Under rear seat (driver side), bolted directly to the floor pan — no fab plate**
 
+- Mounted on **vibration isolators** (rubber standoffs) into **rivnuts** set in the floor pan. The isolator standoff height raises the chassis off the floor, giving the convection air gap underneath; no fabricated mounting plate.
+- Allow a **14" × 8-3/8"** floor footprint (chassis L×W plus connector clearance)[^specs-manual] and **verify clearance from the seat slider rails** before drilling rivnuts.
+- Maintain at least **1" (2.5 cm) clear air space above the shell** (manual requirement for enclosed-compartment mounting); convection-cooled, no fan.
 - Power feed ~3-4 ft direct from AUX battery+ (short feed, low loss)
 - Ground return ~3-4 ft to AUX battery−. All system grounds (head unit + amp) should land at the same point per the manual to avoid ground loops.[^specs-manual]
 - Centroid to all 4 speakers + 2 subs — minimizes speaker wire runs
 - RCA + remote bundled together from head unit through trans tunnel (~10-12 ft, high-quality shielded RCA required to avoid alternator whine)
-- Mounting plate with at least **1" (2.5 cm) clear air space above the shell** (manual requirement for enclosed-compartment mounting); convection-cooled, no fan
 - Orient with connections pointing downward where practical (preserves IPX2 rating)
-- Keyhole mounting screws — insert screws first, then drop amp onto them and slide
 - USB access (front of chassis) needed for TüN DSP tuning — leave service loop
 
 ## Outstanding Items

--- a/docs/jeep_lj/06-audio-systems/06-bluetooth-tuning.md
+++ b/docs/jeep_lj/06-audio-systems/06-bluetooth-tuning.md
@@ -124,7 +124,7 @@ Press-and-hold the LED button 10 sec → Factory Reset (wipes paired-device list
 
 ## Build Tasks
 
-- [ ] Decide BTC mounting surface — trans-tunnel cover vs amp-mounting-plate standoff vs A-pillar/under-dash (whatever balances RF clearance with status-LED visibility)
+- [ ] Decide BTC mounting surface — trans-tunnel cover vs near-amp standoff vs A-pillar/under-dash (whatever balances RF clearance with status-LED visibility)
 - [ ] Source VXi-BTC product image (`docs/jeep_lj/images/jl-audio-vxi-btc.jpg`)
 
 ## Related Documentation


### PR DESCRIPTION
## Summary

Changes the MV800/8i amplifier under-seat mounting approach per build direction: **no fabricated mounting plate**. The amp mounts directly to the floor pan on vibration isolators (rubber standoffs) into rivnuts. The isolator standoff height provides the convection air gap underneath the chassis (no fan, Class-D).

## Changes

- `06-audio-systems/02-amplifier.md`
  - Updated the **Mounting** product-info line and the **Mounting Location** section to describe isolators-on-rivnuts instead of a fab plate.
  - Retained the relevant constraints: 14" × 8-3/8" floor footprint, **verify clearance from seat slider rails** before drilling rivnuts, and 1" clear air space above the shell (manual requirement).
- `06-audio-systems/06-bluetooth-tuning.md`
  - Dropped the now-obsolete "amp-mounting-plate standoff" option for the BTC mounting surface.
- Issue [#79](https://github.com/sob/drawings/issues/79) retitled and rescoped from "fab a plate" to isolator + rivnut selection; seat-slider-rail clearance check preserved.

## Verification

- `python3 hooks/verify_tbd.py` → OK (47 open tbd issues, 0 untracked source markers, all reconciled).
- Edits are plain-text within existing files; no new links or anchors introduced.

https://claude.ai/code/session_01BWGp8w388ZBEXFezELqAtd

---
_Generated by [Claude Code](https://claude.ai/code/session_01BWGp8w388ZBEXFezELqAtd)_