### PR TITLE
docs(winch): reconcile winch ground-return voltage drop; close #106

### DIFF
--- a/docs/jeep_lj/01-power-systems/01-power-generation/05-wire-distance-reference.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/05-wire-distance-reference.md
@@ -47,13 +47,15 @@ Wire gauges optimized for performance at measured routing distances:
 | **PMU24 Power Feed**           | 7 ft                          | 2/0 AWG    | 220A                    | 2.40% @ 60°C                     | Direct connection via 250A CB - upgraded from 1/0 AWG     |
 | **Starter Motor**              | 6 ft                          | 2/0 AWG    | 400-600A                | <3% @ 20°C                       | Brief cranking load - minimal temp effect                 |
 | **BCDC Inter-Battery**         | 5-6 ft                        | 4 AWG      | 50A                     | 0.94% @ 20°C                     | Rear wheel well to rear wheel well (H3 cross-cab, see [Wire Routing][wire-routing]) |
-| **Winch → AUX battery**        | 13 ft one-way (26 ft circuit) | 1/0 AWG    | 250A typical, 400A peak | 6.3% @ 250A, 10.1% @ 400A @ 20°C | Passenger rear wheel well to front bumper routing — see {{ tbd(106) }} and [Wire Routing][wire-routing] |
+| **Winch → AUX battery**        | 13 ft one-way (26 ft circuit) | 1/0 AWG    | 250A typical, 409A peak | 4.9% @ 250A, 7.9% @ 409A @ 13.8V[^winch-vdrop] | Passenger rear wheel well to front bumper routing — see {{ tbd(106) }} and [Wire Routing][wire-routing] |
 
 **Temperature Derating Notes:**
 
 - Engine bay circuits (alternator, PMU) calculated @ 60°C ambient
 - Wheel well circuits (starter, winch) calculated @ 20°C ambient
-- Voltage drop percentages shown at maximum rated current
+- Voltage drop percentages shown at maximum rated current (winch shown at both typical and peak)
+
+[^winch-vdrop]: 1/0 AWG flexible cable, ~0.103 Ω/1000 ft; **26 ft circuit** (13 ft supply + 13 ft dedicated ground return) = 0.00268 Ω. At **13.8 V** (engine running during winch ops): 250 A → 0.67 V (**4.9%**), 409 A → 1.10 V (**7.9%**). Calculated @ 20°C — winch is a brief peak load (seconds), so no engine-bay temperature derating per build standard. Winch feeders are not held to the 3% rule (brief, intermittent); 1/0 AWG is a deliberate upsize over WARN's 2 AWG service-lead spec — see [Winch][recovery].
 
 ## Measurements Needed
 

--- a/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/index.md
+++ b/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/index.md
@@ -37,7 +37,7 @@ This page is the authoritative source for all AUX battery wire specs (gauge, dis
 
 | Circuit                          | Destination            | Wire Gauge | Distance | Current             | Voltage Drop  |
 | :------------------------------- | :--------------------- | :--------- | :------- | :------------------ | :------------ |
-| Rear Frame Rail                  | Local (chassis)        | 2/0 AWG    | ~3 ft    | 654A peak           | <0.1V @ 20°C  |
+| Rear Frame Rail (chassis bond)   | Local (chassis)        | 2/0 AWG    | ~3 ft    | {{ tbd(124) }}      | <0.1V @ 20°C  |
 | [BCDC Alpha 50][bcdc]            | Local                  | 4 AWG      | Short    | 50A                 | Negligible    |
 | [JL Audio MV800/8i Amp][audio]   | Under rear seat        | 4 AWG      | ~3-4 ft  | 80A max (fuse)      | <0.5% @ 30°C  |
 | [START Battery][starter-battery] | Driver rear wheel well | 1/0 AWG    | 5-6 ft   | 75A max             | <0.05V @ 20°C |

--- a/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/index.md
+++ b/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/index.md
@@ -31,7 +31,7 @@ This page is the authoritative source for all AUX battery wire specs (gauge, dis
 | [Firewall CONSTANT Bus][constant-bus] | Firewall (cabin side, passenger) | 2/0 AWG    | ~13 ft   | ~152A max           | 1.3% @ 20°C     | 300A CB at battery (<7") |
 | [SafetyHub 150][aux-safetyhub]       | Local (rear wheel well)           | 2 AWG      | ~2 ft    | ~100A max           | <0.5% @ 20°C    | 150A CB at battery (<7") |
 | [JL Audio MV800/8i Amp][audio]       | Under rear seat                   | 4 AWG      | ~3-4 ft  | 80A max (fuse)      | <0.5% @ 20°C    | 100A CB at battery (<7") |
-| [Winch][recovery]                    | Front bumper                      | 1/0 AWG    | 13 ft    | 250A typ, 409A peak | 4.9-7.9% @ 20°C | [None][winch-protection] |
+| [Winch][recovery]                    | Front bumper                      | 1/0 AWG    | 13 ft    | 250A typ, 409A peak | 4.9% @ 250A / 7.9% @ 409A | [None][winch-protection] |
 
 ## AUX battery Negative Terminal (5 connections)
 
@@ -41,7 +41,7 @@ This page is the authoritative source for all AUX battery wire specs (gauge, dis
 | [BCDC Alpha 50][bcdc]            | Local                  | 4 AWG      | Short    | 50A                 | Negligible    |
 | [JL Audio MV800/8i Amp][audio]   | Under rear seat        | 4 AWG      | ~3-4 ft  | 80A max (fuse)      | <0.5% @ 30°C  |
 | [START Battery][starter-battery] | Driver rear wheel well | 1/0 AWG    | 5-6 ft   | 75A max             | <0.05V @ 20°C |
-| [Winch][recovery]                | Front bumper           | 1/0 AWG    | 13 ft    | 250A typ, 409A peak | 4.9-7.9% @ 20°C |
+| [Winch][recovery]                | Front bumper           | 1/0 AWG    | 13 ft    | 250A typ, 409A peak | 4.9% @ 250A / 7.9% @ 409A |
 
 ## Related Documentation
 

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/index.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/index.md
@@ -73,7 +73,7 @@ All wire runs require appropriate protection based on location and environment:
 | **Forward feed (Firewall CONSTANT bus)** | 2/0 AWG  | ~13 ft   | TO Firewall CONSTANT Bus (cabin trunk)            | ~232A max           | Protected by 300A CB at battery - feeds SwitchPros, BODY PDU, Fusion |
 | **SafetyHub local feed**               | 2 AWG      | ~2 ft    | TO SafetyHub 150 (local in wheel well)            | ~100A max           | Protected by 150A CB at battery                                      |
 | **BCDC output**                        | 4 AWG      | Short    | FROM BCDC (local in wheel well)                   | 50A                 | Charging input to AUX battery                                        |
-| **Primary ground**                     | 2/0 AWG    | 3 ft     | TO Rear frame rail                                | 569A peak           | Winch + accessories return                                           |
+| **Primary ground**                     | 2/0 AWG    | 3 ft     | TO Rear frame rail                                | {{ tbd(124) }}      | Chassis-grounded accessory return only — winch returns via dedicated 1/0 H1 cable to AUX battery−, not chassis |
 | **Cross-ground reference**             | 1/0 AWG    | 5-6 ft   | FROM START battery- (driver)                      | BCDC reference      | Critical for BCDC operation                                          |
 
 **Routing:**


### PR DESCRIPTION
## Summary

Resolves the winch ground-return routing question (issue #106) and reconciles **two** inconsistencies it surfaced.

**Routing — already documented.** The winch ground return is the dedicated 1/0 AWG black (−) conductor of harness **H1** (AUX battery− → winch motor), routed inside the body up the passenger sill/floor — no exposed frame rail. Issue #106 closed; the three `{{ tbd(106) }}` markers self-resolve to the closing comment.

### Fix 1 — winch voltage drop reconciled to a single figure
Two pages disagreed on the same circuit:

| Page | Was | Now |
|:-----|:----|:----|
| `05-wire-distance-reference.md` | 6.3% @ 250A, 10.1% @ **400A** | **4.9% @ 250A, 7.9% @ 409A @ 13.8V** + footnote |
| `03-aux-battery-distribution/index.md` (×2 rows) | 4.9–7.9% @ 20°C (unlabeled range) | **4.9% @ 250A / 7.9% @ 409A** |

Standardized on **4.9% @ 250 A / 7.9% @ 409 A** over the **26 ft circuit at 13.8 V**, fixed 400 A → 409 A, and added a footnote with the calculation basis.

### Fix 2 — AUX− chassis-bond peak current corrected
The AUX battery− "Rear Frame Rail" primary-ground peak read **654 A** (`03-aux-battery-distribution/index.md`) vs **569 A** (`07-wire-routing/index.md`) — both underived and both wrongly counting the winch (~409 A) as a chassis return. Per owner confirmation, the **winch returns via the dedicated H1 cable, not the chassis**, so it doesn't belong in this bond at all. Removed the winch from both rows, corrected the label to *chassis-grounded accessory return only*, and replaced the bogus figures with tracked **TBD #124** (priority/low — the 2/0 bond is generously sized for any realistic accessory return) pending a proper accessory chassis-return derivation.

## Verification
- Cloudflare Pages deploy succeeded on `6b60bb1` → confirms `mkdocs build` passes (couldn't run mkdocs locally — no network). Build on `2ead1fb` in progress.
- verify-tbd: macro lines (`{{ tbd(...) }}`) are skipped by the verifier; #124 carries all four required label facets and valid Source paths.

Closes #106

https://claude.ai/code/session_01C9jW2FtrcNDncWBHFxrc3Y