### PR TITLE
docs(lj): reflect START+ forward-bus relocation in harness layout

### DIFF
--- a/docs/jeep_lj/01-power-systems/07-wire-routing/03-harness-inventory.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/03-harness-inventory.md
@@ -42,7 +42,7 @@ Each build sheet embeds the matching tub-map diagram and the workbench specs for
 | # | Harness | Build sheet | Conductors | Largest gauge | Length |
 |:--|:--------|:------------|:----------:|:-------------:|:-------|
 | H1 | Passenger Rear Power Trunk (AUX fwd + winch) | [Power][power-build] | 3 | 2/0 AWG | ~13 ft (+13 ft winch to bumper) |
-| H2 | START Engine Bay Trunk | [Power][power-build] | 3 | 2/0 AWG | 6–8 ft |
+| H2 | START Engine Bay Trunk (alt + starter + PMU feed + START+ fwd-bus feed) | [Power][power-build] | 4 | 2/0 AWG | 6–8 ft |
 | H3 | BCDC Cross-Cab | [Power][power-build] | 2 | 1/0 AWG | ~5–6 ft |
 | H4 | SwitchPros Front Bundle | [Lighting][lighting-build] | 3 outputs | 14 AWG | 4–8 ft |
 | H5 | Rear Cabin Trunk Bundle (SP rear + PMU rear) | [Lighting][lighting-build] | ~10 | 14 AWG | 8–14 ft |
@@ -50,6 +50,12 @@ Each build sheet embeds the matching tub-map diagram and the workbench specs for
 | H7 | Winch Trigger | [Controls][controls-build] | 5 | 18 AWG | ~3 ft + ~13 ft |
 | H8 | Kilduff Shifter → TCU | [Controls][controls-build] | 1 (multi) | Proprietary | ~3–5 ft |
 | H9 | TCU → Engine Bay | [Controls][controls-build] | 6 | 14 AWG | 3–4 ft |
+
+!!! note "Engine-bay distribution nodes (not cabin harnesses)"
+    Two busbars fan power out to local loads and so are **not** catalogued as fabricatable cabin harnesses — like the Firewall CONSTANT bus, they are distribution points, and their short local feeds are built in place:
+
+    - **START+ Forward Distribution Bus** (Blue Sea 2105 MaxiBus, engine bay) — fed by H2's 2 AWG forward-bus master feed; fans out on short engine-bay local feeds to the radiator fan (4 AWG), iBooster main (8 AWG), and TCU (12 AWG). The TCU's leg is carried by [H9][controls-build]; the fan and iBooster legs are short engine-bay runs. See [START+ Forward Distribution Bus][start-fwd-bus].
+    - **Firewall CONSTANT bus** (cabin side) — fed by H1's 2/0 AWG forward feed; fans out to SwitchPros, BODY PDU, and Fusion. See [AUX Battery Distribution][aux-battery].
 
 ## Wire Color Convention {#wire-color-convention}
 
@@ -74,7 +80,7 @@ Wrap preference for this build:
 | Harness | Sleeve | Carries |
 |:--------|:-------|:--------|
 | **H1** Passenger Rear Power Trunk | Black braided, red tracer | AUX forward feed + winch power/ground |
-| **H2** START Engine Bay Trunk | Black braided, yellow tracer | Alternator, starter, PMU feed |
+| **H2** START Engine Bay Trunk | Black braided, yellow tracer | Alternator, starter, PMU feed, START+ forward-bus feed |
 | **H3** BCDC Cross-Cab | Black braided, green tracer | BCDC input + cross-ground reference |
 | **H6** ARB Compressor (motor pair) | Black braided, blue tracer | 2× 6 AWG compressor motor cables |
 
@@ -90,7 +96,7 @@ Wrap preference for this build:
                   │                  ENGINE BAY                       │
                   │                                                   │
   H2 START trunk ─►──┐                                                │
-                     │ alt, starter, PMU feed, BCDC input             │
+                     │ alt, starter, PMU feed, START+ fwd-bus feed    │
                      │                                                │
                      ▼                                                │
                   ┌─────┐                                             │
@@ -126,7 +132,7 @@ Wrap preference for this build:
        │ • 250A + 80A CBs    │  H3     │ • 300A + 150A CBs  │         │
        │                     │ BCDC    │ • SafetyHub        │         │
        │                     │ cross   │ • BCDC             │         │
-       │  H2 ↑ (3× 2/0 AWG)  │ (under  │  H1 ↑ (3 cables)   │         │
+       │  H2 ↑ (4 cables)    │ (under  │  H1 ↑ (3 cables)   │         │
        │  driver floor/wall  │  rear   │  passenger         │         │
        │  to engine bay      │  bench) │  floor/wall to     │         │
        │                     │         │  3× bulkhead studs │         │
@@ -178,14 +184,14 @@ The **cabin trunk** (trans tunnel / sill, firewall ↔ rear wheel wells) carries
 |:----------|:--------|:-----------:|:-------------:|:---------:|
 | Forward (rear → firewall) | **H1** Passenger Rear Power Trunk (AUX fwd + winch power+gnd) | 3 | 2/0 AWG | Passenger sill/floor |
 | Cross-cab | H3 (BCDC inter-battery + cross-gnd) | 2 | 1/0 AWG | Under rear bench |
-| Forward (driver rear → engine bay) | H2 (alt, starter, PMU feed) | 3 | 2/0 AWG | Driver sill/floor |
+| Forward (driver rear → engine bay) | H2 (alt, starter, PMU feed, START+ fwd-bus feed) | 4 | 2/0 AWG | Driver sill/floor |
 | Rearward (firewall → rear) | **H5** Rear Cabin Trunk Bundle (SP rear outputs + PMU rear lighting) | ~10 | 14 AWG | Trans tunnel |
 | Rearward (firewall → rear) | CT4 rear turn signals | 2 | 14 AWG | Trans tunnel (could merge into H5) |
 | Rearward (firewall → under pass seat) | SwitchPros control + pressure (ARB) | 2 | 14–18 AWG | Trans tunnel (per H6 optimization) |
 
 **Passenger sill/floor (H1):** ~3 cables, ~1.5" OD bundle, terminates at 3× bulkhead studs at firewall
 
-**Driver sill/floor (H2):** ~3 cables, ~1.5" OD bundle, terminates at heavy power grommet at firewall
+**Driver sill/floor (H2):** ~4 cables (3× 2/0 AWG + 1× 2 AWG), ~1.6" OD bundle, terminates at heavy power grommet at firewall
 
 **Trans tunnel rearward (H5 + CT4 + ARB signal):** ~14 conductors of small wire (14–18 AWG)
 
@@ -243,6 +249,7 @@ These were noted inline on the build sheets; consolidated here for review:
 [firewall-ingress]: 02-firewall-ingress.md
 [aux-battery]: ../03-aux-battery-distribution/index.md
 [start-battery]: ../02-starter-battery-distribution/index.md
+[start-fwd-bus]: ../02-starter-battery-distribution/index.md#start-forward-bus
 [switchpros]: ../../05-control-interfaces/02-switchpros-sp1200.md
 [pmu-outputs]: ../04-pmu/03-pmu-outputs.md
 [safetyhub]: ../03-aux-battery-distribution/04-safetyhub.md

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/04-harness-power-distribution.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/04-harness-power-distribution.md
@@ -59,7 +59,9 @@ Workbench specs for the high-current power harnesses: **H1** Passenger Rear Powe
 
 ## H2 — START Engine Bay Trunk {#h2}
 
-**Build:** 3 conductors (all 2/0 AWG) · 6–8 ft per cable · ~1.5" OD black braided sleeve, yellow tracer · lug terminations both ends · heat sleeve at engine-bay entry.
+*Gained a 4th conductor on 2026-06-07 when the radiator fan, iBooster, and TCU were relocated off the PMU onto the [START+ Forward Distribution Bus][start-fwd-bus]. Its 2 AWG master feed runs the same driver-side rear-well → engine-bay path as the existing three cables, so it is fabricated and installed as part of this bundle.*
+
+**Build:** 4 conductors (3× 2/0 AWG + 1× 2 AWG) · 6–8 ft per cable · ~1.6" OD black braided sleeve, yellow tracer · lug terminations both ends · heat sleeve at engine-bay entry.
 
 **Route:** Driver rear wheel well (START battery) → up inside driver rear quarter sill → forward along **inside floor board / side wall** (driver side) → A-pillar area → driver firewall penetration → engine bay
 
@@ -72,20 +74,22 @@ Workbench specs for the high-current power harnesses: **H1** Passenger Rear Powe
 | Alternator charging input | 2/0 AWG | Red | Alternator → START battery+ | Lug to battery+ stud | Lug to alternator output stud |
 | Starter motor power | 2/0 AWG | Red | START battery+ → starter | Lug to battery+ stud | Lug to starter B+ stud |
 | PMU24 main feed | 2/0 AWG | Red | START battery+ → 250A CB → PMU24 | Lug to 250A CB output | Lug to PMU power stud |
+| START+ Forward Dist Bus master feed | 2 AWG | Red | START battery+ → 150A master CB → engine-bay busbar (fan / iBooster / TCU) | Lug to 150A CB output | Lug to [START+ Forward Distribution Bus][start-fwd-bus] busbar input stud |
 
 (BCDC input feed (4 AWG via 80A CB) takes the H3 cross-cab path instead — see [H3](#h3).)
 
-**Connectors:** Lug terminations at both ends. Heat sleeve required where bundle enters engine bay (>12" from exhaust). Bundle 3 cables with looms; expect ~1.5" OD final bundle.
+**Connectors:** Lug terminations at both ends. Heat sleeve required where bundle enters engine bay (>12" from exhaust). Bundle 4 cables with looms; expect ~1.6" OD final bundle. The 2 AWG forward-bus feed terminates at the engine-bay busbar, not at a load; the busbar's three short local feeds (fan, iBooster, TCU) are engine-bay-side and are **not** part of this harness — see [START+ Forward Distribution Bus][start-fwd-bus].
 
-**Protection:** Black braided expandable sleeve (yellow tracer) over the cabin / sill run, sized to the ~1.5" OD bundle. Heat sleeve in engine bay. P-clamps every 12–18".
+**Protection:** Black braided expandable sleeve (yellow tracer) over the cabin / sill run, sized to the ~1.6" OD bundle. Heat sleeve in engine bay. P-clamps every 12–18".
 
-**Firewall penetration:** Driver-side grommet for high-current cables — separate from the HDP24 (HDP24 is passenger-side, signal-only). Three 2/0 AWG cables need a grommet sized for ~1.5" bundle OD.
+**Firewall penetration:** Driver-side grommet for high-current cables — separate from the HDP24 (HDP24 is passenger-side, signal-only). Four cables (3× 2/0 AWG + 1× 2 AWG) need a grommet sized for ~1.6" bundle OD.
 
 **Notes:**
 
-- All 3 high-current cables share the same driver-side floor / side wall path
+- All 4 high-current cables share the same driver-side floor / side wall path
 - Path is fully inside the body (no exposed frame rail)
 - Driver-side firewall grommet is a new firewall penetration — separate from existing passenger-side HDP24 and SwitchPros bulkheads
+- The 2 AWG forward-bus master feed is the rear-to-front leg only; the engine-bay busbar fan-out to the radiator fan (4 AWG), iBooster (8 AWG), and TCU (12 AWG) lives on the engine-bay side — TCU's leg is harness [H9][controls-build]
 
 ---
 
@@ -137,4 +141,5 @@ Workbench specs for the high-current power harnesses: **H1** Passenger Rear Powe
 [firewall-ingress]: 02-firewall-ingress.md
 [aux-battery]: ../03-aux-battery-distribution/index.md
 [start-battery]: ../02-starter-battery-distribution/index.md
+[start-fwd-bus]: ../02-starter-battery-distribution/index.md#start-forward-bus
 [recovery]: ../../08-exterior-systems/01-winch.md

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/index.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/index.md
@@ -39,6 +39,7 @@ All wire runs require appropriate protection based on location and environment:
 | :------------------------- | :--------- | :-------------------------------------------- |
 | Alternator → START battery | 2/0 AWG    | Heat sleeve (engine bay) → split loom (frame) |
 | PMU power feed             | 2/0 AWG    | Heat sleeve entire run (engine bay exposure)  |
+| START+ forward-bus feed    | 2 AWG      | Heat sleeve (engine bay) → braided sleeve (cabin run, H2) |
 | BCDC inter-battery         | 4 AWG      | Split loom + P-clamps (under vehicle)         |
 | Winch cables               | 1/0 AWG    | Split loom + abrasion sleeve (frame contact)  |
 | Battery grounds            | 2/0 AWG    | Heat sleeve (engine) → split loom (frame)     |
@@ -54,11 +55,12 @@ All wire runs require appropriate protection based on location and environment:
 | **Alternator charging input** | 2/0 AWG    | 8 ft     | FROM Alternator (engine bay)        | 270A           | Charges START battery - see [Alternator][alternator] |
 | **Starter motor power**       | 2/0 AWG    | 6 ft     | TO Starter motor (engine bay)       | 400-600A       | Brief cranking load - see [Starter][starter]         |
 | **PMU24 power feed**          | 2/0 AWG    | 7 ft     | TO PMU24 (engine bay)               | 220A max       | Via 250A CB - see [PMU][pmu]                         |
+| **START+ Forward Dist Bus feed** | 2 AWG   | ~8 ft    | TO engine-bay busbar (fan/iBooster/TCU) | ~108A peak | Via 150A master CB - see [START+ Forward Distribution Bus][start-fwd-bus] |
 | **BCDC input feed**           | 4 AWG      | 5-6 ft   | TO BCDC (passenger rear wheel well) | 50-55A         | Via 80A CB - see [BCDC][bcdc]                        |
 | **Primary ground**            | 2/0 AWG    | 3 ft     | TO Rear frame rail                  | 600A+ peak     | Primary return path                                  |
 | **Battery cross-ground**      | 1/0 AWG    | 5-6 ft   | TO AUX battery- (passenger)         | BCDC reference | Critical for BCDC operation                          |
 
-**Routing:** Driver rear wheel well → up inside driver rear quarter sill → forward along **inside floor board / side wall (driver side)** → driver A-pillar area → driver-side firewall grommet → engine bay. Path is fully inside the body (no exposed frame rail). BCDC input (4 AWG) takes the H3 cross-cab path instead (under rear bench seat to passenger side).
+**Routing:** Driver rear wheel well → up inside driver rear quarter sill → forward along **inside floor board / side wall (driver side)** → driver A-pillar area → driver-side firewall grommet → engine bay. Path is fully inside the body (no exposed frame rail). The PMU feed and the START+ Forward Dist Bus master feed (2 AWG) share this driver-side path as part of harness [H2][power-build]. BCDC input (4 AWG) takes the H3 cross-cab path instead (under rear bench seat to passenger side).
 
 ---
 
@@ -92,6 +94,10 @@ All wire runs require appropriate protection based on location and environment:
 | :------------------------ | :--------- | :------- | :-------------------- | :-------------------- | :--------- | :---------------------------- |
 | **Alternator to battery** | 2/0 AWG    | 8 ft     | Alternator            | START battery+        | 270A       | See Driver Rear Wheel Well section |
 | **Starter motor**         | 2/0 AWG    | 6 ft     | START battery+        | Starter motor         | 400-600A   | See Driver Rear Wheel Well section |
+| **START+ Fwd Bus feed**   | 2 AWG      | ~8 ft    | START battery+ (150A CB) | Engine-bay busbar  | ~108A peak | Rear-to-front master feed (H2) - see [START+ Forward Distribution Bus][start-fwd-bus] |
+| **Busbar → Radiator fan** | 4 AWG      | short    | Engine-bay busbar     | Radiator fan          | 53A        | Via 60A CB (local engine-bay feed) |
+| **Busbar → iBooster main**| 8 AWG      | short    | Engine-bay busbar     | iBooster              | 40A peak   | Via 50A CB (local engine-bay feed) |
+| **Busbar → TCU**          | 12 AWG     | short    | Engine-bay busbar     | Turbolamik TCU (trans)| 15A        | Via 25A CB; TCU leg is harness [H9][controls-build] |
 | **Engine block ground**   | 2/0 AWG    | 8 ft     | Engine block          | Engine bay ground bus | 600A+ peak | Starter/alternator return     |
 | **Frame ground**          | 2/0 AWG    | 3 ft     | Engine bay ground bus | Front frame rail      | 600A+ peak | Chassis ground point          |
 
@@ -218,6 +224,7 @@ J1939 CAN High/Low wires tap into Cummins harness at firewall punch-through, the
 
 [grounding]: ../05-grounding/index.md
 [starter-battery]: ../02-starter-battery-distribution/index.md
+[start-fwd-bus]: ../02-starter-battery-distribution/index.md#start-forward-bus
 [aux-battery]: ../03-aux-battery-distribution/index.md
 [pmu]: ../04-pmu/index.md
 [safetyhub]: ../03-aux-battery-distribution/04-safetyhub.md


### PR DESCRIPTION
## Why

Moving the radiator fan, iBooster, and TCU off the PMU onto the **START+ Forward Distribution Bus** (#137) added a new **2 AWG master feed** from the START battery in the driver rear wheel well forward to a new engine-bay busbar. That feed runs the **exact same driver-side path as harness H2**, so it changed the harness layout — but only part of the docs were updated at the time (#137 threaded the TCU leg through H9 and the firewall-ingress note, but left the power-distribution harness sheets and zone routing reference stale).

## What changed

**`04-harness-power-distribution.md` — H2 build sheet**
- H2 is now a **4-cable bundle** (3× 2/0 AWG + 1× 2 AWG, ~1.6" OD). Added the START+ forward-bus master feed conductor row, updated build/connectors/firewall-penetration/notes.

**`03-harness-inventory.md`**
- Summary table, sleeve/tracer table, ASCII harness map, and cabin-trunk bundle summary all updated H2 from 3 → 4 conductors.
- Added an inventory note documenting the **engine-bay busbar** (Blue Sea 2105 MaxiBus) as a *distribution node*, not a fabricatable cabin harness — mirroring how the Firewall CONSTANT bus is treated.

**`index.md` (zone routing)**
- Driver Rear Wheel Well table: added the forward-bus master feed.
- Engine Bay table: added the busbar feed + its short local feeds (fan 4 AWG / iBooster 8 AWG / TCU 12 AWG).
- High-Current Cable Protection table: added the 2 AWG forward-bus feed.

## Decisions (confirmed with the builder)
- **Master feed → folded into H2** (shares H2's route) rather than a standalone harness.
- **Engine-bay busbar → zone note + inventory mention** rather than a new fabricatable harness; the short local feeds are built in place and the TCU leg stays in H9.

All wire specs reference the START battery distribution single-source-of-truth (`02-starter-battery-distribution/index.md`); no new specs were invented.

https://claude.ai/code/session_014QSB1drgBJS9dNTLWcDnBq

---
_Generated by [Claude Code](https://claude.ai/code/session_014QSB1drgBJS9dNTLWcDnBq)_