### PR TITLE
docs: nightly tidiness — trim verbosity (2026-06-05)

### DIFF
--- a/docs/jeep_lj/02-engine-systems/02-brake-booster.md
+++ b/docs/jeep_lj/02-engine-systems/02-brake-booster.md
@@ -43,7 +43,7 @@ tags:
 
 Electromechanical brake booster required for the Cummins R2.8 diesel (minimal manifold vacuum). The Honda Accord Hybrid donor delivers the same Bosch Gen 2 unit as the Tesla Model 3 with better DIY documentation and sourcing.
 
-The factory master cylinder is discarded. The Back Bay Customs adapter mates a Wilwood Tandem Compact master (260-15542, 1.00" bore) directly to the iBooster — solving the vertical-firewall reservoir-angle problem and putting the hydraulics on Wilwood's remote-reservoir ecosystem.
+The Back Bay Customs adapter mates a Wilwood Tandem Compact master (260-15542, 1.00" bore) to the iBooster, solving the vertical-firewall reservoir-angle problem.
 
 **Vendor compatibility (Back Bay Customs / Adam, email 2026-05-30):**
 

--- a/docs/jeep_lj/05-control-interfaces/02-switchpros-sp1200.md
+++ b/docs/jeep_lj/05-control-interfaces/02-switchpros-sp1200.md
@@ -37,8 +37,6 @@ tags:
 
 ## Overview
 
-The SwitchPros SP-1200 is the main lighting and accessory controller for the Jeep LJ build. It provides 17 total outputs controlled via a 12-button control panel with Bluetooth app integration.
-
 **Specifications:**
 
 - 150A total capacity on CONSTANT bus
@@ -123,8 +121,6 @@ See [AUX Battery Distribution][aux-battery] for source battery and [Firewall CON
 ## Trigger Input Assignments
 
 ### TRIGGER-1: Door Switches → Dome Lights
-
-Factory door plunger switches retained and wired in parallel to activate dome lights when either door opens.
 
 **Switch Type:** Factory Jeep TJ/LJ door jamb plunger switch (normally open, closes to ground when door opens)
 

--- a/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
+++ b/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
@@ -48,8 +48,6 @@ tags:
 
 ## Turn Signal and Lighting System Integration
 
-The CT4 provides complete turn signal and headlight control:
-
 ### Turn Signals {#ct4-turn-signals}
 
 - **Front Turn Signals:** Amber LED turn signal lights (dedicated turn signal only)
@@ -166,25 +164,6 @@ ELSE
   Out23_DRL = OFF
 END
 ```
-
-**How It Works:**
-
-1. **Ignition ON, Headlights OFF (CT4 SW3 off):**
-   - PMU Pin 7 = ON (ignition RUN)
-   - PMU In 7 = OFF (CT4 SW3 not active)
-   - PMU Out 23 = ON
-   - All DRL/parking lights illuminated
-
-2. **Ignition ON, Headlights ON (CT4 SW3 on):**
-   - PMU Pin 7 = ON (ignition RUN)
-   - PMU In 7 = ON (CT4 SW3 active)
-   - PMU Out 23 = OFF
-   - Headlights (low or high beam) active instead
-
-3. **Ignition OFF:**
-   - PMU Pin 7 = OFF
-   - PMU Out 23 = OFF (regardless of headlight status)
-   - All DRL/parking lights off
 
 **Installation Notes:**
 

--- a/docs/jeep_lj/06-audio-systems/02-amplifier.md
+++ b/docs/jeep_lj/06-audio-systems/02-amplifier.md
@@ -9,8 +9,6 @@ tags:
 
 # 6.2 Amplifier {#amplifier}
 
-8-channel Class-D marine amplifier with integrated DSP. Each subwoofer runs on its own bridged channel pair @ 4Ω; four remaining channels drive the four cabin speakers.
-
 /// html | div.product-info
 ![JL Audio MV800/8i](../images/jl-audio-mv800-8i.jpg){ loading=lazy }
 

--- a/docs/jeep_lj/08-exterior-systems/01-winch.md
+++ b/docs/jeep_lj/08-exterior-systems/01-winch.md
@@ -79,8 +79,6 @@ SafetyHub ATC-1 (15A) → Dash Rocker Switch ⟷ Handheld Remote (parallel) → 
                            DOWN = IN             Remote IN button
 ```
 
-**Both controls work simultaneously** - either dash rocker OR remote can trigger winch IN/OUT
-
 ## Wiring
 
 **Main Power Wiring:**
@@ -121,19 +119,6 @@ See [AUX Battery Distribution][aux-battery] for cable specs and routing path.
 - **Securing:** P-clamps every 18" along the chosen path
 - **Grommets:** Rubber grommets with sealant at body penetrations
 - **Heat:** Route away from exhaust components (minimum 6" clearance)
-
-**Winch Mounting:**
-
-- Zeon 10-S fits front bumper (verified compatible)
-- Factory contactor mounted on winch motor housing
-- Ensure contactor is protected from direct water spray
-- Verify all connections are tight and corrosion-free
-
-**Control Switch Location:**
-
-- Dash-mounted center-off momentary rocker switch
-- Easily accessible from driver's seat
-- Clear labeling: UP = OUT, DOWN = IN
 
 ## Safety Considerations
 

--- a/docs/jeep_lj/index.md
+++ b/docs/jeep_lj/index.md
@@ -112,31 +112,15 @@ The factory TIPM is replaced with discrete, serviceable modules:
 - **[Communication][communications]:** Rugged Radio G1 GMRS, STX 4-place intercom, WolfBox dash camera
 - **[Recovery & Air][recovery-air]:** Warn 10,000 lb winch, ARB air lockers, ARB Twin Air Compressor
 
-## Documentation Notes
-
-!!! info "Outstanding Items"
-    Throughout this documentation, you'll find "Outstanding Items" checklists. These track design decisions, measurements, and tasks that need to be completed during installation.
-
-    **[View Global TBD Tracker][tbd-tracker]** - Centralized tracking of all To-Be-Determined items with priorities
-
-!!! warning "Work in Progress"
-    This is a living document that evolves as the build progresses. Some specifications may be marked as TBD (To Be Determined) and will be updated during the build process.
+**[TBD Tracker][tbd-tracker]** — Open items and unresolved specs.
 
 ## Print / Download
 
-Need a physical copy for the shop? Use the print page which combines all documentation into a single printable page optimized for 3-ring binder formatting (US Letter, duplex, with binding margins).
+Print page combines all docs into a single binder-ready page (US Letter, duplex, binding margins).
 
 <div class="print-hide" markdown="1">
 
-**[Open Print Page](/print_page/){target="_blank"}** - All Jeep LJ docs on one page
-
-**To print or save as PDF:**
-
-1. Click the Print Page link above
-2. Wait for the page to fully load
-3. Use your browser's print function (Ctrl+P / Cmd+P)
-4. Select "Save as PDF" or your printer
-5. For duplex printing, select "Print on both sides" with "Flip on long edge"
+**[Open Print Page](/print_page/){target="_blank"}**
 
 </div>
 


### PR DESCRIPTION
Automated nightly pass — prose trimmed, no specs/numbers/tables/TBDs touched.

Build check: `mkdocs build --strict` — 9 pre-existing warnings, identical on `main`; zero warnings introduced by this PR. `markdownlint-cli2` — 1002 pre-existing errors (all in `tbd-tracker.md`, an auto-generated file); none introduced by this PR.

## Changes

| File | Lines before → after | What was cut | Persona it failed |
| :--- | :------------------- | :----------- | :---------------- |
| `docs/jeep_lj/index.md` | 180 → 164 | `## Documentation Notes` section (two boilerplate admonitions explaining what Outstanding Items and TBD mean); verbose Print/Download how-to-print steps (generic browser instructions). TBD Tracker link preserved as inline text. | Mechanic, Owner |
| `docs/jeep_lj/08-exterior-systems/01-winch.md` | 169 → 154 | `**Winch Mounting**` subsection (restated product-info "Front bumper verified compatible" and Contactor section "mounted on winch motor housing"; plus generic "tight and corrosion-free" advice); `**Control Switch Location**` subsection (restated Control System dash switch entries); "Both controls work simultaneously" line after diagram (restated "Dual Control Setup" header above it). | Mechanic |
| `docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md` | 261 → 240 | Topic sentence "The CT4 provides complete turn signal and headlight control:" (restates section heading); `**How It Works**` numbered scenario expansion that restated the adjacent pseudocode block line-for-line. | Mechanic, Troubleshooter |
| `docs/jeep_lj/05-control-interfaces/02-switchpros-sp1200.md` | 233 → 229 | 2-sentence Overview intro ("The SwitchPros SP-1200 is the main… 17 total outputs… Bluetooth app integration") — restated heading and output table; first sentence of TRIGGER-1 section ("Factory door plunger switches retained and wired in parallel…") — restated the control panel layout note directly above. | Mechanic |
| `docs/jeep_lj/06-audio-systems/02-amplifier.md` | 170 → 168 | 2-line preamble before product-info div ("8-channel Class-D marine amplifier with integrated DSP. Each subwoofer…") — first sentence restates `**Type:**` in product-info; second summarizes the Channel Configuration table below. | Mechanic, Parts Buyer |
| `docs/jeep_lj/02-engine-systems/02-brake-booster.md` | 301 → 301 | Within-paragraph prose tightening: removed "The factory master cylinder is discarded." (obvious from context) and "putting the hydraulics on Wilwood's remote-reservoir ecosystem" (marketing). Design rationale ("solving the vertical-firewall reservoir-angle problem") preserved. | Owner |

## Left for human judgment

- **winch.md `!!! warning "Winch Safety"` and `!!! warning "Electrical Safety"` blocks** — mostly generic recovery advice. Two items are build-specific ("Monitor battery voltage" is relevant to this dual-battery build; "Never disconnect battery while winch is under load" is non-obvious). Left intact; owner can trim if desired.
- **brake-booster.md Overview rationale** — first sentence ("Electromechanical brake booster required for the Cummins R2.8 diesel…") and second sentence ("The Honda Accord Hybrid donor delivers the same Bosch Gen 2 unit as the Tesla Model 3 with better DIY documentation and sourcing") are design rationale the owner wanted preserved. Both kept.
- **switchpros-sp1200.md TRIGGER-3 section** — narrative logic walkthrough (cut-in/cut-out pressure states) slightly restates the wiring code block, but aids a troubleshooter diagnosing compressor behavior. Left intact.
- **ct4.md GPS Module Configuration** — "May require initial calibration drive for optimal performance" is hedging language, but reflects genuine uncertainty in the product behavior. Left intact.

https://claude.ai/code/session_01QTU5yEy9hMjLMzsvcMDZns

---
_Generated by [Claude Code](https://claude.ai/code/session_01QTU5yEy9hMjLMzsvcMDZns)_