### PR TITLE
docs: nightly tidiness — trim verbosity (2026-06-06)

### DIFF
--- a/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
+++ b/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
@@ -109,17 +109,11 @@ See [PMU DRL Auto-Off Logic](#pmu-drl-auto-off-logic) section below for complete
 
 ## Programming Configuration
 
-The CT4 is highly programmable. Recommended configuration for this build:
+Recommended configuration for this build:
 
 1. **Turn Signal Mode:** GPS turn signal mode (automatic cancellation based on speed and steering angle)
-   - SW1 (UP) = Right Turn
-   - SW2 (DOWN) = Left Turn
-   - GPS module monitors vehicle speed and steering to detect turn completion
 
-2. **Ignition Control:** Ignition-aware mode
-   - SW1/SW2 (turn signals/hazards) work anytime, even when ignition is off (critical for safety)
-   - SW3/SW4 (headlights) disabled when ignition off (via ignition signal from ignition switch RUN)
-   - Prevents battery drain from headlights left on
+2. **Ignition Control:** Ignition-aware mode (SW1/SW2 always active; SW3/SW4 disabled when ignition off)
 
 3. **ON-OFF/Momentary:**
    - SW1/SW2: ON-OFF (latching turn signals with GPS auto-cancel)

--- a/docs/jeep_lj/08-exterior-systems/01-winch.md
+++ b/docs/jeep_lj/08-exterior-systems/01-winch.md
@@ -70,15 +70,6 @@ No external circuit breaker — per the [WARN ZEON 10-S installation manual][war
 - **Connection:** Plugs into winch control pack
 - **Use case:** Outside vehicle spotting (traditional winch operation with visual line of sight)
 
-**Control Architecture:**
-
-```text
-SafetyHub ATC-1 (15A) → Dash Rocker Switch ⟷ Handheld Remote (parallel) → Winch Contactor IN/OUT
-                              ↑                      ↑
-                           UP = OUT              Remote OUT button
-                           DOWN = IN             Remote IN button
-```
-
 ## Wiring
 
 **Main Power Wiring:**
@@ -115,25 +106,6 @@ See [AUX Battery Distribution][aux-battery] for wire specs (gauge, length, routi
 See [AUX Battery Distribution][aux-battery] for cable specs and routing path.
 
 - **Route:** Passenger rear wheel well → front bumper (~13 ft, exact path: {{ tbd(106) }} - avoid exposed frame rail per offroad protection requirement)
-- **Protection:** Split loom over entire run
-- **Securing:** P-clamps every 18" along the chosen path
-- **Grommets:** Rubber grommets with sealant at body penetrations
-- **Heat:** Route away from exhaust components (minimum 6" clearance)
-
-## Safety Considerations
-
-!!! warning "Winch Safety"
-    - Never exceed winch rated capacity (10,000 lbs)
-    - Always use proper recovery techniques and safety equipment
-    - Keep hands and body clear of winch line under tension
-    - Use tree savers and recovery equipment rated for load
-    - Monitor battery voltage during extended winch operations
-
-!!! warning "Electrical Safety"
-    - Winch power cables carry extremely high current (up to 409A)
-    - Ensure all connections are tight and properly crimped
-    - Never disconnect battery while winch is under load
-    - Check cable insulation regularly for damage
 
 ## Outstanding Items
 

--- a/docs/jeep_lj/08-exterior-systems/02-air-compressor.md
+++ b/docs/jeep_lj/08-exterior-systems/02-air-compressor.md
@@ -144,20 +144,6 @@ ARB Twin Compressor system with air tank and automatic pressure management for l
 
 ### SwitchPros Integration
 
-**Control Architecture:**
-
-```text
-Air Tank Pressure Switch (ARB 180901)
-    ↓ (trigger signal when pressure < 135 PSI)
-SwitchPros TRIGGER-3 (Pin 17, PINK wire)
-    ↓
-SwitchPros Logic: TRIGGER-3 OR Button 11 → OUTPUT-11
-    ↓
-OUTPUT-11 activates compressor
-    ↓
-Compressor fills tank to 150 PSI → pressure switch opens → compressor stops
-```
-
 **SwitchPros Programming:**
 
 - **TRIGGER-3 Input:** Pressure switch signal (tank < 135 PSI activates trigger)


### PR DESCRIPTION
Nightly tidiness pass — 3 pages, 51 lines removed, 0 spec values changed.

## Changes

| File | Lines before → after | What was cut | Persona(s) failed |
|:-----|:---------------------|:-------------|:------------------|
| `08-exterior-systems/01-winch.md` | 155 → 128 | **Control Architecture ASCII diagram** (duplicates the prose bullet list immediately above it); **4 Installation bullets** (split loom, P-clamps, grommets, 6″ heat clearance — all generic shop practice); **Safety Considerations section** (two `!!! warning` blocks containing 100% generic boilerplate: "never exceed rated capacity", "ensure connections are tight", etc.) | Mechanic/Installer — none of this is build-specific or non-obvious |
| `08-exterior-systems/02-air-compressor.md` | 206 → 193 | **Control Architecture text diagram** in the Automatic Pressure Control section — the signal flow it depicts (pressure switch → TRIGGER-3 → OUTPUT-11 → compressor) is fully covered by the SwitchPros Programming bullets and Operational Modes table immediately below it | All personas — diagram restates adjacent prose and table |
| `05-control-interfaces/03-command-touch-ct4.md` | 235 → 228 | **"The CT4 is highly programmable."** (marketing filler); **6 sub-bullets** under Programming Configuration items 1–2 that restate the Wiring Pinout table Notes column (`SW1=Right`, `SW2=Left`, GPS description, ignition-disable behavior, "prevents battery drain"). Condensed item 2 to inline parenthetical preserving the key non-obvious detail (turn signals active with key off; headlights not). | All personas — content already in wiring table and product-info block |

## Verification

- `zensical build --clean` — **passes**, same 28 pre-existing "unused link definition" warnings, no new errors
- `npx markdownlint-cli2` on the 3 edited files — **same 12 pre-existing errors** before and after (MD060 table alignment, one MD051 fragment in ct4.md that pre-dates this PR); zero new issues introduced

## Left for human judgment

- **`05-control-interfaces/02-switchpros-sp1200.md` — Buttons 5 and 8 inconsistency:** The "Notes" section after the Control Panel Layout table says `Buttons 5, 8: Available for future use`, but the table itself assigns Button 5 → Interior LEDs (OUTPUT-5) and Button 8 → Navigation (OUTPUT-8). Additionally, the 20-pin harness table marks OUTPUT-5 and OUTPUT-8 as `_AVAILABLE_`. This is a genuine contradiction that needs a human to resolve — either the button assignments are provisional/planned (and the note is correct), or the note is stale. Not touched.
- **`05-control-interfaces/03-command-touch-ct4.md` — `[Wiring](#wiring)` anchor:** Line 172 (post-edit: 166) contains a cross-link to `#wiring` that has no matching heading in the file (the heading is `## Wiring Pinout`). Pre-existing MD051 lint error; not introduced by this PR but flagged for awareness.
- Several files surveyed (brake-booster, runaway-protection, keyless-ignition, subwoofer) were found to be lean and purposeful — rationale sections in those files were deliberately left intact per the style guide.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y5YBzUWkBR7di88k9Z77c8)_