### PR TITLE
Identify the radiator-fan controller as the Lingenfelter VSFM-002 (resolves controller P/N for #134)

### DIFF
--- a/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
+++ b/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
@@ -50,7 +50,7 @@ The radiator fan, iBooster, and TCU were relocated off the PMU onto START-direct
 | [iBooster][brake-booster] main | Firewall | 8 AWG | short | 40A peak / 0.25A idle | <0.5%[^fwd-bus-vdrop] | 50A |
 | [Turbolamik TCU][transmission] | Transmission | 12 AWG | short | 15A continuous | <0.5%[^fwd-bus-vdrop] | 25A |
 
-The master feed carries the combined load (~68A continuous, ~108A brief peak); voltage drop and breaker sizing are set on that single cable.[^fwd-bus-vdrop] The iBooster's separate ignition **enable** (~5A) is sourced from the [Ignition Signal bus][ignition-signal], not this bus. Fan speed is set by a dedicated brushless-fan controller ({{ tbd(134) }}) with its own coolant sensor, independent of the PMU and J1939.
+The master feed carries the combined load (~68A continuous, ~108A brief peak); voltage drop and breaker sizing are set on that single cable.[^fwd-bus-vdrop] The iBooster's separate ignition **enable** (~5A) is sourced from the [Ignition Signal bus][ignition-signal], not this bus. Fan speed is set by a Lingenfelter VSFM-002 controller (sensor P/N + setpoints {{ tbd(134) }}) with its own coolant sensor, independent of the PMU and J1939.
 
 !!! info "Shared forward feed — intentional tradeoff"
     The three loads share one master feed + busbar (a passive cable, breaker, and bus bar — no active electronics), versus three independent runs from the battery. This is the same tradeoff the [AUX side][constant-bus] accepts, and is far more robust than their former shared dependency on the PMU module. Each load keeps its own breaker. See [Standards Exceptions][standards-exceptions].

--- a/docs/jeep_lj/01-power-systems/04-pmu/04-pmu-programming.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/04-pmu-programming.md
@@ -51,7 +51,7 @@ ELSEIF (J1939_SPN110_CoolantTemp < 210°F) THEN Out8_PSFan = OFF
 
 ### Radiator Fan Control — relocated off the PMU
 
-The radiator fan no longer runs on PMU outputs. It is powered START-direct from the [START+ Forward Distribution Bus][start-fwd-bus] and speed-controlled by a dedicated brushless-fan controller with its own coolant sensor, independent of the PMU and J1939 — see [Radiator Fan][radiator-fan]. The controller commands **full speed on lost/invalid sensor signal** (the former PMU/CAN PWM path defaulted the fan OFF on lost coolant-temp data — the failure mode this relocation closes).
+The radiator fan no longer runs on PMU outputs. It is powered START-direct from the [START+ Forward Distribution Bus][start-fwd-bus] and speed-controlled by a **Lingenfelter VSFM-002** controller with its own coolant sensor, independent of the PMU and J1939 — see [Radiator Fan][radiator-fan]. The VSFM-002 is to be configured to command **full speed on lost/invalid sensor signal** (the former PMU/CAN PWM path defaulted the fan OFF on lost coolant-temp data — the failure mode this relocation closes).
 
 ### Sequential Load Startup
 

--- a/docs/jeep_lj/01-power-systems/08-load-analysis/02-start-battery.md
+++ b/docs/jeep_lj/01-power-systems/08-load-analysis/02-start-battery.md
@@ -30,7 +30,7 @@ All circuits powered by START battery (alternator charging):
 | OUT23            | DRL               |    2.6A |     2.6A | Daytime only           | Auto-off at night     |
 | **Fwd Dist Bus (START-direct)** | |       |          |                        | relocated off the PMU |
 | Fwd Bus          | iBooster main     |   0.25A |      40A | Seconds during braking | Brief peak            |
-| Fwd Bus          | Radiator Fan      |     20A |      53A | Variable (own controller) | Dedicated fan controller |
+| Fwd Bus          | Radiator Fan      |     20A |      53A | Variable (own controller) | Lingenfelter VSFM-002    |
 | Fwd Bus          | Turbolamik TCU    |     15A |      15A | Continuous             | Must stay on          |
 | Ign bus          | iBooster Enable   |      5A |       5A | Continuous             | Ignition-switched     |
 | **BCDC Charger** |                   |         |          |                        |                       |

--- a/docs/jeep_lj/02-engine-systems/06-radiator-fan.md
+++ b/docs/jeep_lj/02-engine-systems/06-radiator-fan.md
@@ -24,24 +24,26 @@ tags:
 
 **Power Source:** [START+ Forward Distribution Bus][start-fwd-bus] (60A CB) — relocated off the PMU
 
-**Speed Control:** Dedicated brushless-fan controller + own coolant sensor ({{ tbd(134) }}) — independent of PMU/J1939
+**Speed Control:** Lingenfelter VSFM-002 PWM controller + own coolant sensor — independent of PMU/J1939 (sensor P/N + setpoints {{ tbd(134) }})[^vsfm002]
 
 ///
 
 ## Overview
 
-Brushless PWM electric fan. Power is START-direct (off the PMU); variable speed is set by a dedicated brushless-fan controller reading its own coolant temperature sensor — independent of the PMU and the J1939 bus. The controller commands **full speed on lost/invalid sensor signal**, so a CAN or PMU fault can no longer leave the engine without cooling.
+Brushless PWM electric fan. Power is START-direct (off the PMU); variable speed is set by a **Lingenfelter VSFM-002** controller reading its own coolant temperature sensor (RTD/thermistor) — independent of the PMU and the J1939 bus.[^vsfm002] The VSFM-002 generates the fan's PWM speed signal (~0.75A); the heavy motor current comes from the forward bus. It must be configured (and confirmed) to command **full speed on lost/invalid sensor signal** ({{ tbd(134) }}), closing the prior "fan defaults OFF on CAN loss" failure mode so a CAN or PMU fault cannot leave the engine without cooling.
 
 ## Specifications
 
 - **Current:** 53A @ full speed, 32A @ 60%, 16A @ 30% — ⚠️ unverified[^fan-specs]
 - **Airflow:** 4188 CFM installed, 5690 CFM free air — ⚠️ unverified[^fan-specs]
 
-[^fan-specs]: ⚠️ UNVERIFIED. Neither GM nor ACDelco publishes a current-draw or CFM figure for fan 84100128 (now superseded by 84790788), so the 53A / 4188 CFM values could not be confirmed against a manufacturer source (checked 2026-05-30). These drive the 60A breaker / 4 AWG wire sizing and fan-controller selection ({{ tbd(134) }}) — confirm by clamp-meter measurement on the actual fan before finalizing, or treat as an engineering estimate.
+[^fan-specs]: ⚠️ UNVERIFIED. Neither GM nor ACDelco publishes a current-draw or CFM figure for fan 84100128 (now superseded by 84790788), so the 53A / 4188 CFM values could not be confirmed against a manufacturer source (checked 2026-05-30). These drive the 60A breaker / 4 AWG wire sizing and the fan-controller coolant-sensor selection ({{ tbd(134) }}) — confirm by clamp-meter measurement on the actual fan before finalizing, or treat as an engineering estimate.
+
+[^vsfm002]: Lingenfelter VSFM-002 Variable Speed DC Brushless Fan & Pump PWM Controller — generates the PWM speed signal for OEM/aftermarket DC brushless fans from a temperature-sensor input (RTD/thermistor) or switched input; PWM signal output rated ~0.75 A; supports PWM in the 1–250 Hz range only. The fan's heavy motor current is supplied separately from the forward bus, switched by a relay. Source: [Lingenfelter VSFM-002 product page][vsfm-product] and [installation manual (PDF)](https://www.lingenfelter.com/PDFdownloads/L460320002.pdf) (accessed 2026-06-06). Coolant-sensor P/N + sender port, setpoints, and confirmation of the fail-to-full-speed behavior remain open — see {{ tbd(134) }}.
 
 ## Temperature Control
 
-The dedicated fan controller maps coolant temp to fan speed (target curve below; exact setpoints tunable on the chosen controller, {{ tbd(134) }}):
+The VSFM-002 maps coolant temp to fan speed (target curve below; exact setpoints tunable on the VSFM-002, {{ tbd(134) }}):
 
 | Coolant Temp | Fan Speed       | PWM Duty Cycle | Current |
 | :----------- | :-------------- | :------------- | :------ |
@@ -49,7 +51,7 @@ The dedicated fan controller maps coolant temp to fan speed (target curve below;
 | 185-195°F    | Low (30%)       | 70%            | ~16A    |
 | 195-205°F    | Medium (60%)    | 40%            | ~32A    |
 | ≥205°F       | Full (100%)     | 10%            | 53A     |
-| sensor fault | **Full (100%)** | failsafe       | 53A     |
+| sensor fault | **Full (100%)** | failsafe ({{ tbd(134) }}) | 53A     |
 
 !!! warning "Inverted Duty Cycle"
     GM brushless fans use **inverted duty cycle** — high duty cycle = low fan speed. The controller's PWM output must account for this inversion.
@@ -58,10 +60,10 @@ The dedicated fan controller maps coolant temp to fan speed (target curve below;
 
 | Circuit             | Wire Gauge     | Source                                   | Destination         | Notes                                |
 | :------------------ | :------------- | :--------------------------------------- | :------------------ | :----------------------------------- |
-| Fan Power           | 4 AWG          | [START+ Forward Dist Bus][start-fwd-bus] (60A CB) → relay | Fan motor (+)       | Relay enabled by the fan controller  |
-| Fan PWM Signal      | 18 AWG         | Fan controller PWM output                | Fan control input   | Low-current speed signal (inverted)  |
+| Fan Power           | 4 AWG          | [START+ Forward Dist Bus][start-fwd-bus] (60A CB) → relay | Fan motor (+)       | Relay enabled by the VSFM-002        |
+| Fan PWM Signal      | 18 AWG         | VSFM-002 PWM output (~0.75A)              | Fan control input   | Low-current speed signal (inverted)  |
 | Fan Ground          | 4 AWG          | Fan motor (−)                            | Engine Bay Bus      | Short run                            |
-| Controller / sensor | per controller | {{ tbd(134) }}                           | Coolant temp sensor | Sensor + sender-port location {{ tbd(134) }} |
+| VSFM-002 + sensor   | per controller | START (ignition) / coolant RTD           | VSFM-002 + temp sensor | Controller = VSFM-002; sensor P/N + sender-port location {{ tbd(134) }} |
 
 Power is switched by a relay (or the controller's integral power stage) at the engine-bay Forward Distribution Bus; the controller sets fan speed via the PWM signal. No PMU outputs are involved.
 
@@ -73,10 +75,12 @@ See [START Battery Distribution][start-fwd-bus] for the forward-bus feed and bre
 
 ## Related Documentation
 
+- [Lingenfelter VSFM-002][vsfm-product] - PWM brushless fan controller (speed control)
 - [START+ Forward Distribution Bus][start-fwd-bus] - Power feed + 60A breaker
 - [Engine Bay Ground Bus][ground-bus] - Fan ground connection
 
 [gm-fan]: https://www.gmpartsdirect.com/oem-parts/gm-fan-84100128
+[vsfm-product]: https://www.lingenfelter.com/product/L460320002.html
 [install-checklist]: ../09-installation/02-engine-systems-checklist.md
 [start-fwd-bus]: ../01-power-systems/02-starter-battery-distribution/index.md#start-forward-bus
 [ground-bus]: ../01-power-systems/05-grounding/01-engine-bay-ground-bus.md

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/03-bim-j1939.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/03-bim-j1939.md
@@ -99,7 +99,7 @@ Specific J1939 parameters vary by ECM configuration and vehicle application. Cum
 - RPM → Tachometer
 - Coolant temp (SPN 110) → Water temp gauge
 - Oil pressure (SPN 100) → Oil pressure gauge
-- Engine oil temp (SPN 175) → Available for display or logic (radiator fan control via PAC-2800BT)
+- Engine oil temp (SPN 175) → Available for display or logic (PMU oil cooler fan, OUT7)
 - Check engine light / MIL → Dashboard warning indicator
 
 **Firewall Routing:**

--- a/docs/jeep_lj/09-installation/01-power-systems-checklist.md
+++ b/docs/jeep_lj/09-installation/01-power-systems-checklist.md
@@ -63,7 +63,7 @@ live in the linked source docs, not here.
 - [ ] Confirm Forward Bus → 50A CB → iBooster main
 - [ ] Confirm Forward Bus → 25A CB → Turbolamik TCU power
 - [ ] Confirm iBooster enable → Ignition bus Term 5 (7.5A fuse) → firewall Pin 18
-- [ ] Install dedicated radiator-fan controller + coolant sensor ({{ tbd(134) }}); verify fail-to-full-speed on lost sensor
+- [ ] Install Lingenfelter VSFM-002 radiator-fan controller + coolant sensor (sensor P/N {{ tbd(134) }}); verify fail-to-full-speed on lost sensor
 
 **Direct Battery Connections (No Circuit Breaker):**
 

--- a/docs/jeep_lj/09-installation/02-engine-systems-checklist.md
+++ b/docs/jeep_lj/09-installation/02-engine-systems-checklist.md
@@ -101,9 +101,9 @@ parts to buy live in the [Purchase Tracker][purchase-tracker].
 
 - [ ] Confirm GM 84100128 fan mounted to radiator shroud
 - [ ] Confirm START+ Forward Dist Bus (60A CB) → relay → fan power
-- [ ] Confirm dedicated fan controller + coolant sensor installed ({{ tbd(134) }})
+- [ ] Confirm Lingenfelter VSFM-002 + coolant sensor installed (sensor P/N + port {{ tbd(134) }})
 - [ ] Confirm fan ground connected to engine bay ground bus
-- [ ] Confirm fan controller fails to full speed on lost sensor signal
+- [ ] Confirm VSFM-002 commands full speed on lost sensor signal ({{ tbd(134) }})
 
 ---
 

--- a/docs/jeep_lj/09-installation/03-purchase-tracker.md
+++ b/docs/jeep_lj/09-installation/03-purchase-tracker.md
@@ -127,7 +127,7 @@ _(Most electrical distribution components already purchased - see Purchased Item
 | Bussmann LR-2 Body PDU | 1 | ~$50-100 | Medium | eBay surplus - [BODY PDU][body-pdu] |
 | START+ Forward Distribution Busbar (Blue Sea 2105) | 1 | ~$40 | High | Engine-bay START+ fan-out for relocated fan/iBooster/TCU — {{ tbd(135) }} - [START Distribution][start-fwd-bus] |
 | Circuit breakers — 150A master + 60A / 50A / 25A (Mechanical Products S17) | 4 | ~$120 | High | Forward-bus master + fan/iBooster/TCU load CBs — {{ tbd(135) }} - [Circuit Breakers][start-cbs] |
-| Brushless fan controller + coolant temp sensor | 1 | ~$80-150 | High | Dedicated PWM controller w/ own sensor, fail-to-full-speed — {{ tbd(134) }} - [Radiator Fan][radiator-fan] |
+| Lingenfelter VSFM-002 fan controller + coolant temp sensor | 1 | ~$190 | High | PWM brushless controller w/ own sensor; sensor P/N + fail-to-full-speed confirm — {{ tbd(134) }} - [Radiator Fan][radiator-fan] |
 | Fan power relay (continuous-duty) | 1 | ~$20 | High | Switches fan power at the forward bus - [Radiator Fan][radiator-fan] |
 
 ---


### PR DESCRIPTION
## Reconciled with #137 (merged)

#137 already moved the radiator fan, iBooster, and TCU off the PMU onto the new **START+ Forward Distribution Bus**, and deliberately left the **fan controller part number open as issue #134** (priority/critical). That superseded the bulk of this PR's original scope.

This branch has been **rebased onto main** and reduced to the one thing #137 didn't have and #134 is asking for: the confirmed controller identity.

## What this PR now does

Pins the radiator-fan controller to the **Lingenfelter VSFM-002** — the kit controller for the GM 84100128 brushless fan — within #137's architecture:

- Names the VSFM-002 (with a cited footnote) in `06-radiator-fan.md`, the START forward-bus note, the PMU-programming note, the START load analysis, both install checklists, and the purchase tracker (~$190).
- The VSFM-002 generates the fan's PWM **signal** (~0.75 A) off its own RTD/thermistor; the heavy motor current stays on the forward-bus feed + relay that #137 designed. ([VSFM-002 page](https://www.lingenfelter.com/product/L460320002.html), [manual PDF](https://www.lingenfelter.com/PDFdownloads/L460320002.pdf))

## #134 stays open (narrowed)

The datasheet does **not** confirm the fan's PWM frequency lands in the VSFM-002's 1–250 Hz window, the coolant-sensor P/N + sender port, or the fail-to-full-speed-on-lost-signal behavior. So #134 remains open, narrowed to those items, and the fail-to-full assertions #137 had stated as fact are softened to "to confirm."

## Drive-by

Fixed a stale `radiator fan control via PAC-2800BT` reference in the J1939 cluster doc (SPN 175 is the PMU oil cooler fan) that #137 missed.

## Scope note

The fan is now the only delta vs main. The iBooster + TCU relocations are already merged via #137 — nothing further from this PR.

## Verification

- `python3 hooks/verify_tbd.py` → `OK — 45 open tbd issues, 0 source TBD markers, all reconciled`
- Diff: 8 files, +20/-16. (Local `zensical` build unavailable — no network for the install; CI builds on the PR.)

https://claude.ai/code/session_01RpkyP57Kr2vWdVo8BrL3j4