### PR TITLE
Remove WAIT-gate relay (watch the lamp) + lockout design note; BODY PDU relay spec

### DIFF
--- a/docs/jeep_lj/01-power-systems/01-power-generation/05-wire-distance-reference.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/05-wire-distance-reference.md
@@ -73,7 +73,7 @@ Distances required for voltage drop calculations and wire purchases. Measure act
 | CT4 (steering column)   | Passenger tail light     | 14 AWG | 16 ft ✓  | Turn signal rear                    |
 | PMU (engine bay)        | Rear tail lights         | 16 AWG | 13 ft ✓  | Brake/reverse/marker (Out 21/22/23) |
 | SwitchPros (firewall) | Roll bar dome lights     | 16 AWG | ~8 ft    | Low current, estimated              |
-| PBS-I PURPLE START      | Cole Hersee 24213 coil   | 16 AWG | ~10 ft ✓ | Via WAIT-gate relay + firewall Pin 15  |
+| PBS-I PURPLE START      | Cole Hersee 24213 coil   | 16 AWG | ~10 ft ✓ | Via firewall Pin 15  |
 | CT4 SW3 output          | PMU In 7                 | 18 AWG | 3 ft ✓   | Same as steering column → PMU       |
 
 ### Offroad Lighting (Priority: Medium)

--- a/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/03-body-pdu.md
+++ b/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/03-body-pdu.md
@@ -16,7 +16,7 @@ tags:
 
 **Model:** Bussmann LR-2
 
-**Part Number:** 301-1C-C-R1 (NSN: 6110-01-523-6374)
+**Part Number:** Bussmann LR-2 panel, NSN 6110-01-523-6374 (the `301-1C-C-R1` is the Song Chuan ISO 280 relay that populates it, not the panel)[^lr2-relay]
 
 **Manufacturer:** Bussmann (Eaton)
 
@@ -68,9 +68,9 @@ tags:
 | K27            | TRAILER BO STOP         | **\[Available\]**       | 12V     | -           | Future expansion                       |
 | K30            | TRAILER REAR LEFT       | **\[Available\]**       | 12V     | -           | Future expansion                       |
 | K31            | TRAILER REAR RIGHT      | **\[Available\]**       | 12V     | -           | Future expansion                       |
-| K53            | RADIO                   | **\[Available\]**       | 24V→12V | -           | Replace with 12V relay                 |
-| K40            | START DISABEL           | **\[Available\]**       | 24V→12V | -           | Replace with 12V relay                 |
-| K42            | ENGINE PTO              | **\[Available\]**       | 24V→12V | -           | Replace with 12V relay                 |
+| K53            | RADIO                   | **\[Available\]**       | 24V→12V | -           | Swap 24V (U02) → 12V Song Chuan `301-1C-C-R1-U01`[^lr2-relay] |
+| K40            | START DISABEL           | **\[Available\]**       | 24V→12V | -           | Swap 24V (U02) → 12V Song Chuan `301-1C-C-R1-U01`[^lr2-relay] |
+| K42            | ENGINE PTO              | **\[Available\]**       | 24V→12V | -           | Swap 24V (U02) → 12V Song Chuan `301-1C-C-R1-U01`[^lr2-relay] |
 
 **Relay Utilization:** 2 of 8 used, 6 available (3 require 12V relay replacement)
 
@@ -88,7 +88,6 @@ G1 GMRS Radio and STX Intercom are powered from [SafetyHub 150][safetyhub] (STAR
 ## Build Tasks
 
 - [ ] Identify pinout for J301-J306 Metri-Pack connectors (military TM manual or reverse engineering)
-- [ ] Determine replacement 12V relay part numbers for K40, K42, K53 (currently 24V coils)
 
 **Design Notes:**
 
@@ -96,6 +95,8 @@ G1 GMRS Radio and STX Intercom are powered from [SafetyHub 150][safetyhub] (STAR
 - Heated seat current: 5A peak, 2A sustained per seat (verified with vendor)
 - Military relays K21/K22 provide fault isolation and independent operation
 - J301-J306 connectors require custom harness fabrication
+
+[^lr2-relay]: The Bussmann **LR-2** is the panel; **`301-1C-C-R1`** is the **Song Chuan** ISO 280 (2.8 mm) relay that populates it, voltage-coded by suffix — **U01 = 12 V, U02 = 24 V**. K40/K42/K53 ship with 24 V (U02); the 12 V drop-in is the same relay in **U01** trim (`301-1C-C-R1-U01-12VDC` — SPDT, 35 A, ISO 280, resistor-suppressed). Sources: [ProWire 301-1C-C-R1-U01-12VDC](https://www.prowireusa.com/301-1C-C-R1-U01-12VDC), [eBay LR-2 listing](https://www.ebay.com/itm/224625878742) (U01/U02 = 12 V/24 V); accessed 2026-06-06.
 
 ## Related Documentation
 

--- a/docs/jeep_lj/01-power-systems/06-ignition-signal/index.md
+++ b/docs/jeep_lj/01-power-systems/06-ignition-signal/index.md
@@ -35,7 +35,7 @@ The bus bar's outbound feed to engine-bay consumers (ECM 12V supply, PMU Pin 7) 
 
     - **PMU 12V Switched Input (Physical Pin 7):** Wire tapped from the bus bar engine-bay distribution stud - see [PMU Inputs][pmu-inputs]
     - **Cummins ECM 12V Supply:** Wire tapped from the same engine-bay distribution stud
-    - **Starter Control:** PBS-I PURPLE START output (separate firewall Pin 15) gates through WAIT-gate relay → Cole Hersee 24213 - see [Starter System][starter-system] and [Keyless Ignition][keyless-ignition]
+    - **Starter Control:** PBS-I PURPLE START output (separate firewall Pin 15) → Cole Hersee 24213 - see [Starter System][starter-system] and [Keyless Ignition][keyless-ignition]
 
     **Note:** PMU "Pin 7" (physical connector pin for 12V switched power) is different from PMU "In 7" (digital input channel #7 used for CT4 headlight status).
 

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/02-firewall-ingress.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/02-firewall-ingress.md
@@ -75,13 +75,13 @@ Pin 12 carries the PBS-I PINK IGN ignition signal; the keyswitch was removed whe
 | 11 | Horn button trigger | 18 AWG | Steering wheel button | PMU In 1 | #16 |
 | 13 | Brake switch | 18 AWG | Brake pedal switch | PMU In 2 | #16 |
 | 14 | A/C request | 18 AWG | HVAC controls | PMU In 9 | #16 |
-| 15 | WAIT-gated PURPLE START | 16 AWG | PBS-I via WAIT-gate relay | Cole Hersee 24213 coil | #16 |
+| 15 | PURPLE START | 16 AWG | PBS-I PURPLE START output | Cole Hersee 24213 coil | #16 |
 | 16 | Winch control IN | 18 AWG | Dash rocker switch | Winch contactor | #16 |
 | 17 | Winch control OUT | 18 AWG | Dash rocker switch | Winch contactor | #16 |
 
 ### Available (13 spare pins)
 
-Pins 18-29 + pin 2 (legacy spare) reserved for future non-SwitchPros circuits. The former Boomerang fob-present and gated-start pins were dropped when the PBS-I self-contained keyless system replaced the Boomerang/PMU keyless approach — PBS-I needs no firewall pins beyond PINK IGN (pin 12) and WAIT-gated PURPLE START (pin 15).
+Pins 18-29 + pin 2 (legacy spare) reserved for future non-SwitchPros circuits. The former Boomerang fob-present and gated-start pins were dropped when the PBS-I self-contained keyless system replaced the Boomerang/PMU keyless approach — PBS-I needs no firewall pins beyond PINK IGN (pin 12) and PURPLE START (pin 15).
 
 ---
 
@@ -183,7 +183,7 @@ Radio grounds do NOT go through firewall - they route through cab floor to START
 | Gauge | Count | Circuits |
 |:------|:-----:|:---------|
 | 14 AWG | 7 | Radio power (2), CT4 outputs (4), PBS-I PINK IGN (1) |
-| 16 AWG | 4 | PMU lighting outputs (3), WAIT-gated PURPLE START (1) |
+| 16 AWG | 4 | PMU lighting outputs (3), PURPLE START (1) |
 | 18 AWG | 5 | Switch signals (3: horn, brake, A/C), winch control (2) |
 | **Main connector** | **16** | HDP24-24-29 (16 of 29 used, 13 spare; exact count pending final recount) |
 

--- a/docs/jeep_lj/02-engine-systems/01-starter.md
+++ b/docs/jeep_lj/02-engine-systems/01-starter.md
@@ -52,7 +52,7 @@ tags:
 
 **Control Solenoid:** Cole Hersee 24213 (200A continuous-duty)[^ch-24213]
 
-**Safety Interlock:** PBS-I keyless ignition module sources the crank signal (60A PURPLE START output). Brake interlock and RFID authorization are inside the PBS-I. On a cold start the driver waits for the Cummins WAIT-to-Start lamp to extinguish before cranking (grid heater preheat). See [Keyless Ignition][keyless-ignition] for the full architecture.
+**Safety Interlock:** PBS-I keyless ignition module sources the crank signal (60A PURPLE START output). Brake interlock and RFID authorization are inside the PBS-I. On a cold start the driver waits for the Cummins WAIT-to-Start lamp to extinguish before cranking (grid heater preheat); an automatic crank lockout was evaluated and deferred — see the [WAIT-to-Start Lockout Design Note][wait-lockout-note]. See [Keyless Ignition][keyless-ignition] for the full architecture.
 
 **Battery Requirement:** 800 CCA minimum (Odyssey PC1500 provides 850 CCA)
 
@@ -132,6 +132,7 @@ Engine starts → driver releases button → Cole Hersee de-energizes → Bendix
 - [Power Generation][power-generation] - Battery specifications
 - [Wire Distance Reference][wire-distance] - Starter to battery routing distances
 - [Keyless Ignition][keyless-ignition] - PBS-I sources PURPLE START; cold-start wait via the WAIT-to-Start lamp
+- [WAIT-to-Start Lockout Design Note][wait-lockout-note] - Deferred automatic crank-lockout design, preserved for future revival
 
 [db-starter]: https://www.dbelectrical.com/products/starter-for-2-8-cummins-isf2-8-qsb3-9-30-qsb4-5-4996706-428000-7090.html
 [starter-battery-distribution]: ../01-power-systems/02-starter-battery-distribution/index.md
@@ -141,4 +142,5 @@ Engine starts → driver releases button → Cole Hersee de-energizes → Bendix
 [power-generation]: ../01-power-systems/01-power-generation/index.md
 [wire-distance]: ../01-power-systems/01-power-generation/05-wire-distance-reference.md
 [keyless-ignition]: ../05-control-interfaces/06-keyless-ignition.md
+[wait-lockout-note]: wait-to-start-lockout-design-note.md
 [tbd-tracker]: ../tbd-tracker.md

--- a/docs/jeep_lj/02-engine-systems/01-starter.md
+++ b/docs/jeep_lj/02-engine-systems/01-starter.md
@@ -52,7 +52,7 @@ tags:
 
 **Control Solenoid:** Cole Hersee 24213 (200A continuous-duty)[^ch-24213]
 
-**Safety Interlock:** PBS-I keyless ignition module sources the crank signal (60A PURPLE START output). Brake interlock and RFID authorization are inside the PBS-I. On a cold start the driver waits for the Cummins WAIT-to-Start lamp to extinguish before cranking (grid heater preheat); an automatic crank lockout was evaluated and deferred — see the [WAIT-to-Start Lockout Design Note][wait-lockout-note]. See [Keyless Ignition][keyless-ignition] for the full architecture.
+**Safety Interlock:** The crank signal (60A PURPLE START) comes solely from the PBS-I keyless module, which owns RFID authorization, the brake interlock, ACC/IGN/START sequencing, and the cold-start WAIT-to-Start lamp procedure — see [Keyless Ignition][keyless-ignition]. (An automatic crank lockout was evaluated and deferred — see the [WAIT-to-Start Lockout Design Note][wait-lockout-note].)
 
 **Battery Requirement:** 800 CCA minimum (Odyssey PC1500 provides 850 CCA)
 
@@ -72,17 +72,15 @@ See [Keyless Ignition][keyless-ignition] for PBS-I power and brake input wiring.
 ## Control Flow
 
 ```text
-Driver presses brake + holds Start Button (PBS-I-mounted)
+PBS-I asserts PURPLE START  (fob auth + brake + sequence: see Keyless Ignition)
             ↓
-PBS-I (cabin) authenticates fob → asserts PINK IGN (ECM powers up) and PURPLE START
-            ↓
-PBS-I PURPLE START → Firewall Pin 15 → Cole Hersee 24213 coil → Ground
+PURPLE START → Firewall Pin 15 → Cole Hersee 24213 coil → Ground
             ↓
 Cole Hersee main contacts close
             ↓
 START battery → Cole Hersee output → Starter switch post → Bendix engages → cranks
             ↓
-Engine starts → driver releases button → Cole Hersee de-energizes → Bendix retracts
+Engine starts → button released → Cole Hersee de-energizes → Bendix retracts
 ```
 
 ## Starter Motor Terminals

--- a/docs/jeep_lj/02-engine-systems/01-starter.md
+++ b/docs/jeep_lj/02-engine-systems/01-starter.md
@@ -52,7 +52,7 @@ tags:
 
 **Control Solenoid:** Cole Hersee 24213 (200A continuous-duty)[^ch-24213]
 
-**Safety Interlock:** PBS-I keyless ignition module sources the crank signal (60A PURPLE START output). Brake interlock and RFID authorization are inside the PBS-I. A single external SPST WAIT-gate relay blocks cranking while the Cummins WAIT-to-Start lamp is on (cold-start grid heater preheat). See [Keyless Ignition][keyless-ignition] for the full architecture.
+**Safety Interlock:** PBS-I keyless ignition module sources the crank signal (60A PURPLE START output). Brake interlock and RFID authorization are inside the PBS-I. On a cold start the driver waits for the Cummins WAIT-to-Start lamp to extinguish before cranking (grid heater preheat). See [Keyless Ignition][keyless-ignition] for the full architecture.
 
 **Battery Requirement:** 800 CCA minimum (Odyssey PC1500 provides 850 CCA)
 
@@ -62,13 +62,12 @@ tags:
 | :-------------------- | :------------------------------ | :-------------------------------- | :--------- | :------- | :--------------------------------------------------------------- |
 | Main Power            | START battery+                  | Starter solenoid battery post     | 2/0 AWG    | 400-600A | See [START Battery Distribution][starter-battery] for wire specs |
 | Solenoid Power Tap    | START battery post              | Cole Hersee 24213 input           | 10 AWG     | 30-75A   | ~2 ft                                                            |
-| Start Signal (cabin)  | PBS-I PURPLE START output       | WAIT-gate relay COM (NC input)    | 14 AWG     | ~0.69A   | PBS-I output rated 60A but only Cole Hersee coil downstream[^ch-24213] |
-| Gated Start (firewall)| WAIT-gate relay NC contact      | Firewall Pin 15 → Cole Hersee coil+ | 16 AWG  | ~0.69A   | Open while WAIT-to-Start lamp on; closed otherwise               |
+| Start Signal          | PBS-I PURPLE START output       | Firewall Pin 15 → Cole Hersee coil+ | 16 AWG  | ~0.69A   | PBS-I output rated 60A but only Cole Hersee coil downstream[^ch-24213] |
 | Solenoid Coil Ground  | Cole Hersee 24213 coil-         | Engine bay ground bus             | 16 AWG     | ~0.69A   | ~3 ft                                                            |
 | Solenoid Output       | Cole Hersee 24213 output        | Starter solenoid switch post      | 10 AWG     | 30-75A   | ~2 ft                                                            |
 | Ground Return         | Starter case                    | Engine block → START battery-     | 2/0 AWG    | 400-600A | Via engine bay ground bus                                        |
 
-See [Keyless Ignition][keyless-ignition] for PBS-I power, brake input, and WAIT-gate relay coil wiring.
+See [Keyless Ignition][keyless-ignition] for PBS-I power and brake input wiring.
 
 ## Control Flow
 
@@ -76,9 +75,6 @@ See [Keyless Ignition][keyless-ignition] for PBS-I power, brake input, and WAIT-
 Driver presses brake + holds Start Button (PBS-I-mounted)
             ↓
 PBS-I (cabin) authenticates fob → asserts PINK IGN (ECM powers up) and PURPLE START
-            ↓
-WAIT-gate relay (NC): closed if WAIT lamp off → start signal passes through
-                       open  if WAIT lamp on  → wait for grid heater to finish
             ↓
 PBS-I PURPLE START → Firewall Pin 15 → Cole Hersee 24213 coil → Ground
             ↓
@@ -117,7 +113,7 @@ Engine starts → driver releases button → Cole Hersee de-energizes → Bendix
 
 - Large Stud 1 (Input): 5/16"-24 copper power stud; from START battery post (10 AWG)
 - Large Stud 2 (Output): 5/16"-24 copper power stud; to starter switch post (10 AWG; starter post is 6.3mm push-on)
-- Small Stud 1 (Coil+): #10-32 steel stud; from WAIT-gate relay NC contact (16 AWG, gated PBS-I PURPLE START)
+- Small Stud 1 (Coil+): #10-32 steel stud; from Firewall Pin 15 (16 AWG, PBS-I PURPLE START)
 - Small Stud 2 (Coil-): #10-32 steel stud; to engine bay ground bus (16-18 AWG)
 
 [^ch-24213]: Littelfuse (Cole Hersee) 24213 continuous-duty SPST solenoid, [product page](https://www.littelfuse.com/products/relays-contactors-transformers/solenoids-relays/standard-high-current-relays/continuous-duty-spst/24213) / DigiKey #6347082. Rated **200A continuous** with two 5/16"-24 copper power studs + two #10-32 steel coil studs; coil ~0.69A @ 12V (17.5 Ω). Corrects the earlier unsourced "85A / M8 / 6.3mm-push-on" figures (validated 2026-05-30). 200A is comfortably oversized for the ~10A starter-trigger path.
@@ -135,7 +131,7 @@ Engine starts → driver releases button → Cole Hersee de-energizes → Bendix
 - [Engine Bay Ground Bus][engine-bay-ground-bus] - Ground connections
 - [Power Generation][power-generation] - Battery specifications
 - [Wire Distance Reference][wire-distance] - Starter to battery routing distances
-- [Keyless Ignition][keyless-ignition] - PBS-I sources PURPLE START; WAIT-gate relay gates on grid heater lamp
+- [Keyless Ignition][keyless-ignition] - PBS-I sources PURPLE START; cold-start wait via the WAIT-to-Start lamp
 
 [db-starter]: https://www.dbelectrical.com/products/starter-for-2-8-cummins-isf2-8-qsb3-9-30-qsb4-5-4996706-428000-7090.html
 [starter-battery-distribution]: ../01-power-systems/02-starter-battery-distribution/index.md

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/01-hdx-control.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/01-hdx-control.md
@@ -102,7 +102,7 @@ Main control box for HDX instrument system. Processes sensor inputs, BIM module 
 | **RIGHT**                | 18 AWG ✓    | CT4 right turn output        | HDX RIGHT input         | Right turn indicator                             |
 | **4x4/EX**               | 18 AWG ✓    | Transfer case switch         | HDX 4x4/EX input        | 4WD/4LO indicators                               |
 | GEAR                     | -           | BIM-01-2 J1939               | -                       | Gear position read from Turbolamik J1939 broadcast (no discrete input wiring) |
-| **WAIT/EX**              | 18 AWG ✓    | ECM Pin 35 (yellow wire, WAIT TO START) | HDX WAIT/EX input | Sink-circuit per Cummins R2.8 Installation Guide 5504137 (§2, ECM pin 35, yellow) — wire is active LOW (~0V when WAIT on, ~+12V when off). HDX input documented as "active high" — polarity needs bench verification during install (HDX may invert internally, or LJ build docs may be mislabeled). Also tapped by WAIT-gate relay coil-, see [Keyless Ignition][keyless-link] |
+| **WAIT/EX**              | 18 AWG ✓    | ECM Pin 35 (yellow wire, WAIT TO START) | HDX WAIT/EX input | Sink-circuit per Cummins R2.8 Installation Guide 5504137 (§2, ECM pin 35, yellow) — wire is active LOW (~0V when WAIT on, ~+12V when off). HDX input documented as "active high" — polarity needs bench verification during install (HDX may invert internally, or LJ build docs may be mislabeled). |
 | EX                       | -           | -                            | -                       | Reserved                                         |
 | EX                       | -           | -                            | -                       | Reserved                                         |
 | WARN OUT                 | -           | -                            | -                       | Not used                                         |
@@ -139,7 +139,6 @@ All BIM modules connect via single daisy-chain harness from HDX control 3.5mm po
 - [Ignition Signal Distribution][ignition-bus] - Ignition power source
 - [Command Touch CT4][ct4] - Lighting signal sources (turn, high beam, etc.)
 - [Cummins R2.8 ECM][ecm] - WAIT/EX (Pin 35 yellow) and ENGINE/MIL (Pin 22 white) signal sources
-- [Keyless Ignition][keyless-link] - WAIT-gate relay coil shares the Pin 35 signal tap
 
 [manual-link]: https://www.dakotadigital.com/pdf/HDX_manual_main.pdf
 [gauge-system]: index.md
@@ -149,4 +148,3 @@ All BIM modules connect via single daisy-chain harness from HDX control 3.5mm po
 [ignition-bus]: ../../01-power-systems/06-ignition-signal/index.md
 [ct4]: ../../05-control-interfaces/03-command-touch-ct4.md
 [ecm]: ../index.md
-[keyless-link]: ../../05-control-interfaces/06-keyless-ignition.md

--- a/docs/jeep_lj/02-engine-systems/wait-to-start-lockout-design-note.md
+++ b/docs/jeep_lj/02-engine-systems/wait-to-start-lockout-design-note.md
@@ -1,0 +1,106 @@
+---
+hide:
+  - toc
+tags:
+  - design-note
+  - engine-systems
+  - starter
+  - keyless
+search:
+  exclude: false
+---
+
+# WAIT-to-Start Crank Lockout — Design Note (Deferred)
+
+!!! warning "Status: NOT IMPLEMENTED — deferred by design"
+    The build does **not** automatically lock out cranking during grid-heater
+    preheat. The current design is **watch the lamp**: on a cold start the driver
+    waits for the Cummins WAIT-to-Start lamp to extinguish before cranking — Digital
+    Guard Dawg's own documented diesel start procedure. See [Starter System][starter]
+    and [Keyless Ignition][keyless-ignition].
+
+    This page preserves the full analysis so that, if an automatic lockout is ever
+    revived, the design and the dead ends are already mapped out. It is intentionally
+    **only linked from the [Starter System][starter] page** and is not in the main nav.
+
+## Why it was deferred
+
+An automatic lockout was evaluated in depth and set aside as **not worth the complexity** for this build:
+
+- **Skipping the wait is harmless.** On a common-rail R2.8 the grid heater is an ECM-managed cold-start *aid*; cranking during preheat doesn't damage anything — worst case is a marginally harder fire. The WAIT lamp is advisory, not a protection interlock.
+- **It's a 3–5 second wait, once per cold start** (per [Grid Heater][grid-heater]), and watching the lamp is the **manufacturer's documented diesel procedure**.
+- **Every automatic option adds disproportionate cost** — parts, wiring, and/or coupling the start path to another module — to automate something a glance handles.
+- **Direction of travel.** Critical systems (TCU, iBooster) are being moved *off* the PMU; adding the crank lockout *onto* the PMU runs against that.
+
+## The requirement (if revived)
+
+Block the crank signal while the WAIT lamp is on, ANDed with the PBS-I crank command, **without loading ECM Pin 35**:
+
+- **WAIT signal:** ECM **Pin 35** (yellow), sink-circuit lamp topology — **active LOW** (~0 V when WAIT on, ~13 V off).[^wait-polarity]
+- **Constraint:** the Pin 35 lamp-driver **sink-current rating is not published** in any public Cummins crate document, so a design must not lean on it. A relay coil on Pin 35 (~160 mA) was the original concern tracked as issue #117.[^pin35-rating]
+- **AND logic:** crank only when the PBS-I is commanding START *and* WAIT is off.
+- **Fail-safe:** any fault must default to **crank-enabled** (engine still starts).
+
+## Options evaluated
+
+| Approach | Auto? | Loads Pin 35? | Verdict |
+| :------- | :---- | :------------ | :------ |
+| Original Bosch changeover relay, coil on Pin 35 | ✅ | ❌ ~160 mA | Rejected — this is #117 |
+| Confirm the Cummins sink rating on paper | — | — | Dead end — not in public docs |
+| Bench-measure lamp + coil draw | — | — | Measures draw, not the limit — insufficient |
+| Opto / SSR high-impedance buffer | ✅ | ✅ ~µA | Works, but it's loose electronics (rejected: error-prone, hard to troubleshoot) |
+| Low-coil-current **plug-in** relay (~30 mA) | ✅ | ⚠️ ~30 mA | **Does not exist off-the-shelf** — plug-in automotive relays are all ~150 mA; low-power coils are PCB-mount only |
+| Enclosed automotive SSR (MRS 1.069) | ✅ | ✅ | Doesn't fit — high-side output fights the series AND; "don't energize I/O unpowered" caution; 6.3 mm body |
+| ISO 280 **micro** SSR (to fit BODY PDU sockets) | ✅ | ✅ | Doesn't exist — micro footprint is electromechanical-only |
+| PBS-I built-in crank delay (~7 s) | ⏱️ timer | ✅ none | Blind timer, not lamp-sensed; covers typical preheat only |
+| iKey Premier sensed wait (Pink wire, 18 s) | ✅ | ✅ | **Remote-start only** — not active for driver-present push-button start |
+| **PMU-sensed gate relay** (see below) | ✅ | ✅ ~µA | The clean implementation if revived |
+| **Watch the lamp** | ❌ manual | ✅ none | **Chosen** — zero parts, mfr procedure |
+
+## Recommended implementation, if revived
+
+A relay-based gate where the **PMU is only the sensor**, never in the crank path. This was fully worked out and is the design to resurrect:
+
+```text
+PMU In 4  ← ECM Pin 35 (WAIT lamp)        high-Z digital input → ~µA on Pin 35
+PMU Out 24 → gate-relay coil+             (from +12, NOT Pin 35); coil− to cabin ground
+relay NC   in series:  PBS-I PURPLE START → relay COM → NC → firewall Pin 15 → Cole Hersee coil+
+```
+
+- **PMU logic:** `IF In4_WaitToStart == LOW THEN Out24 = ON (block) ELSE OFF (pass)`.
+- **Behavior:** WAIT on → PMU energizes relay → NC opens → crank blocked. WAIT off → relay drops → NC closed → start passes.
+- **Zero Pin 35 load:** the PMU senses with a high-impedance input; the relay coil is driven from the PMU output, so the coil current never touches Pin 35 — a standard ~150 mA relay is fine.
+- **Block-only:** the PMU drives the *relay coil*, not the starter solenoid, so it can only interrupt an already-authorized PBS-I crank, never command one.
+- **Fail-safe, no bypass needed:** dead/unpowered PMU, failed Out 24, or open coil → relay de-energized → NC closed → PBS-I cranks. A dead PMU also stops the cooling fan, so the start path is never the limiting failure.
+
+**Proposed I/O (both currently spare):** PMU **In 4** (WAIT sense) and **Out 24** (gate-relay coil, ~0.16 A). See [PMU Inputs][pmu-inputs] / [PMU Outputs][pmu-outputs].
+
+**Parts:**
+
+- Gate relay: any standard 12 V SPDT (changeover) automotive relay wired SPST-NC; NC contact carries only the ~0.69 A Cole Hersee coil. Mount cabin, adjacent to the PBS-I.
+- (Optional limp-home, not required) a manual bypass across the relay's COM↔NC — a latching illuminated push-button such as the **Blue Sea 4160** (build standard) glowing when engaged, or simply a spare relay / a COM-NC jumpered "bypass plug" in the glovebox. The NC topology already self-enables on the common faults, so this is belt-and-suspenders.
+
+## Why not the simpler-looking alternatives
+
+- **No off-the-shelf "WAIT-gate" module exists.** Plug-in SSRs don't come in a form that does a fail-safe series AND of two 12 V signals, and low-coil-current relays only exist as PCB parts. Anything that gets Pin 35 to ~zero load while staying a finished, plug-in product ends up being the PMU (sensor) + relay (gate) above.
+- **It can't live in the BODY PDU.** The Bussmann LR-2 uses ISO 280 micro relays (~150 mA coils → re-creates #117), and it's a high-side power panel, not a series-signal-gate host.
+
+## Sources
+
+[^wait-polarity]: **Active-low confirmed.** Cummins Repower R2.8 CM2220 R101B Installation Guide, Bulletin 5504137 (Jan 2018), §2 *Wiring Harness* / *Engine Indicator Lamps*: "Lamp, Wait To Start — Yellow — ECM pin 35"; lamps are fed +12 V from the keyswitch with the ECM "providing a path to ground via a sink circuit." Full schematic = Wiring Diagram Bulletin 5467560 (QuickServe Online). Also documented on [HDX Control][hdx-control].
+
+[^pin35-rating]: The CM2220 lamp-driver sink-current rating is **not published** in the public crate documents (Installation Guide 5504137, spec flyer 5410825, Wiring Diagram 5467560, Lamp ID card 4971518) — same gap the grid-heater current carries. It would require Cummins QuickServe / Care to obtain. This is why a design that *senses* Pin 35 (high-Z) is preferred over one that *loads* it.
+
+## Related Documentation
+
+- [Starter System][starter] - The crank circuit this would gate (sole inbound link to this note)
+- [Keyless Ignition][keyless-ignition] - PBS-I architecture and the current watch-the-lamp cold-start sequence
+- [Grid Heater System][grid-heater] - R2.8 preheat duty cycle (3–5 s typical)
+- [HDX Control][hdx-control] - ECM Pin 35 WAIT signal and its active-low sourcing
+
+[starter]: 01-starter.md
+[keyless-ignition]: ../05-control-interfaces/06-keyless-ignition.md
+[grid-heater]: 07-grid-heater.md
+[hdx-control]: 09-gauge-cluster/01-hdx-control.md
+[pmu-inputs]: ../01-power-systems/04-pmu/02-pmu-inputs.md
+[pmu-outputs]: ../01-power-systems/04-pmu/03-pmu-outputs.md

--- a/docs/jeep_lj/05-control-interfaces/01-overview.md
+++ b/docs/jeep_lj/05-control-interfaces/01-overview.md
@@ -30,7 +30,7 @@ This section documents all control interfaces in the Jeep LJ build - the switche
 - **[Keyless Ignition][keyless-ignition]** - RFID + push-button start/stop replacing the factory keyswitch
   - Digital Guard Dawg PBS-I self-contained module with RFID iTag fobs
   - Single dash push-button included with kit
-  - WAIT-gate relay handles cold-start grid heater preheat automatically
+  - Cold-start grid heater preheat: driver waits for the WAIT-to-Start lamp before cranking
   - Emergency Bypass Card with 4-digit PIN (no hidden toggle)
 
 ## System Integration

--- a/docs/jeep_lj/05-control-interfaces/06-keyless-ignition.md
+++ b/docs/jeep_lj/05-control-interfaces/06-keyless-ignition.md
@@ -11,7 +11,7 @@ tags:
 
 # 5.6 Keyless Ignition System {#keyless-ignition}
 
-Push-button ignition for the Cummins R2.8 + 8HP70 build. Replaces the factory keyswitch entirely. Self-contained Digital Guard Dawg PBS-I handles RFID immobilizer, brake interlock, and ACC/IGN/START sequencing internally. One external SPST relay gates cranking through the diesel wait-to-start lamp so cold-day starts auto-wait for grid heater preheat. PMU is not involved.
+Push-button ignition for the Cummins R2.8 + 8HP70 build. Replaces the factory keyswitch entirely. Self-contained Digital Guard Dawg PBS-I handles RFID immobilizer, brake interlock, and ACC/IGN/START sequencing internally. On a cold start the driver waits for the Cummins WAIT-to-Start lamp to extinguish before cranking — Digital Guard Dawg's documented diesel start procedure. PMU is not involved.
 
 ## Architecture
 
@@ -43,24 +43,8 @@ Push-button ignition for the Cummins R2.8 + 8HP70 build. Replaces the factory ke
 | Auto-arm | 60 sec after fob leaves range |
 | Module Dimensions | ~5.5" × 3" × 1.25" |
 | Wiring | Heavy-duty Molex high-current connectors, 12 GA bus wiring |
-| Mounting | **Dakota Digital HDPE panel, under dash** — co-located with the HDX control module (shares the ECM Pin 35 WAIT tap; panel detailed in the [HDX Control][hdx-control] plan). Vendor mandate: cabin only, never engine bay |
+| Mounting | **Dakota Digital HDPE panel, under dash** — co-located with the HDX control module (panel detailed in the [HDX Control][hdx-control] plan). Vendor mandate: cabin only, never engine bay |
 | Kit Contents | ICM + 2 iTag fobs + Start Button (36" pre-wired harness) + Programming Button + Bypass Card + 4-digit PIN |
-
-### WAIT-gate Relay
-
-Single SPST automotive relay with normally-closed contacts. Blocks PBS-I's START output from reaching the Cole Hersee coil while the Cummins WAIT-to-Start lamp is illuminated.
-
-The Cummins R2.8 ECM uses a **sink-circuit lamp topology**: keyswitch +12V → lamp → ECM Pin 35 (yellow) → ECM internal sink to ground when condition is active. The WAIT signal at Pin 35 is therefore **active LOW** (~0V when WAIT lamp on, ~+12V when WAIT lamp off).[^wait-polarity]
-
-| Specification | Value |
-| :------------ | :---- |
-| Type | 5-pin SPDT changeover, used as SPST-NC (30/87a wired, 87 unused); 30A NO / 20A NC contacts[^wait-relay] |
-| Coil | 12V DC, ~160 mA |
-| Coil+ | Switched +12V (tap from ignition signal bus bar — same source as the WAIT lamp itself) |
-| Coil- | ECM Pin 35 (yellow WAIT-to-Start wire) tap on cabin side (shared with HDX WAIT/EX input) |
-| Contacts | NC (87a); closed when coil de-energized (WAIT lamp off), opens when coil energized (WAIT lamp on) |
-| Mounting | Cabin, adjacent to PBS-I |
-| Part | **Bosch 0332209150** (superseded by 0986332400) — 5-pin changeover[^wait-relay] |
 
 ### Cole Hersee 24213 Solenoid
 
@@ -77,11 +61,10 @@ Unchanged from existing starter design. See [Starter System][starter].
 **Cold engine (grid heater active):**
 
 1. Approach — fob recognized — Start Button LED illuminates
-2. Press brake + press and hold Start Button
-3. PBS-I energizes PINK IGN immediately → ECM powers up → grid heater runs → WAIT-to-Start lamp illuminates
-4. PBS-I asserts PURPLE START, but WAIT-gate relay holds it open while WAIT lamp on — **keep holding button**
-5. ~3-5 seconds later (per [Grid Heater][grid-heater]), WAIT lamp extinguishes → WAIT-gate relay NC closes → starter cranks
-6. Release on engine start
+2. Press Start Button twice (no brake) → IGN energizes → ECM powers up → grid heater runs → WAIT-to-Start lamp illuminates
+3. Wait ~3-5 seconds (per [Grid Heater][grid-heater]) for the WAIT-to-Start lamp to extinguish
+4. Press brake + press and hold Start Button → starter cranks
+5. Release on engine start
 
 **Shut off:** Press brake + press and hold Start Button for 2 seconds.
 
@@ -98,7 +81,7 @@ Unchanged from existing starter design. See [Starter System][starter].
 | RED | +12V Battery | Critical Cabin PDU (CONSTANT) | PBS-I module | 14 AWG; ~50 mA standby ({{ tbd(84) }}) |
 | BLACK | Chassis Ground | Cabin ground bus | PBS-I module | 14 AWG |
 | PINK | 1st Ignition Out (60A) | PBS-I module | Ignition signal bus bar (cabin), Stud 1 | Does NOT drop during crank; bus bar Stud 2 outbounds to ECM Pin 41 via 5A inline fuse[^ecm-fuse] |
-| PURPLE | Starter Out (60A) | PBS-I module | WAIT-gate relay common (NC input) | Cranks while button held |
+| PURPLE | Starter Out (60A) | PBS-I module | Firewall Pin 15 → Cole Hersee 24213 coil+ | Cranks while button held |
 | PINK/BLK | Accessory 1 (60A) | PBS-I module | **[Reserve]** | Drops during crank |
 | BROWN | Accessory 2 (60A) | PBS-I module | **[Reserve]** | Stays on during crank |
 
@@ -116,17 +99,6 @@ Unchanged from existing starter design. See [Starter System][starter].
 | Start Button | Pre-wired 36" harness → PBS-I side port | Mounts at the factory keyswitch location on the dash (within the 36" harness reach of the panel); included in kit |
 | Programming Button | Pre-wired harness → PBS-I side port | Stash under dash or in trunk; needed only for fob-learn and emergency bypass PIN entry |
 
-### WAIT-Gate Relay
-
-| Wire | Source | Destination | Notes |
-| :--- | :----- | :---------- | :---- |
-| Coil (+) | Switched +12V tap (ignition signal bus bar terminal) | WAIT-gate relay coil+ | Same source that powers the WAIT lamp |
-| Coil (-) | WAIT-gate relay coil- | T-tap on ECM Pin 35 wire (cabin side, shared with HDX WAIT/EX input) | Active-low sink path; ECM grounds this wire when WAIT lamp on |
-| Contact COM | PBS-I PURPLE START | WAIT-gate relay COM terminal | |
-| Contact NC | WAIT-gate relay NC terminal | Firewall Pin 15 → Cole Hersee 24213 coil+ | Closed when WAIT off; opens when WAIT on |
-
-See [HDX Control][hdx-control] for the existing WAIT/EX wiring on the cabin side.
-
 ### Firewall Crossings
 
 Two PBS-I outputs need to cross the firewall from cabin (PBS-I location) to engine bay:
@@ -134,7 +106,7 @@ Two PBS-I outputs need to cross the firewall from cabin (PBS-I location) to engi
 | Signal | Direction | Approximate Current | Notes |
 | :----- | :-------- | :------------------ | :---- |
 | Ignition signal (outbound from cabin bus bar) | Cabin → EB (HDP24 Pin 12) | ~5A typical (ECM + PMU Pin 7) | 14 AWG; feeds ECM Pin 41 (black, via **5A inline fuse**[^ecm-fuse]) and PMU Pin 7 |
-| WAIT-gated PURPLE | Cabin → EB (HDP24 Pin 15) | ~0.69A (Cole Hersee coil)[^ch-coil] | 16 AWG sufficient; drives Cole Hersee 24213 coil+ during crank only |
+| PURPLE START | Cabin → EB (HDP24 Pin 15) | ~0.69A (Cole Hersee coil)[^ch-coil] | 16 AWG sufficient; drives Cole Hersee 24213 coil+ during crank only |
 
 See [Firewall Ingress][firewall-ingress] for pin assignments.
 
@@ -156,7 +128,7 @@ Normal engine shutdown (press brake + 2 sec button hold) drops PBS-I's PINK IGN 
 
 ## Related Documentation
 
-- [Starter System][starter] - Cole Hersee 24213 and PBS-I PURPLE → WAIT-gate → coil chain
+- [Starter System][starter] - Cole Hersee 24213 and PBS-I PURPLE START → coil chain
 - [Ignition Signal Distribution][ignition-signal] - PBS-I PINK IGN feeds the bus bar
 - [HDX Control][hdx-control] - WAIT/EX signal source for the gate relay
 - [Grid Heater System][grid-heater] - R2.8 grid heater duty cycle (3-5 sec typical)
@@ -164,13 +136,9 @@ Normal engine shutdown (press brake + 2 sec button hold) drops PBS-I's PINK IGN 
 
 [^pbs-i-specs]: Onboard relay ratings (4× 60A), 300A inrush capacity, and kit contents per the Digital Guard Dawg PBS-I install manual ([PBS-I Manual PDF][pbs-i-manual]) and product page ([Digital Guard Dawg PBS-I][pbs-i]).
 
-[^wait-relay]: **Bosch 0332209150** — 5-pin SPDT *changeover* mini-relay, 12V, 30A NO / **20A NC**, ~160 mA coil (Bosch/Amazon listing, accessed 2026-06-03; superseded by **0986332400**). This circuit energizes the coil to *open* the start path (WAIT lamp on → coil energized → contacts open), so it must use the **NC (87a)** contact — which requires a changeover relay. The earlier "suggested" parts were both wrong for this: Bosch **0332019150** is a twin-87 NO-only relay (no 87a terminal) and Hella **4RA** is an SPST make-only series — neither has an NC contact. The NC side here carries only the Cole Hersee 24213 coil (~0.69A), far under the 20A NC rating. Equivalent changeover relays (Hella **4RD** series, Tyco/TE V23234) are acceptable substitutes.
-
 [^ch-coil]: Cole Hersee 24213 coil draw ~0.69A (17.5 Ω @ 12V) per the Littelfuse datasheet — see the `[^ch-24213]` footnote in [Starter System][starter]. Supersedes the earlier unsourced "~1.6A" figure that appeared in pre-merge drafts.
 
 [^ecm-fuse]: **Confirmed.** Cummins Repower R2.8 CM2220 R101B Installation Guide, Bulletin 5504137 (Jan 2018), §2 *Wiring Harness* (pp. 2-19/2-20): the keyswitch feed to the ECM is **Pink, ECM pin 41**, with a **5 amp inline fuse** (Figure 2, item 3: *"Keyswitch – pink, 5 amp inline fuse"*). The guide requires this *"pink 5 amp wire … provide a minimum of 12 volts in the run position and during engine cranking."* Supersedes the unverified "document 0042728" cited in pre-merge drafts.
-
-[^wait-polarity]: **Confirmed active-low.** Cummins Repower R2.8 CM2220 R101B Installation Guide, Bulletin 5504137 (Jan 2018), §2 *Wiring Harness* / *Engine Indicator Lamps* (pp. 2-19 → 2-24): the Circuit Wiring table lists **Lamp, Wait To Start — Yellow — ECM pin 35**, and the guide states *"The lamp circuits require power from the keyswitch to each lamp, with the ECM providing a path to ground via a sink circuit as engine conditions dictate"* and *"The ECM will enable a grounding path for the warning light to illuminate."* Pin 35 is therefore active-low (ECM sinks to ground when WAIT is active), validating the WAIT-gate relay logic above. The full schematic is the separate **R2.8 CM2220 R101B Wiring Diagram, Bulletin 5467560** (QuickServe Online). Supersedes the unverified "document 0042728" cited in pre-merge drafts. Note: the relay taps ECM Pin 35 directly, so it is governed by this Cummins spec — independent of the HDX *cluster-input* polarity question in [HDX Control][hdx-control].
 
 [pbs-i]: https://www.digitalguarddawg.com/keyless-ignition/automotive/pbs-i
 [pbs-i-manual]: https://cdn.shopify.com/s/files/1/0896/8005/2530/files/PBS-I-Manual.pdf

--- a/docs/jeep_lj/05-control-interfaces/06-keyless-ignition.md
+++ b/docs/jeep_lj/05-control-interfaces/06-keyless-ignition.md
@@ -130,7 +130,7 @@ Normal engine shutdown (press brake + 2 sec button hold) drops PBS-I's PINK IGN 
 
 - [Starter System][starter] - Cole Hersee 24213 and PBS-I PURPLE START → coil chain
 - [Ignition Signal Distribution][ignition-signal] - PBS-I PINK IGN feeds the bus bar
-- [HDX Control][hdx-control] - WAIT/EX signal source for the gate relay
+- [HDX Control][hdx-control] - ECM Pin 35 WAIT/EX signal (dash display)
 - [Grid Heater System][grid-heater] - R2.8 grid heater duty cycle (3-5 sec typical)
 - [Firewall Ingress][firewall-ingress] - PBS-I pin assignments
 

--- a/docs/jeep_lj/09-installation/02-engine-systems-checklist.md
+++ b/docs/jeep_lj/09-installation/02-engine-systems-checklist.md
@@ -22,9 +22,7 @@ parts to buy live in the [Purchase Tracker][purchase-tracker].
 - [ ] Confirm starter battery post → Cole Hersee input
 - [ ] Confirm Cole Hersee output → starter switch post
 - [ ] Confirm PBS-I module mounted under-dash, powered from Critical Cabin PDU
-- [ ] Confirm PBS-I PURPLE START → WAIT-gate relay COM
-- [ ] Confirm WAIT-gate relay coil → ECM WAIT signal tap (shared with HDX WAIT/EX input)
-- [ ] Confirm WAIT-gate relay NC contact → firewall Pin 15 → Cole Hersee coil+
+- [ ] Confirm PBS-I PURPLE START → firewall Pin 15 → Cole Hersee coil+
 - [ ] Confirm Cole Hersee coil- grounded to engine bay ground bus
 - [ ] Confirm PBS-I PINK IGN → cabin ignition bus bar → firewall Pin 12 → ECM 12V + PMU Pin 7
 - [ ] Confirm Start Button mounted on dash, harness plugged into PBS-I
@@ -180,7 +178,7 @@ parts to buy live in the [Purchase Tracker][purchase-tracker].
 - [ ] Verify starter does NOT crank when Start Button not pressed
 - [ ] Verify starter does NOT crank without valid iTag fob in range
 - [ ] Verify starter cranks when fob + Start Button + brake all asserted (warm engine)
-- [ ] Verify cold-start sequence: WAIT lamp illuminates → extinguishes → starter cranks
+- [ ] Verify cold-start sequence: IGN on → WAIT lamp illuminates → extinguishes → driver cranks (no auto-gate; driver waits for the lamp)
 - [ ] Verify engine shutoff: brake + button hold → engine stops
 - [ ] Verify Emergency Bypass: Programming Button + PIN authorizes start with fob absent
 - [ ] Verify fob auto-arm after fob leaves range

--- a/docs/jeep_lj/index.md
+++ b/docs/jeep_lj/index.md
@@ -7,7 +7,7 @@ hide:
 
 ## Project Overview
 
-This documentation covers the complete electrical system design for a 2006 Jeep LJ (Wrangler Unlimited) with a Cummins R2.8 Turbo Diesel engine swap. The factory wiring and TIPM are replaced with a modular architecture: dual isolated batteries, programmable power management (PMU24), a safety controller (SafetyHub), and split control surfaces for street lighting (Command Touch CT4) and offroad lighting (SwitchPros SP-1200). Brakes are converted to electro-hydraulic (Bosch iBooster + Wilwood master cylinder), and ignition is keyless via PBS-I with a WAIT-gate relay.
+This documentation covers the complete electrical system design for a 2006 Jeep LJ (Wrangler Unlimited) with a Cummins R2.8 Turbo Diesel engine swap. The factory wiring and TIPM are replaced with a modular architecture: dual isolated batteries, programmable power management (PMU24), a safety controller (SafetyHub), and split control surfaces for street lighting (Command Touch CT4) and offroad lighting (SwitchPros SP-1200). Brakes are converted to electro-hydraulic (Bosch iBooster + Wilwood master cylinder), and ignition is keyless via PBS-I.
 
 <div class="mobile-nav-only" markdown="1">
 
@@ -52,7 +52,7 @@ The electrical system is organized into zones for logical distribution and maint
 - **[SwitchPros SP-1200][switchpros]** - SwitchPros lighting controller
 - **[Command Touch CT4][ct4]** - Command Touch control panel
 - **[Dashboard Switches][dashboard-controls]** - Physical dashboard controls
-- **[Keyless Ignition][keyless-ignition]** - PBS-I keyless start with WAIT-gate relay
+- **[Keyless Ignition][keyless-ignition]** - PBS-I keyless start
 
 ### Stereo Systems
 
@@ -102,7 +102,7 @@ The factory TIPM is replaced with discrete, serviceable modules:
 ### Brake & Ignition
 
 - **[Bosch iBooster Gen 2 + Wilwood MC][brake-booster]:** Electro-hydraulic brake booster (Honda Accord Hybrid Gen 2 iBooster, Wilwood Tandem Compact master cylinder, Back Bay Customs adapter)
-- **[PBS-I Keyless Ignition][keyless-ignition]:** Pushbutton start, self-contained WAIT-gate relay (no PMU dependency)
+- **[PBS-I Keyless Ignition][keyless-ignition]:** Pushbutton start, self-contained RFID immobilizer (no PMU dependency)
 
 ### Major Systems
 


### PR DESCRIPTION
## Summary

Cleanup that came out of reviewing open TBDs.

### Keyless ignition — remove the WAIT-gate relay (closes #117)
The original WAIT-gate relay blocked cranking during grid-heater preheat by tapping its coil onto **ECM Pin 35** — ~160 mA against a lamp-driver sink rating Cummins doesn't publish (that's #117). It's removed; PBS-I `PURPLE START` drives the Cole Hersee coil directly.

The cold-start procedure is now **watch the lamp** — the driver waits for the WAIT-to-Start lamp to extinguish before cranking, which is Digital Guard Dawg's own documented diesel procedure. Cranking during preheat is harmless on the common-rail R2.8, so the ~3–5 s wait is a non-issue.

### Design note — the deferred automatic lockout (new page)
An automatic lockout was evaluated in depth (SSR, low-coil relay, bypass switch, and a fully-worked PMU-sensed gate-relay design) and **deferred** as not worth the complexity. Rather than lose that study, it's preserved in a new page — `02-engine-systems/wait-to-start-lockout-design-note.md` — that captures the requirement, every option and why it was rejected, and the ready-to-implement PMU design with fail-safe analysis. It's **linked only from the Starter System page** and kept out of the main nav, so it's there if the idea is ever revived.

### BODY PDU — 12 V relay spec + part-number fix (closes #70)
- K40/K42/K53 (24 V coils) → the panel's own relay one trim down: **Song Chuan `301-1C-C-R1-U01-12VDC`**, with a cited footnote.
- Corrected the page's Part Number: `301-1C-C-R1` is the relay that populates the panel, not the panel (the panel is the **Bussmann LR-2**).

## Validation
- All footnotes and reference-style links resolve across `docs/**`.
- No stale "gate relay" references remain in the keyless/starter path.

https://claude.ai/code/session_01EDrhU1ZjDUzg9rAgeK71uy