### PR TITLE
Move radiator fan, iBooster, and TCU off the PMU to a START+ forward distribution bus

### DIFF
--- a/docs/jeep_lj/01-power-systems/01-power-generation/05-wire-distance-reference.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/05-wire-distance-reference.md
@@ -48,6 +48,7 @@ Wire gauges optimized for performance at measured routing distances:
 | **Starter Motor**              | 6 ft                          | 2/0 AWG    | 400-600A                | <3% @ 20°C                       | Brief cranking load - minimal temp effect                 |
 | **BCDC Inter-Battery**         | 5-6 ft                        | 4 AWG      | 50A                     | 0.94% @ 20°C                     | Rear wheel well to rear wheel well (H3 cross-cab, see [Wire Routing][wire-routing]) |
 | **Winch → AUX battery**        | 13 ft one-way (26 ft circuit) | 1/0 AWG    | 250A typical, 409A peak | 4.9% @ 250A, 7.9% @ 409A @ 13.8V[^winch-vdrop] | Passenger rear wheel well to front bumper routing — see {{ tbd(106) }} and [Wire Routing][wire-routing] |
+| **START+ Fwd Bus master feed** | ~8 ft ({{ tbd(136) }})        | 2 AWG      | ~108A peak / ~68A cont  | 1.3% @ 60°C                                    | Single feed to engine-bay busbar; relocated fan/iBooster/TCU fan out on short load runs |
 
 **Temperature Derating Notes:**
 

--- a/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/01-circuit-breakers.md
+++ b/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/01-circuit-breakers.md
@@ -15,13 +15,26 @@ All START battery positive circuits protected by Mechanical Products Series 17 c
 
 | Circuit        | Model                                            | Rating | Reset Type | Power Path                                                          | Max Load                                  | Sizing                                                             |
 | :------------- | :----------------------------------------------- | :----: | :--------- | :------------------------------------------------------------------ | :---------------------------------------- | :----------------------------------------------------------------- |
-| **PMU24**      | Mechanical Products<br/>([174-S2-250-2][mp-250]) |  250A  | Manual     | START battery+<br/>└→ 250A CB<br/>&nbsp;&nbsp;&nbsp;└→ PMU24        | ~253A theoretical peak (140-170A typical) | 99% of max load (with all radios transmitting + full radiator fan) |
+| **PMU24**      | Mechanical Products<br/>([174-S2-250-2][mp-250]) |  250A  | Manual     | START battery+<br/>└→ 250A CB<br/>&nbsp;&nbsp;&nbsp;└→ PMU24        | 140-170A typical (radiator fan, iBooster + TCU no longer on PMU) | Protects 2/0 AWG (265A @ 60°C); now generously oversized after relocation |
+| **Fwd Dist Bus (master)** | Mechanical Products<br/>(174-S2-150-2, {{ tbd(135) }}) | 150A | Manual | START battery+<br/>└→ 150A CB<br/>&nbsp;&nbsp;&nbsp;└→ [START+ Forward Distribution Bus][front-battery] | ~108A peak (~68A continuous) | Protects 2 AWG forward feed; selective with downstream load CBs |
 | **BCDC Input** | Mechanical Products<br/>([174-S2-080-2][mp-80])  |  80A   | Manual     | START battery+<br/>└→ 80A CB<br/>&nbsp;&nbsp;&nbsp;└→ BCDC Alpha 50 | 50-55A BCDC input                         | 145-160% of max load                                               |
 
-**Total Circuit Breakers:** 2 (PMU 250A, BCDC 80A)
+**Total battery-side Circuit Breakers:** 3 (PMU 250A, Forward Dist Bus master 150A, BCDC 80A)
 
 !!! info "PMU Circuit Breaker Sizing"
-250A CB sized to protect 2/0 AWG wire (265A @ 60°C). Typical PMU load is 140-170A (56-68% of CB rating). The 253A theoretical peak requires all loads maxed simultaneously - not realistic in practice.
+250A CB sized to protect 2/0 AWG wire (265A @ 60°C). With the radiator fan, iBooster, and TCU relocated to the [Forward Distribution Bus][front-battery], typical PMU load drops to ~85-115A (well under half the CB rating). The CB is left at 250A (no benefit to downsizing).
+
+## Forward Distribution Bus Breakers (engine bay)
+
+The three loads relocated off the PMU each get a breaker at the [START+ Forward Distribution Bus][front-battery] (engine bay), fed from the 150A master above. SKUs follow the Mechanical Products Series 17 S2 pattern — confirm via {{ tbd(135) }}.
+
+| Circuit | Model | Rating | Power Path | Max Load | Sizing |
+| :------ | :---- | :----: | :--------- | :------- | :----- |
+| **Radiator Fan** | Mechanical Products (174-S2-060-2) | 60A | Fwd Bus → 60A CB → fan | 53A continuous | 113% of max load (protects 4 AWG) |
+| **iBooster main** | Mechanical Products (174-S2-050-2) | 50A | Fwd Bus → 50A CB → iBooster | 40A brief peak / 0.25A idle | 125% of brief peak (protects 8 AWG) |
+| **Turbolamik TCU** | Mechanical Products (174-S2-025-2) | 25A | Fwd Bus → 25A CB → TCU | 15A continuous | 167% of max load (protects 12 AWG) |
+
+**Total Forward Bus Circuit Breakers:** 3 (fan 60A, iBooster 50A, TCU 25A)
 
 **All Circuit Breakers:**
 
@@ -34,7 +47,7 @@ All START battery positive circuits protected by Mechanical Products Series 17 c
 - Standards: Marine-rated (SAE J1171, ABYC E-11, UL1500, IP67, MIL-STD-202)
 - Mounting: Driver rear wheel well within 7" of battery positive terminal
 
-**Space Requirements:** 2 CBs side-by-side with wiring clearance for 2/0 AWG cables: ~7" × 4" (~28 sq in)
+**Space Requirements:** 3 battery-side CBs (PMU 250A, Forward Bus master 150A, BCDC 80A) side-by-side with wiring clearance: ~10" × 4" (~40 sq in). The 3 forward-bus load CBs (fan/iBooster/TCU) mount in the engine bay on a bracket beside the [Forward Distribution Bus][front-battery], not in the wheel well.
 
 ## Related Documentation
 

--- a/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/CLAUDE.md
+++ b/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/CLAUDE.md
@@ -19,11 +19,11 @@ Documents START battery power distribution from the driver rear wheel well (Odys
 
 ### `01-circuit-breakers.md` - Circuit Breakers
 
-**Contains:** All START battery circuit breaker specifications and ratings (250A → PMU, 80A → BCDC input)
+**Contains:** All START battery circuit breaker specifications and ratings (250A → PMU, 80A → BCDC input, 150A master → START+ Forward Distribution Bus, plus forward-bus load CBs 60A/50A/25A for fan/iBooster/TCU)
 
-**Use when:** Finding circuit breaker size for PMU, BCDC, or other loads
+**Use when:** Finding circuit breaker size for PMU, BCDC, the forward bus, or other loads
 
-Note: The START battery has no CONSTANT bus. All loads connect via inline CBs at the battery (within 7" per code) or direct (ECM, grid heater via integrated fusible link).
+Note: Most START loads connect via inline CBs at the battery (within 7" per code) or direct (ECM, grid heater via integrated fusible link). The radiator fan, iBooster, and TCU were relocated off the PMU onto a **START+ Forward Distribution Bus** (engine bay), fed by a single 150A master CB at the battery — see `index.md#start-forward-bus` and STANDARDS-EXCEPTIONS.md.
 
 ## Cross-Section References
 

--- a/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
+++ b/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
@@ -15,25 +15,47 @@ The START battery (driver rear wheel well) provides power for critical engine an
 
 1. **Direct high-current** → Starter (no CB), alternator charging input (no CB)
 2. **Circuit breaker protected** → PMU (250A CB), BCDC (80A CB)
-3. **Direct low-current** → ECM, grid heater (fusible link protection)
+3. **[START+ Forward Distribution Bus](#start-forward-bus)** (150A master CB → single feed → engine-bay busbar) → radiator fan (60A), iBooster main (50A), TCU (25A) — relocated off the PMU
+4. **Direct low-current** → ECM, grid heater (fusible link protection)
 
 See [Circuit Breakers][circuit-breakers] for complete CB specifications. All CBs mounted in rear wheel well within 7" of battery (code compliant).
 
 !!! info "Single Source of Truth"
 This page is the authoritative source for all START battery wire specs (gauge, distance, voltage drop). Component pages reference here. For battery specs see [Section 1.1][batteries]. For ground bus bars see [Section 1.5][grounding].
 
-## START battery Positive Terminal (6 connections)
+## START battery Positive Terminal (7 connections)
 
 | Circuit                    | Destination          | Wire Gauge  | Distance | Current  | Voltage Drop    | Protection   |
 | :------------------------- | :------------------- | :---------- | :------- | :------- | :-------------- | :----------- |
 | [Alternator][alternator]   | Engine bay           | 2/0 AWG     | 8 ft     | 270A     | 2.81% @ 60°C    | None         |
 | [Starter][starter]         | Engine bay           | 2/0 AWG     | 6 ft     | 400-600A | 1.9-3.9% @ 20°C | None         |
 | [PMU24][pmu]               | Engine bay           | 2/0 AWG     | ~7 ft    | 250A max | 2.4% @ 60°C     | 250A CB      |
+| [START+ Forward Dist Bus](#start-forward-bus) | Engine bay | 2 AWG | ~8 ft | ~108A peak | 1.3% @ 60°C | 150A master CB |
 | ECM                        | Engine bay           | Per Cummins | Short    | <5A      | Negligible      | Fusible link |
 | [Grid Heater][grid-heater] | Engine bay           | Per Cummins | Short    | ~80A     | Negligible      | Fusible link |
 | [BCDC Alpha 50][bcdc]      | Passenger rear wheel well | 4 AWG       | ~6 ft    | 50A      | 0.94% @ 20°C    | 80A CB       |
 
 All circuit breakers mounted within 7" of battery (ABYC/NEC compliant). See [Circuit Breakers][circuit-breakers].
+
+## START+ Forward Distribution Bus {#start-forward-bus}
+
+The radiator fan, iBooster, and TCU were relocated off the PMU onto START-direct power. All three sit forward (engine bay / transmission) while the START battery is in the rear wheel well, so — mirroring the [AUX forward-feed architecture][constant-bus] — a **single master-protected feed** runs forward to an engine-bay busbar that fans out to the three loads on short local feeds. This keeps the long rear-to-front run to one heavy cable instead of three, and places each load's breaker near its load.
+
+**Busbar:** Blue Sea 2105 MaxiBus (250A), engine bay, insulated cover — recommended; confirm with {{ tbd(135) }}
+**Master feed:** 2 AWG, ~8 ft, 150A CB at battery post (<7")
+
+| Load | Feed (from bus) | Wire Gauge | Distance | Current | Voltage Drop | Breaker |
+| :--- | :-------------- | :--------- | :------- | :------ | :----------- | :------ |
+| [Radiator Fan][radiator-fan] | Radiator shroud | 4 AWG | short | 53A continuous | <1% @ 60°C[^fwd-bus-vdrop] | 60A |
+| [iBooster][brake-booster] main | Firewall | 8 AWG | short | 40A peak / 0.25A idle | <0.5%[^fwd-bus-vdrop] | 50A |
+| [Turbolamik TCU][transmission] | Transmission | 12 AWG | short | 15A continuous | <0.5%[^fwd-bus-vdrop] | 25A |
+
+The master feed carries the combined load (~68A continuous, ~108A brief peak); voltage drop and breaker sizing are set on that single cable.[^fwd-bus-vdrop] The iBooster's separate ignition **enable** (~5A) is sourced from the [Ignition Signal bus][ignition-signal], not this bus. Fan speed is set by a dedicated brushless-fan controller ({{ tbd(134) }}) with its own coolant sensor, independent of the PMU and J1939.
+
+!!! info "Shared forward feed — intentional tradeoff"
+    The three loads share one master feed + busbar (a passive cable, breaker, and bus bar — no active electronics), versus three independent runs from the battery. This is the same tradeoff the [AUX side][constant-bus] accepts, and is far more robust than their former shared dependency on the PMU module. Each load keeps its own breaker. See [Standards Exceptions][standards-exceptions].
+
+[^fwd-bus-vdrop]: Master feed 2 AWG @ ~108A brief peak (~68A continuous), ~8 ft, 60°C-derated (×1.2) ≈ 1.3% — sized on the combined load. Load feeds are short from the engine-bay bus, so per-load drop is negligible: fan 4 AWG @ 53A, iBooster 8 AWG @ 40A brief, TCU 12 AWG @ 15A. Final master-feed length and breaker selective-coordination pending {{ tbd(136) }} and {{ tbd(135) }}.
 
 ## START battery Negative Terminal (7 connections)
 
@@ -71,3 +93,9 @@ Radio grounds direct to battery for RF noise isolation. ECM/grid heater via Cumm
 [alternator]: ../01-power-generation/02-alternator.md
 [radios]: ../../07-communication-systems/index.md
 [circuit-breakers]: 01-circuit-breakers.md
+[radiator-fan]: ../../02-engine-systems/06-radiator-fan.md
+[brake-booster]: ../../02-engine-systems/02-brake-booster.md
+[transmission]: ../../10-drivetrain/01-transmission.md
+[ignition-signal]: ../06-ignition-signal/index.md
+[constant-bus]: ../03-aux-battery-distribution/02-constant-bus.md
+[standards-exceptions]: ../STANDARDS-EXCEPTIONS.md

--- a/docs/jeep_lj/01-power-systems/04-pmu/01-pmu-overview.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/01-pmu-overview.md
@@ -55,16 +55,16 @@ tags:
 
 | Outputs   |  Rating  | Total  |  Used  | Available |
 | :-------- | :------: | :----: | :----: | :-------: |
-| 1-10      | 25A each |   10   |   10   |     0     |
-| 11-16     | 15A each |   6    |   6    |     0     |
+| 1-10      | 25A each |   10   |   5    |     5     |
+| 11-16     | 15A each |   6    |   3    |     3     |
 | 17-24     | 7A each  |   8    |   6    |     2     |
-| **Total** |    -     | **24** | **23** |   **1**   |
+| **Total** |    -     | **24** | **14** |  **10**   |
 
-**Utilization:** 23 of 24 outputs used (96%)
+**Utilization:** 14 of 24 outputs used (58%) — 7 freed by relocating the radiator fan, iBooster, and TCU
 
-**Primary loads:** Radiator fan (OUT2+3+4: 3×25A combined), iBooster (OUT1+10: 2×25A non-adjacent), HVAC (OUT5: 25A), GMRS radio (OUT6: 25A), aux fans (OUT7+8: 2×15A), Dakota Digital (OUT9: 25A), wipers (OUT11: 15A), Ham radio (OUT12: 15A), CT4 (OUT13: 15A), winch trigger (OUT15: 15A), Turbolamik TCU (OUT16: 15A), A/C clutch (OUT17: 7A), horn (OUT18: 7A), iBooster ignition (OUT19: 7A), intercom (OUT20: 7A), brake lights (OUT21: 7A), reverse lights (OUT22: 7A), DRL/parking (OUT23: 7A)
+**Primary loads:** HVAC (OUT5: 25A), GMRS radio (OUT6: 25A), aux cooling fans (OUT7+8: 2×15A), Dakota Digital (OUT9: 25A), wipers (OUT11: 15A), CT4 (OUT13: 15A), winch trigger (OUT15: 15A), A/C clutch (OUT17: 7A), horn (OUT18: 7A), intercom (OUT20: 7A), brake lights (OUT21: 7A), reverse lights (OUT22: 7A), DRL/parking (OUT23: 7A). _Radiator fan (was OUT2+3+4), iBooster main + enable (was OUT1+10, OUT19), and Turbolamik TCU (was OUT16) relocated to the [START+ Forward Distribution Bus][start-fwd-bus] — OUT1–4, 10, 16, 19 now free._
 
-**Load:** ~253A theoretical peak (all radios transmitting + full radiator fan + iBooster braking), ~106A typical PMU circuits continuous (excluding radiator fan which varies 16-53A via PWM), total typical load ~140-170A (well within 300A PMU capacity)
+**Load:** With the radiator fan, iBooster, and TCU relocated to the START+ Forward Bus, PMU peak drops to ~145A theoretical (all radios transmitting), ~85-115A typical continuous — comfortably within the 300A PMU capacity, with 10 of 24 outputs now free.
 
 **Mounting:** Engine bay, accessible for LED diagnostics and USB configuration
 
@@ -80,6 +80,7 @@ tags:
 [pmu-outputs]: 03-pmu-outputs.md
 [pmu-programming]: 04-pmu-programming.md
 [starter-battery-distribution]: ../02-starter-battery-distribution/index.md
+[start-fwd-bus]: ../02-starter-battery-distribution/index.md#start-forward-bus
 [wire-distance]: ../01-power-generation/05-wire-distance-reference.md
 [ecumaster-pmu24]: https://www.ecumaster.com/products/pmu24/
 [pmu-manual]: https://www.ecumaster.com/files/PMU/PMU_Manual.pdf

--- a/docs/jeep_lj/01-power-systems/04-pmu/03-pmu-outputs.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/03-pmu-outputs.md
@@ -13,16 +13,16 @@ Complete configuration of all 24 PMU outputs, load allocations, and combined out
 
 | Output     | Circuit                      | Load     | Ground                                                | Control Type       | Notes                          |
 | :--------- | :--------------------------- | :------- | :---------------------------------------------------- | :----------------- | :----------------------------- |
-| **Out 1**  | **iBooster Main (combined)** | Combined | [Engine Bay Bus][engine-ground] Stud 7                | CONSTANT           | Combined with OUT10, 40A peak  |
-| **Out 2**  | **Radiator Fan (combined)**  | Combined | Fan housing → engine block                            | PWM (CAN temp)     | Combined with OUT3+4, 53A max  |
-| **Out 3**  | **Radiator Fan (combined)**  | Combined | Fan housing → engine block                            | PWM (CAN temp)     | Combined with OUT2+4           |
-| **Out 4**  | **Radiator Fan (combined)**  | Combined | Fan housing → engine block                            | PWM (CAN temp)     | Combined with OUT2+3           |
+| **Out 1**  | **[Available]**             | -        | -                                                     | -                  | Freed — iBooster relocated to [START+ Forward Bus][start-fwd-bus] |
+| **Out 2**  | **[Available]**             | -        | -                                                     | -                  | Freed — radiator fan relocated to [START+ Forward Bus][start-fwd-bus] |
+| **Out 3**  | **[Available]**             | -        | -                                                     | -                  | Freed — radiator fan relocated     |
+| **Out 4**  | **[Available]**             | -        | -                                                     | -                  | Freed — radiator fan relocated     |
 | **Out 5**  | HVAC Blower Motor            | ~20A     | Factory HVAC ground                                   | Auto (ignition ON) | See [HVAC System][hvac-system] |
 | **Out 6**  | GMRS Radio (Midland G1)      | 15A      | [Direct START battery-][starter-battery-distribution] | CONSTANT           | RF noise isolation             |
 | **Out 7**  | Oil Cooler Fan               | ~15A     | [Engine Bay Bus][engine-ground] Stud 8                | Auto (CAN temp)    | SPN 175 oil temp trigger       |
 | **Out 8**  | PS Cooler Fan                | ~15A     | [Engine Bay Bus][engine-ground] Stud 8                | 180°F inline thermostat | Mishimoto PS cooler fan; thermostat-switched on PS fluid temp (not engine coolant) |
 | **Out 9**  | Dakota Digital System        | ~25A     | [Firewall Stud Bus][firewall-ground] T4-5             | CONSTANT           | Cluster + 4 BIM modules        |
-| **Out 10** | **iBooster Main (combined)** | Combined | [Engine Bay Bus][engine-ground] Stud 7                | CONSTANT           | Combined with OUT1             |
+| **Out 10** | **[Available]**             | -        | -                                                     | -                  | Freed — iBooster relocated to [START+ Forward Bus][start-fwd-bus] |
 
 ### 15A High-Side Outputs (OUT11-OUT16)
 
@@ -33,7 +33,7 @@ Complete configuration of all 24 PMU outputs, load allocations, and combined out
 | **Out 13** | Command Touch CT4         | ~9A  | [Firewall Stud Bus][firewall-ground] T1               | CONSTANT             | Turn signals, headlights, hazards             |
 | **Out 14** | **[Available]**           | -    | -                                                     | -                    | Future expansion (15A)                        |
 | **Out 15** | Winch Contactor Trigger   | 1A   | Via winch contactor                                   | Manual (dash rocker) | Control signal only                           |
-| **Out 16** | Turbolamik TCU            | 15A  | Engine bay ground bus                                 | CONSTANT             | 8HP70 transmission controller                 |
+| **Out 16** | **[Available]**           | -    | -                                                     | -                    | Freed — TCU relocated to [START+ Forward Bus][start-fwd-bus] |
 
 ### 7A High-Side Outputs (OUT17-OUT24)
 
@@ -43,7 +43,7 @@ Complete configuration of all 24 PMU outputs, load allocations, and combined out
 | :--------- | :----------------------- | :--- | :---------------------------------------------------- | :------------------ | :----------------------------- |
 | **Out 17** | A/C Clutch               | 3-5A | Factory A/C ground                                    | Auto (A/C request)  | See [HVAC System][hvac-system] |
 | **Out 18** | Horn                     | 5.4A | [Engine Bay Bus][engine-ground] Stud 6                | External input      | PIAA horns (2.7A × 2)          |
-| **Out 19** | iBooster Ignition Signal | ~5A  | [Engine Bay Bus][engine-ground] Stud 7                | Auto (ignition RUN) | Same ground as iBooster main   |
+| **Out 19** | **[Available]**          | -    | -                                                     | -                   | Freed — iBooster enable now on ignition bus    |
 | **Out 20** | STX Intercom             | ~5A  | [Direct START battery-][starter-battery-distribution] | Auto (ignition ON)  | RF noise isolation             |
 | **Out 21** | Brake Lights             | ~3A  | [SwitchPros Ground Bus][switchpros-ground]            | External input      | Shared tail light ground       |
 | **Out 22** | Reverse Lights           | ~5A  | [SwitchPros Ground Bus][switchpros-ground]            | External input      | Maxbilt + Squadron Sport       |
@@ -52,9 +52,7 @@ Complete configuration of all 24 PMU outputs, load allocations, and combined out
 
 ## Combined Outputs
 
-**Radiator Fan (OUT2+3+4):** GM Camaro electric fan, 53A @ full speed, 3×25A outputs paralleled = 75A capacity, PWM variable speed control
-
-**iBooster Main (OUT1+10):** Bosch Gen 2, 40A peak, 2×25A outputs paralleled (non-adjacent) = 46A @ 40°C capacity, CONSTANT power
+_The radiator fan (formerly OUT2+3+4) and iBooster main (formerly OUT1+10) were relocated to the [START+ Forward Distribution Bus][start-fwd-bus]. No PMU outputs are currently combined; OUT1–4, OUT10, OUT16, and OUT19 are now free (7 spare outputs). The combining rules below are retained for any future high-current output._
 
 **Combining Rules:**
 
@@ -72,8 +70,7 @@ Complete configuration of all 24 PMU outputs, load allocations, and combined out
 
 | Outputs     | Load             | Terminal Rating                          | Utilization @ 40°C            | Status      | Notes                                                                     |
 | :---------- | :--------------- | :--------------------------------------- | :---------------------------- | :---------- | :------------------------------------------------------------------------ |
-| **OUT1+10** | 40A peak (brief) | 46A @ 40°C (non-adjacent)<br/>50A @ 23°C | 87% @ 40°C peak<br/>1% @ idle | ✓ EXCELLENT | iBooster - non-adjacent combining eliminates thermal concerns, 0.25A idle |
-| **OUT5**    | 20A continuous   | 23A (single @ 40°C)                      | 87%                           | ✓ OK        | HVAC blower - relocated from OUT1, same thermal margin                    |
+| **OUT5**    | 20A continuous   | 23A (single @ 40°C)                      | 87%                           | ✓ OK        | HVAC blower - now the largest continuous PMU load after fan/iBooster relocation |
 | **OUT11**   | 15A continuous   | 19A (1.5mm terminal)                     | 79%                           | ✓ OK        | Wiper controller - avoid adjacent high-current load on OUT12              |
 
 **Installation Notes:**
@@ -104,6 +101,7 @@ Complete configuration of all 24 PMU outputs, load allocations, and combined out
 [pmu-inputs]: 02-pmu-inputs.md
 [pmu-programming]: 04-pmu-programming.md
 [starter-battery-distribution]: ../02-starter-battery-distribution/index.md
+[start-fwd-bus]: ../02-starter-battery-distribution/index.md#start-forward-bus
 [engine-ground]: ../05-grounding/01-engine-bay-ground-bus.md
 [firewall-ground]: ../05-grounding/02-firewall-stud-bus.md
 [switchpros-ground]: ../05-grounding/03-switchpros-ground-bus.md

--- a/docs/jeep_lj/01-power-systems/04-pmu/04-pmu-programming.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/04-pmu-programming.md
@@ -49,23 +49,9 @@ ELSEIF (J1939_SPN110_CoolantTemp < 210°F) THEN Out8_PSFan = OFF
 
 10°F hysteresis prevents rapid cycling. Uses J1939 coolant temperature from ECM (SPN 110) as proxy for PS fluid temp.
 
-### Radiator Fan PWM Control (Output 2+3+4) - Variable Speed
+### Radiator Fan Control — relocated off the PMU
 
-```text
-// Temperature-based PWM curve for variable speed control
-IF (J1939_SPN110_CoolantTemp < 185°F) THEN Out234_RadiatorFan_PWM = 0%      // Fan OFF
-ELSEIF (J1939_SPN110_CoolantTemp < 195°F) THEN Out234_RadiatorFan_PWM = 30%  // Low speed
-ELSEIF (J1939_SPN110_CoolantTemp < 205°F) THEN Out234_RadiatorFan_PWM = 60%  // Medium speed
-ELSEIF (J1939_SPN110_CoolantTemp >= 205°F) THEN Out234_RadiatorFan_PWM = 100% // Full speed
-```
-
-**Benefits:**
-
-- **Variable speed:** 30% = ~16A, 60% = ~32A, 100% = 53A - reduces average electrical load
-- **PWM frequency:** 100-400 Hz (PMU supports 4-400 Hz on 25A outputs)
-- **Temperature source:** J1939 SPN 110 (coolant temp) - same as PS fan
-- **Quieter operation:** Low speed sufficient for highway cruising
-**Replaces:** Dakota Digital PAC-2800BT controller, BIM-01-2 adapter (for fan), external relay, 100A circuit breaker
+The radiator fan no longer runs on PMU outputs. It is powered START-direct from the [START+ Forward Distribution Bus][start-fwd-bus] and speed-controlled by a dedicated brushless-fan controller with its own coolant sensor, independent of the PMU and J1939 — see [Radiator Fan][radiator-fan]. The controller commands **full speed on lost/invalid sensor signal** (the former PMU/CAN PWM path defaulted the fan OFF on lost coolant-temp data — the failure mode this relocation closes).
 
 ### Sequential Load Startup
 
@@ -149,4 +135,6 @@ IF (BatteryVoltage < 12.5V) AND (EngineRPM > 1000)
 [pmu-outputs]: 03-pmu-outputs.md
 [arb-load-shedding]: 05-pmu-arb-load-shedding.md
 [starter-battery-distribution]: ../02-starter-battery-distribution/index.md
+[start-fwd-bus]: ../02-starter-battery-distribution/index.md#start-forward-bus
+[radiator-fan]: ../../02-engine-systems/06-radiator-fan.md
 [gauge-cluster]: ../../02-engine-systems/09-gauge-cluster/index.md

--- a/docs/jeep_lj/01-power-systems/04-pmu/CLAUDE.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/CLAUDE.md
@@ -45,7 +45,7 @@ Documents ECUMaster PMU24 programmable power management unit configuration and a
 
 **To START battery (1.2):** PMU power source via circuit breaker
 
-**To Engine Systems (2):** Radiator fan, HVAC blower, starter relay, wipers, horn
+**To Engine Systems (2):** HVAC blower, wipers, horn (radiator fan, iBooster, and TCU relocated to the START+ Forward Distribution Bus — no longer PMU)
 
 **To Lighting (3):** DRL, brake lights, reverse lights
 

--- a/docs/jeep_lj/01-power-systems/05-grounding/01-engine-bay-ground-bus.md
+++ b/docs/jeep_lj/01-power-systems/05-grounding/01-engine-bay-ground-bus.md
@@ -42,7 +42,7 @@ tags:
 | 4    | AUX battery reference           | 1/0 AWG     | 75A       | See [START Battery Distribution][front-battery-ground] |
 | 5    | PMU ground reference (Pin 25)   | Per harness | <100mA    | Logic/CAN reference only                               |
 | 6    | Horn + relay coil grounds       | 14-18 AWG   | ~10A      | Horn (5.4A), starter solenoid coil                     |
-| 7    | iBooster (OUT1+10, OUT19)       | 10 AWG      | ~45A peak | Brake booster main + ignition signal                   |
+| 7    | iBooster (main + enable)        | 10 AWG      | ~45A peak | Brake booster (START-direct, off PMU); dedicated/redundant ground recommended |
 | 8    | Aux cooling fans (OUT7+8)       | 12 AWG      | ~30A      | Oil cooler + PS cooler fans                            |
 
 **Utilization:** 8 of 8 studs used (0 available)

--- a/docs/jeep_lj/01-power-systems/06-ignition-signal/index.md
+++ b/docs/jeep_lj/01-power-systems/06-ignition-signal/index.md
@@ -35,6 +35,8 @@ The bus bar's outbound feed to engine-bay consumers (ECM 12V supply, PMU Pin 7) 
 
     - **PMU 12V Switched Input (Physical Pin 7):** Wire tapped from the bus bar engine-bay distribution stud - see [PMU Inputs][pmu-inputs]
     - **Cummins ECM 12V Supply:** Wire tapped from the same engine-bay distribution stud
+    - **Turbolamik TCU wake:** Low-current tap from the same engine-bay distribution stud - see [Transmission][transmission]
+    - **iBooster Enable:** ~5A on its own ignition-bus terminal + **own 7.5A fuse** (not the ECM 5A feed) and its own firewall pin - see [Brake Booster][brake-booster]
     - **Starter Control:** PBS-I PURPLE START output (separate firewall Pin 15) → Cole Hersee 24213 - see [Starter System][starter-system] and [Keyless Ignition][keyless-ignition]
 
     **Note:** PMU "Pin 7" (physical connector pin for 12V switched power) is different from PMU "In 7" (digital input channel #7 used for CT4 headlight status).
@@ -52,15 +54,15 @@ The bus bar's outbound feed to engine-bay consumers (ECM 12V supply, PMU Pin 7) 
 | Stud/Terminal           | Connection                | Wire Gauge   | Distance              | Max Current     | Notes                                              |
 | :---------------------- | :------------------------ | :----------- | :-------------------- | :-------------- | :------------------------------------------------- |
 | **Stud 1 (5/16")**      | **PBS-I PINK IGN (INPUT)** | **14 AWG ✓** | **~2 ft (cabin local)** | **~5A total**   | No firewall crossing; PBS-I onboard 60A relay protects |
-| Stud 2 (5/16")          | **Engine-bay outbound (OUTPUT)** | 14 AWG ✓     | Through firewall (HDP24 Pin 12) | ~5A peak     | **5A inline fuse required at this stud** per Cummins R2.8 install manual; feeds ECM Pin 41 (black, keyswitch) + PMU Pin 7 |
+| Stud 2 (5/16")          | **Engine-bay outbound (OUTPUT)** | 14 AWG ✓     | Through firewall (HDP24 Pin 12) | ~5A peak     | **5A inline fuse required at this stud** per Cummins R2.8 install manual; feeds ECM Pin 41 (black, keyswitch) + PMU Pin 7 + Turbolamik TCU wake (low current) |
 | Terminal 1 (#10-24)     | Command Touch CT4         | 18 AWG ✓     | ~3 ft                 | ~20mA           | Ignition sense for turn signal auto-cancel         |
 | Terminal 2 (#10-24)     | SwitchPros SP-1200        | 18 AWG ✓     | ~4 ft                 | ~20mA           | Pin 3 (Lt Blue) - ignition sense                   |
 | Terminal 3 (#10-24)     | Fusion MS-RA670 Radio     | 18 AWG ✓     | ~2 ft                 | ~20mA           | Yellow wire - ignition sense                       |
 | Terminal 4 (#10-24)     | BCDC Alpha 50             | 18 AWG ✓     | ~12 ft                | ~20mA           | Blue wire - activates charging when engine running |
-| Terminal 5 (#10-24)     | **\[Available\]**           | -            | -                     | -               | Future ignition-switched device                    |
+| Terminal 5 (#10-24)     | **iBooster Enable**       | 16 AWG ✓     | ~10 ft (own HDP24 pin) | ~5A             | iBooster ignition enable; **own 7.5A inline fuse** (not shared with the ECM 5A feed); crosses firewall |
 | Terminals 6-12 (#10-24) | **\[Available\]**           | -            | -                     | -               | Future expansion (7 terminals)                     |
 
-**Utilization:** 6 of 14 used (2 studs + 4 terminals used, 0 studs + 8 terminals available)
+**Utilization:** 7 of 14 used (2 studs + 5 terminals used, 0 studs + 7 terminals available)
 
 ## Mounting
 
@@ -82,3 +84,5 @@ The bus bar's outbound feed to engine-bay consumers (ECM 12V supply, PMU Pin 7) 
 [bcdc]: ../01-power-generation/03-bcdc.md
 [keyless-ignition]: ../../05-control-interfaces/06-keyless-ignition.md
 [starter-system]: ../../02-engine-systems/01-starter.md
+[transmission]: ../../10-drivetrain/01-transmission.md
+[brake-booster]: ../../02-engine-systems/02-brake-booster.md

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/02-firewall-ingress.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/02-firewall-ingress.md
@@ -78,10 +78,14 @@ Pin 12 carries the PBS-I PINK IGN ignition signal; the keyswitch was removed whe
 | 15 | PURPLE START | 16 AWG | PBS-I PURPLE START output | Cole Hersee 24213 coil | #16 |
 | 16 | Winch control IN | 18 AWG | Dash rocker switch | Winch contactor | #16 |
 | 17 | Winch control OUT | 18 AWG | Dash rocker switch | Winch contactor | #16 |
+| 18 | iBooster enable | 16 AWG | Ignition bus Term 5 (own 7.5A fuse) | iBooster ignition input | #16 |
 
-### Available (13 spare pins)
+!!! note "Relocated power feeds do NOT use this connector"
+    The radiator fan (4 AWG), iBooster main (8 AWG), and TCU (12 AWG) feeds — relocated off the PMU — run from the [START+ Forward Distribution Bus][start-fwd-bus] in the engine bay to their loads, entirely engine-bay-side. Only the low-current **iBooster enable** (Pin 18 above) crosses the firewall.
 
-Pins 18-29 + pin 2 (legacy spare) reserved for future non-SwitchPros circuits. The former Boomerang fob-present and gated-start pins were dropped when the PBS-I self-contained keyless system replaced the Boomerang/PMU keyless approach — PBS-I needs no firewall pins beyond PINK IGN (pin 12) and PURPLE START (pin 15).
+### Available (12 spare pins)
+
+Pins 19-29 + pin 2 (legacy spare) reserved for future non-SwitchPros circuits. The former Boomerang fob-present and gated-start pins were dropped when the PBS-I self-contained keyless system replaced the Boomerang/PMU keyless approach — PBS-I needs no firewall pins beyond PINK IGN (pin 12), PURPLE START (pin 15), and the iBooster enable (pin 18).
 
 ---
 
@@ -183,9 +187,9 @@ Radio grounds do NOT go through firewall - they route through cab floor to START
 | Gauge | Count | Circuits |
 |:------|:-----:|:---------|
 | 14 AWG | 7 | Radio power (2), CT4 outputs (4), PBS-I PINK IGN (1) |
-| 16 AWG | 4 | PMU lighting outputs (3), PURPLE START (1) |
+| 16 AWG | 5 | PMU lighting outputs (3), PURPLE START (1), iBooster enable (1) |
 | 18 AWG | 5 | Switch signals (3: horn, brake, A/C), winch control (2) |
-| **Main connector** | **16** | HDP24-24-29 (16 of 29 used, 13 spare; exact count pending final recount) |
+| **Main connector** | **17** | HDP24-24-29 (17 of 29 used, 12 spare; exact count pending final recount) |
 
 ### SwitchPros HDP24-18-14 (forward SP outputs)
 
@@ -338,6 +342,7 @@ PMU In 7 receives the headlight status signal from this tap, enabling DRL auto-o
 - [Intercom][intercom] - STX power routing
 
 [wire-routing]: index.md
+[start-fwd-bus]: ../02-starter-battery-distribution/index.md#start-forward-bus
 [tbd-tracker]: ../../tbd-tracker.md
 [keyless-ignition]: ../../05-control-interfaces/06-keyless-ignition.md
 [pmu-outputs]: ../04-pmu/03-pmu-outputs.md

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/06-harness-controls-recovery-drivetrain.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/06-harness-controls-recovery-drivetrain.md
@@ -130,7 +130,7 @@ See [Transmission][transmission] for shifter and TCU specs.
 
 | Wire | Gauge | Color | Function | Source | Destination |
 |:-----|:-----:|:-----:|:---------|:-------|:------------|
-| TCU power feed | 14 AWG | Red | PMU OUT16 (CONSTANT, 15A) → TCU power input | PMU OUT16 (engine bay) | TCU power terminal |
+| TCU power feed | 12 AWG | Red | START+ Forward Dist Bus (25A CB, CONSTANT, 15A) → TCU power input | START+ Forward Dist Bus (engine bay) | TCU power terminal |
 | J1939 CAN High | Twisted pair | Twisted pair (CAN) | Shared J1939 bus tap (same tap as PMU, Dakota Digital BIM-01-2) | CAN bus tap point | TCU CAN-H |
 | J1939 CAN Low | Twisted pair (paired with CAN High) | Twisted pair (CAN) | Shared J1939 bus tap | CAN bus tap point | TCU CAN-L |
 | Aux out (Reverse) | 18 AWG | Builder's choice | TCU aux output: 12V when shifter in R → PMU In 3 (drives PMU OUT22 reverse lights) | TCU aux Reverse pin | PMU In 3 |

--- a/docs/jeep_lj/01-power-systems/08-load-analysis/02-start-battery.md
+++ b/docs/jeep_lj/01-power-systems/08-load-analysis/02-start-battery.md
@@ -14,8 +14,6 @@ All circuits powered by START battery (alternator charging):
 | Source           | Circuit           | Typical |     Peak | Duty Cycle             | Notes                 |
 | :--------------- | :---------------- | ------: | -------: | :--------------------- | :-------------------- |
 | **PMU Outputs**  |                   |         |          |                        |                       |
-| OUT1+10          | iBooster          |   0.25A |      40A | Seconds during braking | Non-adjacent combined |
-| OUT2+3+4         | Radiator Fan      |     20A |      53A | Variable PWM           | 3× combined outputs   |
 | OUT5             | HVAC Blower       |     10A |      20A | Continuous when on     | Speed-dependent       |
 | OUT6             | GMRS Radio        |      1A |      15A | Brief TX bursts        | Standby vs transmit   |
 | OUT7             | Oil Cooler Fan    |      0A |      15A | Temp-triggered         | Off unless hot        |
@@ -26,17 +24,24 @@ All circuits powered by START battery (alternator charging):
 | OUT15            | Winch Trigger     |      0A |       1A | Recovery only          | Control signal only   |
 | OUT17            | A/C Clutch        |      0A |       5A | Summer only            | Seasonal              |
 | OUT18            | Horn              |      0A |     5.4A | Seconds                | Emergency only        |
-| OUT19            | iBooster Ignition |      5A |       5A | Continuous             | Ignition signal       |
 | OUT20            | STX Intercom      |      1A |       5A | Brief TX bursts        | Standby vs transmit   |
 | OUT21            | Brake Lights      |      0A |       3A | Seconds during braking | Traffic-dependent     |
 | OUT22            | Reverse Lights    |      0A |       3A | Seconds in reverse     | Parking only          |
 | OUT23            | DRL               |    2.6A |     2.6A | Daytime only           | Auto-off at night     |
+| **Fwd Dist Bus (START-direct)** | |       |          |                        | relocated off the PMU |
+| Fwd Bus          | iBooster main     |   0.25A |      40A | Seconds during braking | Brief peak            |
+| Fwd Bus          | Radiator Fan      |     20A |      53A | Variable (own controller) | Dedicated fan controller |
+| Fwd Bus          | Turbolamik TCU    |     15A |      15A | Continuous             | Must stay on          |
+| Ign bus          | iBooster Enable   |      5A |       5A | Continuous             | Ignition-switched     |
 | **BCDC Charger** |                   |         |          |                        |                       |
 | -                | BCDC to AUX       |     30A |      50A | Continuous             | Charges AUX battery   |
 | **Direct Loads** |                   |         |          |                        |                       |
 | -                | Starter           |      0A | 400-600A | 3-5 seconds            | Cranking only         |
 | -                | ECM               |     ~2A |      ~5A | Continuous             | Engine management     |
 | -                | Grid Heater       |      0A |     250A | 3-5 seconds            | Cold start only       |
+
+!!! info "Forward Distribution Bus relocation — totals unchanged"
+    The radiator fan, iBooster, and TCU now feed START-direct via the [Forward Distribution Bus][start-fwd-bus] instead of the PMU. Because they were *already* powered by the START battery through the PMU, the battery and alternator totals are unchanged — only the distribution path moved. The TCU (~15A continuous) is now itemized separately; folding it into the scenarios below raises the worst realistic case from 201A to ~216A (80% of the 270A alternator) — still within margin.
 
 ## Scenario Analysis
 
@@ -46,8 +51,8 @@ All circuits powered by START battery (alternator charging):
 
 | Circuit                       |      Load | Reason                      |
 | :---------------------------- | --------: | :-------------------------- |
-| **iBooster (OUT1+10)**        | **0.25A** | Idle - no braking           |
-| **Radiator Fan (OUT2+3+4)**   |   **16A** | Low speed - highway airflow |
+| **iBooster (Fwd Bus)**        | **0.25A** | Idle - no braking           |
+| **Radiator Fan (Fwd Bus)**   |   **16A** | Low speed - highway airflow |
 | **HVAC Blower (OUT5)**        |   **10A** | Medium speed                |
 | **GMRS Radio (OUT6)**         |    **1A** | Standby                     |
 | Oil Cooler Fan (OUT7)         |        0A | Temp normal                 |
@@ -55,7 +60,7 @@ All circuits powered by START battery (alternator charging):
 | **Dakota Digital (OUT9)**     |   **25A** | Always on                   |
 | Wiper (OUT11)                 |        0A | Dry weather                 |
 | **CT4 (OUT13)**               |   **10A** | Running lights              |
-| **iBooster Ignition (OUT19)** |    **5A** | Always on                   |
+| **iBooster Enable (ign bus)** |    **5A** | Always on                   |
 | **STX Intercom (OUT20)**      |    **1A** | Standby                     |
 | **DRL (OUT23)**               |    **2.6A** | Daytime                     |
 | **BCDC Charger**              |   **30A** | Maintaining AUX             |
@@ -71,8 +76,8 @@ All circuits powered by START battery (alternator charging):
 
 | Circuit                       |     Load | Reason                       |
 | :---------------------------- | -------: | :--------------------------- |
-| **iBooster (OUT1+10)**        |   **5A** | Average - frequent braking   |
-| **Radiator Fan (OUT2+3+4)**   |  **42A** | High speed - no airflow, hot |
+| **iBooster (Fwd Bus)**        |   **5A** | Average - frequent braking   |
+| **Radiator Fan (Fwd Bus)**   |  **42A** | High speed - no airflow, hot |
 | **HVAC Blower (OUT5)**        |  **20A** | Max speed for A/C            |
 | **GMRS Radio (OUT6)**         |   **1A** | Standby                      |
 | **Oil Cooler Fan (OUT7)**     |  **15A** | Hot - active                 |
@@ -81,7 +86,7 @@ All circuits powered by START battery (alternator charging):
 | Wiper (OUT11)                 |       0A | Dry weather                  |
 | **CT4 (OUT13)**               |  **10A** | Running lights               |
 | **A/C Clutch (OUT17)**        |   **5A** | A/C on                       |
-| **iBooster Ignition (OUT19)** |   **5A** | Always on                    |
+| **iBooster Enable (ign bus)** |   **5A** | Always on                    |
 | **STX Intercom (OUT20)**      |   **1A** | Standby                      |
 | **Brake Lights (OUT21)**      |   **1A** | Average - traffic            |
 | **DRL (OUT23)**               |   **2.6A** | Daytime                      |
@@ -98,8 +103,8 @@ All circuits powered by START battery (alternator charging):
 
 | Circuit                       |     Load | Reason                            |
 | :---------------------------- | -------: | :-------------------------------- |
-| **iBooster (OUT1+10)**        |   **2A** | Occasional braking                |
-| **Radiator Fan (OUT2+3+4)**   |  **53A** | Max speed - no airflow            |
+| **iBooster (Fwd Bus)**        |   **2A** | Occasional braking                |
+| **Radiator Fan (Fwd Bus)**   |  **53A** | Max speed - no airflow            |
 | **HVAC Blower (OUT5)**        |  **15A** | Moderate                          |
 | **GMRS Radio (OUT6)**         |   **5A** | Occasional TX                     |
 | **Oil Cooler Fan (OUT7)**     |  **15A** | Hot - active                      |
@@ -107,7 +112,7 @@ All circuits powered by START battery (alternator charging):
 | **Dakota Digital (OUT9)**     |  **25A** | Always on                         |
 | Wiper (OUT11)                 |       0A | Dry                               |
 | **CT4 (OUT13)**               |  **10A** | Running lights                    |
-| **iBooster Ignition (OUT19)** |   **5A** | Always on                         |
+| **iBooster Enable (ign bus)** |   **5A** | Always on                         |
 | **STX Intercom (OUT20)**      |   **3A** | Occasional TX                     |
 | **DRL (OUT23)**               |   **2.6A** | Daytime                           |
 | **BCDC Charger**              |  **50A** | Full rate - supporting SwitchPros |
@@ -125,8 +130,8 @@ All circuits powered by START battery (alternator charging):
 
 | Circuit                       |     Load | Reason                   |
 | :---------------------------- | -------: | :----------------------- |
-| **iBooster (OUT1+10)**        |  **40A** | Peak braking assist      |
-| **Radiator Fan (OUT2+3+4)**   |  **20A** | Normal - highway airflow |
+| **iBooster (Fwd Bus)**        |  **40A** | Peak braking assist      |
+| **Radiator Fan (Fwd Bus)**   |  **20A** | Normal - highway airflow |
 | **HVAC Blower (OUT5)**        |  **15A** | Defrost                  |
 | **GMRS Radio (OUT6)**         |   **1A** | Standby                  |
 | Oil Cooler Fan (OUT7)         |       0A | Temp normal              |
@@ -134,7 +139,7 @@ All circuits powered by START battery (alternator charging):
 | **Dakota Digital (OUT9)**     |  **25A** | Always on                |
 | **Wiper (OUT11)**             |  **15A** | High speed               |
 | **CT4 (OUT13)**               |  **10A** | Headlights               |
-| **iBooster Ignition (OUT19)** |   **5A** | Always on                |
+| **iBooster Enable (ign bus)** |   **5A** | Always on                |
 | **STX Intercom (OUT20)**      |   **1A** | Standby                  |
 | **Brake Lights (OUT21)**      |   **3A** | Braking                  |
 | DRL (OUT23)                   |       0A | Off - headlights on      |
@@ -153,8 +158,8 @@ All circuits powered by START battery (alternator charging):
 
 | Circuit                       |      Load | Reason                |
 | :---------------------------- | --------: | :-------------------- |
-| **iBooster (OUT1+10)**        | **0.25A** | Idle                  |
-| **Radiator Fan (OUT2+3+4)**   |   **35A** | Moderate - no airflow |
+| **iBooster (Fwd Bus)**        | **0.25A** | Idle                  |
+| **Radiator Fan (Fwd Bus)**   |   **35A** | Moderate - no airflow |
 | **HVAC Blower (OUT5)**        |   **10A** | Comfortable           |
 | **GMRS Radio (OUT6)**         |    **1A** | Standby               |
 | Oil Cooler Fan (OUT7)         |        0A | Temp stable           |
@@ -163,7 +168,7 @@ All circuits powered by START battery (alternator charging):
 | Wiper (OUT11)                 |        0A | Off                   |
 | **CT4 (OUT13)**               |   **10A** | Parking lights        |
 | **A/C Clutch (OUT17)**        |    **5A** | If summer             |
-| **iBooster Ignition (OUT19)** |    **5A** | Always on             |
+| **iBooster Enable (ign bus)** |    **5A** | Always on             |
 | **STX Intercom (OUT20)**      |    **1A** | Standby               |
 | DRL (OUT23)                   |        0A | Off - parked          |
 | **BCDC Charger**              |   **30A** | Normal rate           |
@@ -183,7 +188,7 @@ All circuits powered by START battery (alternator charging):
 | Emergency Braking | 165A       | 270A       | 61%         | Excellent |
 | Parked Idling     | 122A       | 270A       | 45%         | Excellent |
 
-**Worst Realistic Case:** 201A (offroad with hot engine) = **69A margin**
+**Worst Realistic Case:** 201A (offroad with hot engine), or ~216A including the now-itemized TCU = **54-69A margin**
 
 **Key Insight:** All realistic scenarios stay well within alternator capacity. The 270A alternator provides adequate margin for all operating conditions.
 
@@ -226,6 +231,7 @@ Loads on the **CONSTANT** (always-on) feed continue to draw with the ignition of
 - [AUX Battery Load Analysis][aux-load-analysis] - Companion analysis for AUX battery
 
 [alternator]: ../01-power-generation/02-alternator.md
+[start-fwd-bus]: ../02-starter-battery-distribution/index.md#start-forward-bus
 [pmu-outputs]: ../04-pmu/03-pmu-outputs.md
 [bcdc]: ../01-power-generation/03-bcdc.md
 [aux-load-analysis]: 03-aux-battery.md

--- a/docs/jeep_lj/01-power-systems/CLAUDE.md
+++ b/docs/jeep_lj/01-power-systems/CLAUDE.md
@@ -45,7 +45,7 @@ Ignition sense signal to CT4, SwitchPros, Fusion Radio, BCDC
 
 | Section                | Power Connection                               | Find In                     |
 | :--------------------- | :--------------------------------------------- | :-------------------------- |
-| Engine Systems (2)     | HVAC→OUT5, Fan→OUT2+3+4, Starter direct        | `02-engine-systems/`        |
+| Engine Systems (2)     | HVAC→OUT5; Fan/iBooster/TCU→START+ Fwd Bus; Starter direct | `02-engine-systems/`        |
 | Lighting (3)           | DRL→OUT23, Brake→OUT21, Reverse→OUT22          | `03-lighting-systems/`      |
 | Control Interfaces (4) | CT4→OUT13, Dakota→OUT9, SwitchPros→AUX 150A CB | `05-control-interfaces/`    |
 | Audio (5)              | Fusion→BODY PDU                                | `06-audio-systems/`         |

--- a/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
+++ b/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
@@ -413,6 +413,30 @@ No additional CB required at BCDC - entire circuit protected from battery termin
 
 ---
 
+## START+ Forward Distribution Bus - Bus Bar Between Battery and Loads
+
+**Components:** START+ Forward Distribution Bus (engine bay) feeding the relocated radiator fan, iBooster, and TCU
+
+**Decision:** A single 150A master-protected 2 AWG feed runs from the START battery to an engine-bay busbar that fans out to three load breakers — a deliberate departure from the START-side "direct lugs, no bus bar between battery and loads" principle.
+
+### Engineering Rationale
+
+- The radiator fan, iBooster, and TCU were moved off the PMU and all sit forward (engine bay / transmission), while the START battery is in the rear wheel well.
+- Three independent feeds would mean three long rear-to-front cables and ~9 stacked lugs on the battery post (impractical, hard to service).
+- A single master feed + forward busbar mirrors the proven AUX-side two-stage architecture (300A master → firewall CONSTANT bus), placing each load's breaker near its load.
+- The intermediate bus is a passive bar; the feed is protected by a 150A master breaker within 7" of the battery (the cable is never unprotected), with selective coordination to the downstream load breakers.
+
+### Review Guidance
+
+**This is intentional.** Do NOT flag the START+ Forward Distribution Bus as violating the "no bus bar between battery and loads" rule — it is the same accepted tradeoff as the AUX CONSTANT bus, chosen to relocate three critical loads off the PMU. See {{ tbd(135) }} for final busbar/breaker selection.
+
+**Documentation References:**
+
+- [START Battery Distribution][starter-battery-distribution] - Forward bus feed and load table
+- [START Battery Circuit Breakers][starter-cbs] - Master + load breakers
+
+---
+
 ## SwitchPros & SafetyHub - CB Sized for Device Capacity
 
 **Components:** SwitchPros RCR-Force 12, Blue Sea SafetyHub 150
@@ -544,6 +568,7 @@ Before flagging as issues, verify these intentional design choices:
 - [ ] **Grid Heater:** Direct battery connection with fusible link (brief high current)
 - [ ] **Alternator:** No CB on output (standard automotive practice)
 - [ ] **BCDC:** CB at battery terminal (no CB at BCDC end required)
+- [ ] **START+ Forward Bus:** 150A master + forward busbar between battery and fan/iBooster/TCU (intentional, mirrors AUX CONSTANT bus)
 - [ ] **SwitchPros/SafetyHub:** 150A CB with 2 AWG wire (actual loads 82-100A, within 130A wire rating)
 
 **If any of these are flagged as "missing protection" or "safety issues" in future reviews, refer to this document for complete justification.**

--- a/docs/jeep_lj/02-engine-systems/02-brake-booster.md
+++ b/docs/jeep_lj/02-engine-systems/02-brake-booster.md
@@ -33,7 +33,7 @@ tags:
 
 **Mounting:** Direct firewall mount via booster's integral 4-stud flange (60×80mm M8, **80mm oriented vertical**) + SendCutSend cabin-side backing plate
 
-**Power Source:** PMU OUT1+10 (40A main), OUT19 (5A ignition signal)
+**Power Source:** [START+ Forward Distribution Bus][start-fwd-bus] (50A CB, 40A main) — relocated off the PMU; ignition **enable** from [Ignition Signal bus][ignition-signal] (~5A)
 
 **Wiring Harness:** {{ tbd(105) }} - [Tulay's Gen 2][tulays-harness] vs [EVcreate Gen 2 kit][evcreate-donors]
 
@@ -118,16 +118,15 @@ Wilwood **260-15542**, **1.00" bore** — sized to the TJ Rubicon front calipers
 
 ## Wiring
 
-| Circuit                | Wire Gauge | Source          | Destination             | Notes                          |
-| :--------------------- | :--------- | :-------------- | :---------------------- | :----------------------------- |
-| Main Power (PMU side)  | 12 AWG × 2 | PMU OUT1, OUT10 | Splice near PMU         | PMU 2.8mm terminals max 12 AWG |
-| Main Power (load side) | 10 AWG     | Splice          | iBooster main connector | CONSTANT (safety requirement)  |
-| Ignition Signal        | 20 AWG     | PMU OUT19       | iBooster ignition input | SWITCHED (ignition RUN)        |
-| Ground                 | 10 AWG     | iBooster ground | Engine Bay Bus Stud 7   | Same stud as main power ground |
+| Circuit         | Wire Gauge | Source                               | Destination             | Notes                                                       |
+| :-------------- | :--------- | :----------------------------------- | :---------------------- | :---------------------------------------------------------- |
+| Main Power      | 8 AWG      | [START+ Forward Dist Bus][start-fwd-bus] (50A CB) | iBooster main connector | CONSTANT (safety requirement); START-direct, off the PMU    |
+| Ignition Enable | 16 AWG     | [Ignition Signal bus][ignition-signal] (fused terminal) | iBooster ignition input | SWITCHED (ignition RUN); ~5A; own firewall pin              |
+| Ground          | 10 AWG     | iBooster ground                      | Engine Bay Bus Stud 7   | Dedicated/redundant ground recommended (a bad ground disables assist) |
 
-**Wire Transition:** PMU terminals accept max 12 AWG. Two 12 AWG wires from OUT1 and OUT10 splice into a single 10 AWG wire **near the PMU** to minimize voltage drop.
+**Relocated off the PMU:** Main power now comes from the [START+ Forward Distribution Bus][start-fwd-bus] (50A CB) instead of PMU OUT1+10, and the ignition enable from the [Ignition Signal bus][ignition-signal] instead of OUT19 — removing the brake booster's dependency on the PMU module. The booster retains its mechanical push-through, so a power loss is a hard pedal, not zero brakes.
 
-See [PMU Outputs][pmu-outputs] for complete PMU configuration and thermal analysis.
+See [START Battery Distribution][start-fwd-bus] for the forward-bus feed and breaker specs.
 
 ## Firewall Backing Plate
 
@@ -276,7 +275,8 @@ See [tail/brake][tail-brake] (PMU lighting flow), [starter][starter] (crank chai
 
 ## Related Documentation
 
-- [PMU Outputs][pmu-outputs] - OUT1+10 and OUT19 configuration
+- [START+ Forward Distribution Bus][start-fwd-bus] - Main power feed + 50A breaker
+- [Ignition Signal Distribution][ignition-signal] - Ignition enable source
 - [Engine Bay Ground Bus][ground-bus] - Stud 7 ground connection
 - [Firewall Ingress][firewall-ingress] - Mounting and wire routing
 
@@ -293,6 +293,8 @@ See [tail/brake][tail-brake] (PMU lighting flow), [starter][starter] (crank chai
 [^body-neck]: ~62mm body-neck (firewall pass-through), corroborated by Back Bay Customs (vendor, 2026-05-30) and Gen 2 Accord iBooster retrofit measurements ([retrofit community](https://nastyz28.com/threads/ibooster-retrofit.343058/) / [EVcreate](https://www.evcreate.com/installing-the-ibooster/): 62mm center bore, ~6mm protrusion). Honda publishes no figure — measured, not datasheet. Confirm on the donor before the final firewall cut: the backing-plate bore is 64mm, ~2mm radial clearance over a 62mm neck. Checked 2026-05-30.
 
 [pmu-outputs]: ../01-power-systems/04-pmu/03-pmu-outputs.md
+[start-fwd-bus]: ../01-power-systems/02-starter-battery-distribution/index.md#start-forward-bus
+[ignition-signal]: ../01-power-systems/06-ignition-signal/index.md
 [ground-bus]: ../01-power-systems/05-grounding/01-engine-bay-ground-bus.md
 [firewall-ingress]: ../01-power-systems/07-wire-routing/02-firewall-ingress.md
 [tail-brake]: ../03-lighting-systems/04-tail-brake-reverse.md

--- a/docs/jeep_lj/02-engine-systems/06-radiator-fan.md
+++ b/docs/jeep_lj/02-engine-systems/06-radiator-fan.md
@@ -22,44 +22,50 @@ tags:
 
 **Mounting:** Radiator shroud
 
-**Power Source:** PMU OUT2+3+4 combined (75A capacity)
+**Power Source:** [START+ Forward Distribution Bus][start-fwd-bus] (60A CB) — relocated off the PMU
+
+**Speed Control:** Dedicated brushless-fan controller + own coolant sensor ({{ tbd(134) }}) — independent of PMU/J1939
 
 ///
 
 ## Overview
 
-Brushless PWM electric fan with automatic temperature control via PMU24. J1939 CAN bus coolant temp (SPN 110) drives PMU PWM output.
+Brushless PWM electric fan. Power is START-direct (off the PMU); variable speed is set by a dedicated brushless-fan controller reading its own coolant temperature sensor — independent of the PMU and the J1939 bus. The controller commands **full speed on lost/invalid sensor signal**, so a CAN or PMU fault can no longer leave the engine without cooling.
 
 ## Specifications
 
 - **Current:** 53A @ full speed, 32A @ 60%, 16A @ 30% — ⚠️ unverified[^fan-specs]
 - **Airflow:** 4188 CFM installed, 5690 CFM free air — ⚠️ unverified[^fan-specs]
 
-[^fan-specs]: ⚠️ UNVERIFIED. Neither GM nor ACDelco publishes a current-draw or CFM figure for fan 84100128 (now superseded by 84790788), so the 53A / 4188 CFM values could not be confirmed against a manufacturer source (checked 2026-05-30). These drive PMU output sizing (OUT2+3+4) and wire gauge — confirm by clamp-meter measurement on the actual fan before finalizing, or treat as an engineering estimate.
+[^fan-specs]: ⚠️ UNVERIFIED. Neither GM nor ACDelco publishes a current-draw or CFM figure for fan 84100128 (now superseded by 84790788), so the 53A / 4188 CFM values could not be confirmed against a manufacturer source (checked 2026-05-30). These drive the 60A breaker / 4 AWG wire sizing and fan-controller selection ({{ tbd(134) }}) — confirm by clamp-meter measurement on the actual fan before finalizing, or treat as an engineering estimate.
 
 ## Temperature Control
 
-| Coolant Temp | Fan Speed    | PMU Duty Cycle | Current |
-| :----------- | :----------- | :------------- | :------ |
-| <185°F       | OFF          | 100%           | 0A      |
-| 185-195°F    | Low (30%)    | 70%            | ~16A    |
-| 195-205°F    | Medium (60%) | 40%            | ~32A    |
-| ≥205°F       | Full (100%)  | 10%            | 53A     |
+The dedicated fan controller maps coolant temp to fan speed (target curve below; exact setpoints tunable on the chosen controller, {{ tbd(134) }}):
+
+| Coolant Temp | Fan Speed       | PWM Duty Cycle | Current |
+| :----------- | :-------------- | :------------- | :------ |
+| <185°F       | OFF             | 100%           | 0A      |
+| 185-195°F    | Low (30%)       | 70%            | ~16A    |
+| 195-205°F    | Medium (60%)    | 40%            | ~32A    |
+| ≥205°F       | Full (100%)     | 10%            | 53A     |
+| sensor fault | **Full (100%)** | failsafe       | 53A     |
 
 !!! warning "Inverted Duty Cycle"
-GM brushless fans use **inverted duty cycle** - high duty cycle = low fan speed. PMU programming must account for this inversion.
+    GM brushless fans use **inverted duty cycle** — high duty cycle = low fan speed. The controller's PWM output must account for this inversion.
 
 ## Wiring
 
-| Circuit              | Wire Gauge | Source               | Destination     | Notes                          |
-| :------------------- | :--------- | :------------------- | :-------------- | :----------------------------- |
-| Fan Power (PMU side) | 12 AWG × 3 | PMU OUT2, OUT3, OUT4 | Splice near PMU | PMU 2.8mm terminals max 12 AWG |
-| Fan Power (load side)| 4 AWG      | Splice               | Fan motor (+)   | ~6 ft, ~1.2% drop @ 53A        |
-| Fan Ground           | 4 AWG      | Fan motor (-)        | Engine Bay Bus  | Short run                      |
+| Circuit             | Wire Gauge     | Source                                   | Destination         | Notes                                |
+| :------------------ | :------------- | :--------------------------------------- | :------------------ | :----------------------------------- |
+| Fan Power           | 4 AWG          | [START+ Forward Dist Bus][start-fwd-bus] (60A CB) → relay | Fan motor (+)       | Relay enabled by the fan controller  |
+| Fan PWM Signal      | 18 AWG         | Fan controller PWM output                | Fan control input   | Low-current speed signal (inverted)  |
+| Fan Ground          | 4 AWG          | Fan motor (−)                            | Engine Bay Bus      | Short run                            |
+| Controller / sensor | per controller | {{ tbd(134) }}                           | Coolant temp sensor | Sensor + sender-port location {{ tbd(134) }} |
 
-**Wire Transition:** PMU terminals accept max 12 AWG. Three 12 AWG wires from OUT2, OUT3, and OUT4 splice into a single 4 AWG wire **near the PMU** (not the fan) to minimize voltage drop - 4 AWG for the long run is better than 3× 12 AWG in parallel.
+Power is switched by a relay (or the controller's integral power stage) at the engine-bay Forward Distribution Bus; the controller sets fan speed via the PWM signal. No PMU outputs are involved.
 
-See [PMU Outputs][pmu-outputs] for complete configuration and [PMU Programming][pmu-programming] for control logic.
+See [START Battery Distribution][start-fwd-bus] for the forward-bus feed and breaker.
 
 ## Outstanding Items
 
@@ -67,12 +73,10 @@ See [PMU Outputs][pmu-outputs] for complete configuration and [PMU Programming][
 
 ## Related Documentation
 
-- [PMU Outputs][pmu-outputs] - OUT2+3+4 configuration
-- [PMU Programming][pmu-programming] - PWM control logic
+- [START+ Forward Distribution Bus][start-fwd-bus] - Power feed + 60A breaker
 - [Engine Bay Ground Bus][ground-bus] - Fan ground connection
 
 [gm-fan]: https://www.gmpartsdirect.com/oem-parts/gm-fan-84100128
 [install-checklist]: ../09-installation/02-engine-systems-checklist.md
-[pmu-outputs]: ../01-power-systems/04-pmu/03-pmu-outputs.md
-[pmu-programming]: ../01-power-systems/04-pmu/04-pmu-programming.md
+[start-fwd-bus]: ../01-power-systems/02-starter-battery-distribution/index.md#start-forward-bus
 [ground-bus]: ../01-power-systems/05-grounding/01-engine-bay-ground-bus.md

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/03-bim-j1939.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/03-bim-j1939.md
@@ -124,7 +124,7 @@ Specific J1939 parameters vary by ECM configuration and vehicle application. Cum
 - [Dashboard Cluster][dashboard-cluster] - Displays J1939 data on gauges
 - [Cummins R2.8 ECM][ecm] - J1939 CAN bus specifications
 - [Firewall Ingress][firewall-ingress] - J1939 wire routing through firewall
-- [Radiator Fan System][radiator-fan] - PMU uses J1939 data for radiator fan PWM control
+- [Radiator Fan System][radiator-fan] - Now uses a dedicated controller + own coolant sensor (no longer J1939/PMU-driven)
 
 [product-link]: https://www.dakotadigital.com/index.cfm/page/ptype=product/product_id=1328/category_id=646/mode=prod/prd1328.htm
 [manual-link]: https://www.dakotadigital.com/pdf/BIM-01-2-J1939.pdf

--- a/docs/jeep_lj/09-installation/01-power-systems-checklist.md
+++ b/docs/jeep_lj/09-installation/01-power-systems-checklist.md
@@ -49,9 +49,21 @@ live in the linked source docs, not here.
 
 - [ ] Mount 250A circuit breaker (PMU main power) within reach of START battery
 - [ ] Mount 80A circuit breaker (BCDC input) within reach of START battery
+- [ ] Mount 150A circuit breaker (Forward Distribution Bus master) within reach of START battery
 - [ ] Confirm START battery+ → 250A CB → PMU main power
 - [ ] Confirm START battery+ → 80A CB → BCDC input
+- [ ] Confirm START battery+ → 150A CB → 2 AWG forward feed → START+ Forward Distribution Bus
 - [ ] Confirm PMU ground reference (Pin 25) → Engine Bay Ground Bus
+
+**START+ Forward Distribution Bus (engine bay):**
+
+- [ ] Mount START+ Forward Distribution Bus (Blue Sea 2105, {{ tbd(135) }}) in engine bay with insulated cover
+- [ ] Mount 60A / 50A / 25A load breakers on a bracket beside the bus
+- [ ] Confirm Forward Bus → 60A CB → radiator fan power (via relay)
+- [ ] Confirm Forward Bus → 50A CB → iBooster main
+- [ ] Confirm Forward Bus → 25A CB → Turbolamik TCU power
+- [ ] Confirm iBooster enable → Ignition bus Term 5 (7.5A fuse) → firewall Pin 18
+- [ ] Install dedicated radiator-fan controller + coolant sensor ({{ tbd(134) }}); verify fail-to-full-speed on lost sensor
 
 **Direct Battery Connections (No Circuit Breaker):**
 
@@ -191,8 +203,6 @@ live in the linked source docs, not here.
 
 ### PMU Output Wiring
 
-- [ ] Confirm iBooster main power → OUT1+10 (combined)
-- [ ] Confirm radiator fan → OUT2+3+4 (combined)
 - [ ] Confirm HVAC blower → OUT5
 - [ ] Confirm GMRS Radio → OUT6
 - [ ] Confirm oil cooler fan → OUT7
@@ -203,12 +213,11 @@ live in the linked source docs, not here.
 - [ ] Confirm winch contactor trigger → OUT15
 - [ ] Confirm A/C clutch → OUT17
 - [ ] Confirm horn → OUT18
-- [ ] Confirm iBooster ignition signal → OUT19
 - [ ] Confirm STX Intercom → OUT20
 - [ ] Confirm brake lights → OUT21
 - [ ] Confirm reverse lights → OUT22
 - [ ] Confirm DRL/parking → OUT23
-- [ ] OUT24 — reserved for future expansion (no wiring)
+- [ ] OUT1–4, 10, 16, 19, 24 — free (no wiring); radiator fan, iBooster, and TCU relocated to the START+ Forward Distribution Bus (see below)
 
 ### PMU CAN Bus Integration
 
@@ -259,8 +268,6 @@ live in the linked source docs, not here.
 
 ### PMU Programming
 
-- [ ] Configure iBooster output combining (OUT1+10)
-- [ ] Configure radiator fan output combining (OUT2+3+4, PWM)
 - [ ] Program DRL auto-off when headlights active
 - [ ] Program A/C clutch engagement logic
 - [ ] Program horn activation

--- a/docs/jeep_lj/09-installation/02-engine-systems-checklist.md
+++ b/docs/jeep_lj/09-installation/02-engine-systems-checklist.md
@@ -61,9 +61,9 @@ parts to buy live in the [Purchase Tracker][purchase-tracker].
 - [ ] Confirm flexlines installed: reservoir → MC
 - [ ] Confirm brake hardlines routed from MC to front/rear brakes
 - [ ] Confirm iBooster wiring harness connected ({{ tbd(105) }}: Tulay's or EVcreate)
-- [ ] Confirm iBooster main power connected (PMU OUT1+10)
-- [ ] Confirm iBooster ignition signal connected (PMU OUT19)
-- [ ] Confirm iBooster ground connected to engine bay ground bus
+- [ ] Confirm iBooster main power connected (START+ Forward Dist Bus, 50A CB)
+- [ ] Confirm iBooster ignition enable connected (Ignition bus Term 5, 7.5A fuse, firewall Pin 18)
+- [ ] Confirm iBooster ground connected to engine bay ground bus (dedicated/redundant ground recommended)
 - [ ] Bleed brake system; verify no leaks
 
 ---
@@ -100,9 +100,10 @@ parts to buy live in the [Purchase Tracker][purchase-tracker].
 ## Phase 6: Radiator Fan
 
 - [ ] Confirm GM 84100128 fan mounted to radiator shroud
-- [ ] Confirm PMU OUT2+3+4 → fan motor
+- [ ] Confirm START+ Forward Dist Bus (60A CB) → relay → fan power
+- [ ] Confirm dedicated fan controller + coolant sensor installed ({{ tbd(134) }})
 - [ ] Confirm fan ground connected to engine bay ground bus
-- [ ] Confirm PMU programmed with temperature-based PWM control
+- [ ] Confirm fan controller fails to full speed on lost sensor signal
 
 ---
 

--- a/docs/jeep_lj/09-installation/03-purchase-tracker.md
+++ b/docs/jeep_lj/09-installation/03-purchase-tracker.md
@@ -125,6 +125,10 @@ _(Most electrical distribution components already purchased - see Purchased Item
 | Item | Quantity | Est. Price | Priority | Notes |
 |:-----|:--------:|:-----------|:---------|:------|
 | Bussmann LR-2 Body PDU | 1 | ~$50-100 | Medium | eBay surplus - [BODY PDU][body-pdu] |
+| START+ Forward Distribution Busbar (Blue Sea 2105) | 1 | ~$40 | High | Engine-bay START+ fan-out for relocated fan/iBooster/TCU — {{ tbd(135) }} - [START Distribution][start-fwd-bus] |
+| Circuit breakers — 150A master + 60A / 50A / 25A (Mechanical Products S17) | 4 | ~$120 | High | Forward-bus master + fan/iBooster/TCU load CBs — {{ tbd(135) }} - [Circuit Breakers][start-cbs] |
+| Brushless fan controller + coolant temp sensor | 1 | ~$80-150 | High | Dedicated PWM controller w/ own sensor, fail-to-full-speed — {{ tbd(134) }} - [Radiator Fan][radiator-fan] |
+| Fan power relay (continuous-duty) | 1 | ~$20 | High | Switches fan power at the forward bus - [Radiator Fan][radiator-fan] |
 
 ---
 
@@ -237,6 +241,9 @@ _(Most electrical distribution components already purchased - see Purchased Item
 [dashboard]: ../05-control-interfaces/05-dashboard-controls.md
 [power-checklist]: 01-power-systems-checklist.md
 [engine-checklist]: 02-engine-systems-checklist.md
+[start-fwd-bus]: ../01-power-systems/02-starter-battery-distribution/index.md#start-forward-bus
+[start-cbs]: ../01-power-systems/02-starter-battery-distribution/01-circuit-breakers.md
+[radiator-fan]: ../02-engine-systems/06-radiator-fan.md
 [runaway-protection]: ../02-engine-systems/11-runaway-protection.md
 [tbd-tracker]: ../tbd-tracker.md
 [bd-site]: https://www.bajadesigns.com/

--- a/docs/jeep_lj/10-drivetrain/01-transmission.md
+++ b/docs/jeep_lj/10-drivetrain/01-transmission.md
@@ -91,7 +91,7 @@ tags:
 
 | Circuit            | Wire Gauge | Source   | Destination                  | Notes                           |
 | :----------------- | :--------- | :------- | :--------------------------- | :------------------------------ |
-| TCU Power          | 14 AWG     | PMU OUT16 | Turbolamik harness (1.8m)   | 15A, CONSTANT (must stay on)    |
+| TCU Power          | 12 AWG     | [START+ Forward Dist Bus][start-fwd-bus] (25A CB) | Turbolamik harness (1.8m)   | 15A, CONSTANT (must stay on); relocated off PMU OUT16 |
 | TCU Ignition       | 18 AWG     | Ignition bus | Turbolamik harness        | Wake-up signal                  |
 | TCU Ground         | 14 AWG     | Engine bay ground bus | Turbolamik harness | 700mm lead from harness         |
 
@@ -196,7 +196,7 @@ The Turbolamik communicates with the Cummins R2.8 ECM via J1939 CAN for:
 
 - [ ] Order Turbolamik TCU 2.0 with basic wiring harness
 - [ ] Install Turbolamik TCU on 8HP70 mechatronic (soldering required)
-- [ ] Route TCU power from PMU OUT16 (14 AWG, CONSTANT)
+- [ ] Route TCU power from START+ Forward Distribution Bus (12 AWG, 25A CB, CONSTANT)
 - [ ] Connect TCU CAN to J1939 bus (same tap as PMU/Dakota Digital)
 - [ ] Install Kilduff shifter in center console
 - [ ] Wire drive mode rocker switch (dash panel) to TCU mode inputs
@@ -211,6 +211,7 @@ The Turbolamik communicates with the Cummins R2.8 ECM via J1939 CAN for:
 - [Cummins R2.8][engine] - Engine CAN integration
 
 [transfer-case]: 02-transfer-case.md
+[start-fwd-bus]: ../01-power-systems/02-starter-battery-distribution/index.md#start-forward-bus
 [pmu-inputs]: ../01-power-systems/04-pmu/02-pmu-inputs.md
 [engine]: ../02-engine-systems/index.md
 [starter]: ../02-engine-systems/01-starter.md


### PR DESCRIPTION
## What & why

Relocates the three most consequential loads — **radiator fan, iBooster, and TCU** — off the ECUMaster PMU24 onto **START-battery-direct** power.

This came out of the critical-systems SPOF audit. The PMU is reliable and fail-safe at the channel level, but for these three loads the fail-safe *direction* is wrong (a high-side driver's safe state is OFF = no brake assist / no cooling / trans limp), and a whole-module event (the single 250A feed breaker, a connector, firmware hang) would drop brakes + cooling + trans together. Moving them swaps an active module for a passive feed + breaker and decouples them from the PMU's health and from the lighting/accessory loads.

## Architecture (forward distribution, mirroring the AUX side)

All three loads sit forward (engine bay / transmission) while the START battery is rear, so rather than three long runs or ~9 stacked lugs on the battery post:

- **150A master breaker** at the battery (<7") → single **2 AWG** feed → engine-bay **START+ Forward Distribution Bus** (Blue Sea 2105)
- Per-load breakers at the bus on short feeds: **fan 60A**, **iBooster 50A**, **TCU 25A**

## Per-load changes

- **Radiator fan** — START-direct power + a **dedicated brushless-fan controller with its own coolant sensor**, independent of the PMU and J1939. Commands **full speed on lost sensor signal**, closing the prior "fan defaults OFF on CAN loss" failure mode (audit finding #3).
- **iBooster** — 40A main from the forward bus; ignition **enable** moved to the ignition bus on its **own fused terminal + firewall pin** (off the ECM's shared 5A feed). Retains mechanical push-through (power loss = hard pedal, not zero brakes).
- **TCU** — 15A from the forward bus; ignition wake already on the ignition bus.

## Knock-on updates (cross-references kept consistent)

- PMU **OUT1–4, 10, 16, 19 freed** (7 outputs); peak load drops ~108A; outputs/overview/programming/thermal updated.
- START distribution (authoritative wire specs) + circuit-breaker tables, grounding label, ignition-signal bus, firewall-ingress pin map, wire-distance reference, both install checklists, purchase tracker, and the relevant CLAUDE nav guides.
- New **START+ Forward Distribution Bus** logged in `STANDARDS-EXCEPTIONS.md` (intentional bus-bar-between-battery-and-loads, same tradeoff as the AUX CONSTANT bus).
- Load-analysis totals **unchanged** (loads were already START-fed via the PMU); TCU now itemized (worst realistic case 201A → ~216A, still within the 270A alternator).

## Tracked specs (can't guess → GitHub issues)

- #134 — brushless fan controller + coolant sensor (P/N, sender port, fail-to-full-speed)
- #135 — START+ forward busbar + breaker SKUs + master sizing
- #136 — measured cable distances for the relocated runs

## Verification

- `python3 hooks/verify_tbd.py` → **OK, all reconciled** (0 untracked markers).
- `mkdocs build` → **9 warnings, identical to the pre-change baseline** (all pre-existing macro/anchor artifacts; zero new).

https://claude.ai/code/session_01LDfhpCpGsG4XP5Jdf5EQsH

---
_Generated by [Claude Code](https://claude.ai/code/session_01LDfhpCpGsG4XP5Jdf5EQsH)_