### PR TITLE
Resolve build design-review findings: doc fixes + TBD issue tracking

### DIFF
--- a/docs/jeep_lj/01-power-systems/01-power-generation/01-batteries.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/01-batteries.md
@@ -80,7 +80,7 @@ Accessories and high-draw auxiliary loads:
 
 - SwitchPros lighting (up to 68A full offroad lighting)
 - BODY PDU (audio, USB, heated seats)
-- Winch (400A peak)
+- Winch (409A peak)
 - ARB compressor (90A)
 
 ### Why LiFePO4

--- a/docs/jeep_lj/01-power-systems/01-power-generation/02-alternator.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/02-alternator.md
@@ -61,7 +61,7 @@ See [START Battery Distribution][starter-battery] for complete wire specificatio
 
 **Alternator Capacity:** 270A continuous
 
-**Worst Realistic Load:** 218A (offroad scenario) = 52A margin (19% headroom)
+**Worst Realistic Load:** 201A (offroad scenario) = 69A margin (26% headroom)
 
 The alternator supplies START battery loads plus BCDC charging. AUX battery loads (SwitchPros, ARB compressor, winch) do NOT draw from alternator.
 

--- a/docs/jeep_lj/01-power-systems/01-power-generation/04-solar.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/04-solar.md
@@ -66,17 +66,19 @@ tags:
 
 ## Function
 
-80W panel maintains AUX battery during extended stops via BCDC solar input. Full sun output at optimal conditions: 80W (1.95A @ 40V), variable in partial sun/clouds.
+80W panel maintains AUX battery during extended stops via BCDC solar input. Full sun panel output at optimal conditions: 80W (1.95A @ 40V), variable in partial sun/clouds.
 
-**BCDC Green Power Priority:** Solar input used first when available, alternator supplements to reach 50A total charging current. In full sun, solar contributes ~1.95A, reducing alternator load by same amount.
+**Panel-side vs battery-side current:** The 1.95A figure is the panel-side current at the panel's ~40V operating voltage (40V × 1.95A ≈ 78W). The BCDC's MPPT steps that down to the battery charge voltage, so the battery-side contribution is higher: 78W ÷ ~13.4V ≈ **~5.8A to the AUX battery**.
 
-**Charging Contribution:**
+**BCDC Green Power Priority:** Solar input used first when available, alternator supplements to reach 50A total charging current. In full sun, solar contributes ~5.8A battery-side, reducing alternator load by the same amount.
 
-- **Full sun:** ~1.95A to AUX battery (reduces alternator load from 50A to ~48A)
-- **Partial sun:** Variable 0.8-1.5A depending on conditions
+**Charging Contribution (battery-side):**
+
+- **Full sun:** ~5.8A to AUX battery (78W ÷ ~13.4V; reduces alternator load from 50A to ~44A)
+- **Partial sun:** Variable, proportional to available irradiance
 - **Overcast/Night:** 0A (BCDC uses alternator only)
 
-**Alternator Load Relief:** Minimal but measurable - reduces worst-case alternator load by ~1.95A during sunny daytime operation
+**Alternator Load Relief:** Minimal but measurable — reduces worst-case alternator load by ~5.8A during sunny daytime operation
 
 See [BCDC Alpha 50][bcdc] for complete charging system details.
 

--- a/docs/jeep_lj/01-power-systems/01-power-generation/05-wire-distance-reference.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/05-wire-distance-reference.md
@@ -90,7 +90,7 @@ Distances required for voltage drop calculations and wire purchases. Measure act
 
 | From                      | To                          | Wire      | Distance | Purpose           |
 |:--------------------------|:----------------------------|:----------|:---------|:------------------|
-| SafetyHub (engine bay)    | ARB compressor (under seat) | 6 AWG × 2 | ~8 ft    | Compressor power (through firewall) |
+| SafetyHub (passenger rear wheel well) | ARB compressor (under seat) | 6 AWG × 2 | ~8 ft {{ tbd(154) }} | Compressor power (8/10/12 ft conflict — issue #154) |
 | ARB compressor            | Chassis ground              | 6 AWG     | ~2 ft    | Local ground      |
 | SwitchPros (firewall)   | Compressor control terminal | 14 AWG    | ~6 ft    | Control signal    |
 | Air manifold (under seat) | Front axle locker           | Air line  | ~6 ft    | Custom air line   |

--- a/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
+++ b/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
@@ -50,14 +50,14 @@ The radiator fan, iBooster, and TCU were relocated off the PMU onto START-direct
 | [iBooster][brake-booster] main | Firewall | 8 AWG | short | 40A peak / 0.25A idle | <0.5%[^fwd-bus-vdrop] | 50A |
 | [Turbolamik TCU][transmission] | Transmission | 12 AWG | short | 15A continuous | <0.5%[^fwd-bus-vdrop] | 25A |
 
-The master feed carries the combined load (~68A continuous, ~108A brief peak); voltage drop and breaker sizing are set on that single cable.[^fwd-bus-vdrop] The iBooster's separate ignition **enable** (~5A) is sourced from the [Ignition Signal bus][ignition-signal], not this bus. Fan speed is set by a Lingenfelter VSFM-002 controller (sensor P/N + setpoints {{ tbd(134) }}) with its own coolant sensor, independent of the PMU and J1939.
+The master feed carries the combined load (~68A continuous, ~108A brief peak); voltage drop and breaker sizing are set on that single cable.[^fwd-bus-vdrop] The iBooster's separate ignition **enable** (~5A) is sourced from the [Ignition Signal bus][ignition-signal], not this bus. Fan speed is set by a dedicated fan controller ({{ tbd(134) }}) with its own coolant sensor, independent of the PMU and J1939.
 
 !!! info "Shared forward feed — intentional tradeoff"
     The three loads share one master feed + busbar (a passive cable, breaker, and bus bar — no active electronics), versus three independent runs from the battery. This is the same tradeoff the [AUX side][constant-bus] accepts, and is far more robust than their former shared dependency on the PMU module. Each load keeps its own breaker. See [Standards Exceptions][standards-exceptions].
 
 [^fwd-bus-vdrop]: Master feed 2 AWG @ ~108A brief peak (~68A continuous), ~8 ft, 60°C-derated (×1.2) ≈ 1.3% — sized on the combined load. Load feeds are short from the engine-bay bus, so per-load drop is negligible: fan 4 AWG @ 53A, iBooster 8 AWG @ 40A brief, TCU 12 AWG @ 15A. Final master-feed length and breaker selective-coordination pending {{ tbd(136) }} and {{ tbd(135) }}.
 
-## START battery Negative Terminal (7 connections)
+## START battery Negative Terminal (6 connections)
 
 | Circuit                                    | Destination          | Wire Gauge  | Distance | Current    | Voltage Drop  |
 | :----------------------------------------- | :------------------- | :---------- | :------- | :--------- | :------------ |
@@ -69,6 +69,8 @@ The master feed carries the combined load (~68A continuous, ~108A brief peak); v
 | [STX Intercom][radios]                     | Dashboard            | 10 AWG      | ~8 ft    | 5A         | 0.4% @ 20°C   |
 
 Radio grounds direct to battery for RF noise isolation. ECM/grid heater via Cummins harness to isolate from starter spikes.
+
+A possible 7th connection — a dedicated rear chassis bond at the START battery− — is under review ({{ tbd(155) }}).
 
 ## Related Documentation
 

--- a/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
+++ b/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
@@ -70,7 +70,7 @@ The master feed carries the combined load (~68A continuous, ~108A brief peak); v
 
 Radio grounds direct to battery for RF noise isolation. ECM/grid heater via Cummins harness to isolate from starter spikes.
 
-A possible 7th connection — a dedicated rear chassis bond at the START battery− — is under review ({{ tbd(155) }}).
+START− intentionally has no local chassis bond — its chassis reference is the 2/0 AWG run to the [Engine Bay Ground Bus][engine-ground-bus] (the rear frame chassis bond lives on the AUX− side). The 6 connections above are the complete, final set; an earlier "7 connections" count was an error.
 
 ## Related Documentation
 

--- a/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/01-circuit-breakers.md
+++ b/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/01-circuit-breakers.md
@@ -20,9 +20,9 @@ Mounted inline on a bracket within 7" of AUX battery+ terminal. Protect the thre
 
 | Circuit                              | Model                                            | Rating | Reset Type | Power Path                                                              | Max Load              | Sizing                         |
 | :----------------------------------- | :----------------------------------------------- | :----: | :--------- | :---------------------------------------------------------------------- | :-------------------- | :----------------------------- |
-| **Forward Feed (to Firewall Bus)**   | Mechanical Products<br/>([174-S2-300-2][mp-300]) |  300A  | Manual     | AUX battery+<br/>└→ 300A CB<br/>&nbsp;&nbsp;&nbsp;└→ Firewall CONSTANT Bus | ~152A combined max (SP + BODY PDU) | 197% of combined load (Fusion relocated to direct AUX feed) |
-| **SafetyHub 150 (Recovery)**         | Mechanical Products<br/>([174-S2-150-2][mp-150]) |  150A  | Manual     | AUX battery+<br/>└→ 150A CB<br/>&nbsp;&nbsp;&nbsp;└→ SafetyHub 150        | ~100A (ARB 90A + Winch Trigger 10A) | 150% of max load (future-proofed) |
-| **JL Audio MV800/8i Amp**            | Blue Sea<br/>([187-100A][bs-100])                |  100A  | Manual     | AUX battery+<br/>└→ 100A CB<br/>&nbsp;&nbsp;&nbsp;└→ JL Audio MV800/8i (under rear seat) | 80A max (fuse-limited) | 125% of fuse rating — wire protection (4 AWG short run); amp's 80A internal fuse is primary trip path |
+| **Forward Feed (to Firewall Bus)**   | Mechanical Products<br/>([174-S2-300-2][mp-300]) |  300A  | Manual     | AUX battery+<br/>└→ 300A CB<br/>&nbsp;&nbsp;&nbsp;└→ Firewall CONSTANT Bus | ~154A combined max (SP + BODY PDU) | 195% of combined load (Fusion head unit rides the forward feed through the BODY PDU on CB30; the JL Audio amp is the direct-AUX-feed device) |
+| **SafetyHub 150 (Recovery)**         | Mechanical Products<br/>([174-S2-150-2][mp-150]) |  150A  | Manual     | AUX battery+<br/>└→ 150A CB<br/>&nbsp;&nbsp;&nbsp;└→ SafetyHub 150        | ~90A (ARB only — winch control on BODY PDU CB43) | 167% of max load (future-proofed) |
+| **JL Audio MV800/8i Amp**            | Blue Sea<br/>([187-100A][bs-100])                |  100A  | Manual     | AUX battery+<br/>└→ 100A CB<br/>&nbsp;&nbsp;&nbsp;└→ JL Audio MV800/8i (under rear seat) | 80A max (fuse-limited) | 125% of fuse rating — wire protection (4 AWG short run); amp's 80A internal fuse is primary trip path. CB-vs-4 AWG resize decision {{ tbd(149) }} |
 
 ## Firewall-Side CBs (Co-located with Firewall CONSTANT Bus)
 
@@ -31,10 +31,10 @@ Mounted within 7" of [Firewall CONSTANT Bus][constant-bus]. Protect each downstr
 | Circuit                      | Model                                            | Rating | Reset Type | Power Path                                                                         | Max Load                                                  | Sizing                              |
 | :--------------------------- | :----------------------------------------------- | :----: | :--------- | :--------------------------------------------------------------------------------- | :-------------------------------------------------------- | :---------------------------------- |
 | **SwitchPros RCR-Force 12**  | Mechanical Products<br/>([174-S2-150-2][mp-150]) |  150A  | Manual     | Firewall CONSTANT Bus<br/>└→ 150A CB<br/>&nbsp;&nbsp;&nbsp;└→ SwitchPros           | ~100A (all lighting outputs on)                           | 150% of max load                    |
-| **BODY PDU**                 | Mechanical Products<br/>([174-S2-100-2][mp-100]) |  100A  | Manual     | Firewall CONSTANT Bus<br/>└→ 100A CB<br/>&nbsp;&nbsp;&nbsp;└→ BODY PDU             | ~54A max (radio 16A, USB 13A, camera 10A, seats 10A peak) | 185% of max load (future expansion) |
+| **BODY PDU**                 | Mechanical Products<br/>([174-S2-100-2][mp-100]) |  100A  | Manual     | Firewall CONSTANT Bus<br/>└→ 100A CB<br/>&nbsp;&nbsp;&nbsp;└→ BODY PDU             | ~54A max (radio 15A, USB 13A, camera 10A, seats 10A peak, winch control 2A, cargo 4A) | 185% of max load (future expansion) |
 
 !!! info "Wire Sizing for CB Protection"
-Forward feed uses 2/0 AWG (300A @ 20°C) for the 13-ft run to the firewall bus (now carries only SP+BODY, ~152A max; 2/0 retained for upgrade headroom). Firewall-side outputs use 2 AWG (130A @ 20°C) for SwitchPros and BODY PDU. Audio amp uses 4 AWG (95A @ 20°C, JL Audio minimum spec) for the short ~3-4 ft run from AUX battery to under-seat amp location.
+Forward feed uses 2/0 AWG protected by the 300A CB for the 13-ft run to the firewall bus (now carries only SP+BODY, ~154A max; 2/0 retained for upgrade headroom). The 300A figure is the CB rating, not the wire's ampacity — 2/0 AWG copper is rated ~265A @ 60°C (project wire-ampacity reference), comfortably above the ~154A load. Firewall-side outputs use 2 AWG (130A @ 20°C) for SwitchPros and BODY PDU. Audio amp uses 4 AWG (95A @ 20°C, JL Audio minimum spec) for the short ~3-4 ft run from AUX battery to under-seat amp location.
 
 **Mechanical Products Series 17 (4 units):**
 
@@ -66,7 +66,7 @@ Forward feed uses 2/0 AWG (300A @ 20°C) for the 13-ft run to the firewall bus (
 - [AUX battery Distribution Overview][rear-battery]
 - [Firewall CONSTANT Bus][constant-bus] - Downstream distribution
 - [SwitchPros][switchpros] - Load details for SwitchPros circuit
-- [SafetyHub 150][safetyhub] - Load details for SafetyHub circuit (ARB compressor, winch trigger)
+- [SafetyHub 150][safetyhub] - Load details for SafetyHub circuit (ARB compressor)
 - [BODY PDU][body-rtmr] - Load details for BODY PDU circuit
 - [JL Audio MV800/8i Amp][audio] - Load details for amplifier circuit
 

--- a/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/03-body-pdu.md
+++ b/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/03-body-pdu.md
@@ -74,12 +74,14 @@ tags:
 
 **Relay Utilization:** 2 of 8 used, 6 available (3 require 12V relay replacement)
 
-**Total Load:** ~60A maximum (Radio 15A + USB 13A + Camera 10A + Seats 10A peak + Winch control 2A + Cargo lights 4A)
+**Total Load:** ~54A maximum (Radio 15A + USB 13A + Camera 10A + Seats 10A peak + Winch control 2A + Cargo lights 4A)
 
 **Control:** All circuits on CONSTANT power with trigger-wire or manual switch control for on/off
 
 !!! info "Communication Devices"
-G1 GMRS Radio and STX Intercom are powered from [SafetyHub 150][safetyhub] (START battery) as critical infrastructure, with direct grounds to START battery to minimize RF noise.
+G1 GMRS Radio and STX Intercom are powered from the PMU — GMRS on OUT6, Intercom on OUT20 — with direct grounds to the START battery− to minimize RF noise. See [PMU Outputs][pmu-outputs]. SafetyHub is an AUX-side device and powers neither.
+
+[pmu-outputs]: ../04-pmu/03-pmu-outputs.md
 
 ## Outstanding Items
 

--- a/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/04-safetyhub.md
+++ b/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/04-safetyhub.md
@@ -33,7 +33,7 @@ Provides fused distribution for recovery and auxiliary systems powered by the AU
 **Note:** Communications systems (GMRS, Intercom) are powered via PMU outputs - see [PMU Outputs][pmu-outputs]
 
 !!! note "Future-Proof Capacity"
-Wire and CB sized for full 150A SafetyHub capacity (current load 100A). Provides 50A headroom for additional recovery or auxiliary systems.
+Wire and CB sized for full 150A SafetyHub capacity (current load 90A). Provides 60A headroom for additional recovery or auxiliary systems.
 
 ## Specifications
 
@@ -47,8 +47,8 @@ Wire and CB sized for full 150A SafetyHub capacity (current load 100A). Provides
 
 | Slot   | Fuse | Circuit                              | Wire Gauge | Distance | Voltage @ Load | Load | Notes                                               |
 | :----- | :--- | :----------------------------------- | :--------- | :------- | :------------- | :--- | :-------------------------------------------------- |
-| MIDI-1 | 60A  | [ARB Compressor][air-system] Motor 1 | 6 AWG ✓    | ~12 ft   | 11.56V (3.6%)  | 45A  | Passenger rear wheel well → cargo → under passenger seat |
-| MIDI-2 | 60A  | [ARB Compressor][air-system] Motor 2 | 6 AWG ✓    | ~12 ft   | 11.56V (3.6%)  | 45A  | Passenger rear wheel well → cargo → under passenger seat |
+| MIDI-1 | 60A  | [ARB Compressor][air-system] Motor 1 | 6 AWG ✓    | ~12 ft {{ tbd(154) }} | 11.56V (3.6%)  | 45A  | Passenger rear wheel well → cargo → under passenger seat |
+| MIDI-2 | 60A  | [ARB Compressor][air-system] Motor 2 | 6 AWG ✓    | ~12 ft {{ tbd(154) }} | 11.56V (3.6%)  | 45A  | Passenger rear wheel well → cargo → under passenger seat |
 | MIDI-3 | -    | **\[Available\]**                      | -          | -        | -              | -    | -                                                   |
 | ATC-1  | -    | **\[Available\]**                      | -          | -        | -              | -    | (Was Winch Contactor Trigger - reallocated 2026-05-30 to BODY PDU CB43 for shorter routing; see [Winch][recovery-systems] and [Dashboard Controls][dashboard-controls]) |
 | ATC-2  | -    | **\[Available\]**                      | -          | -        | -              | -    | -                                                   |
@@ -57,14 +57,14 @@ Wire and CB sized for full 150A SafetyHub capacity (current load 100A). Provides
 
 **Slot Utilization:** 2 of 7 used (2 MIDI, 5 available — ATC-1 freed after winch trigger reallocated to BODY PDU CB43)
 
-**Total Load:** 100A maximum (ARB 90A + Winch Trigger 10A)
+**Total Load:** 90A maximum (ARB only — winch control reallocated to BODY PDU CB43)
 
-**Utilization:** 100A / 150A = 67%
+**Utilization:** 90A / 150A = 60%
 
-**Future Capacity:** 50A additional capacity available (150A max - 100A current = 50A headroom)
+**Future Capacity:** 60A additional capacity available (150A max - 90A current = 60A headroom)
 
 !!! info "Winch Main Power"
-Winch motor power (400A peak) connects directly to AUX battery positive terminal with no external circuit breaker per WARN manufacturer specifications. See [STANDARDS-EXCEPTIONS.md][standards-exceptions] and [Recovery Systems][recovery-systems] for complete protection strategy.
+Winch motor power (409A peak) connects directly to AUX battery positive terminal with no external circuit breaker per WARN manufacturer specifications. See [STANDARDS-EXCEPTIONS.md][standards-exceptions] and [Recovery Systems][recovery-systems] for complete protection strategy.
 
 ## Related Documentation
 

--- a/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/CLAUDE.md
+++ b/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/CLAUDE.md
@@ -29,7 +29,7 @@ Documents rear wheel well power distribution from the AUX battery (Dakota Lithiu
 
 **Use when:** Finding firewall CONSTANT bus capacity, available studs, or what connects to the bus
 
-Note: AUX battery itself has NO local CONSTANT bus. Battery has 4 stacked terminal lugs + 2 inline CBs (300A master forward feed + 150A SafetyHub local).
+Note: AUX battery itself has NO local CONSTANT bus. Battery has 5 stacked terminal lugs + 3 inline CBs (300A master forward feed + 150A SafetyHub local + 100A audio amp).
 
 ### `03-body-pdu.md` - BODY PDU
 

--- a/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/index.md
+++ b/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/index.md
@@ -28,7 +28,7 @@ This page is the authoritative source for all AUX battery wire specs (gauge, dis
 | Circuit                              | Destination                       | Wire Gauge | Distance | Current             | Voltage Drop    | Protection               |
 | :----------------------------------- | :-------------------------------- | :--------- | :------- | :------------------ | :-------------- | :----------------------- |
 | [BCDC Alpha 50 output][bcdc]         | Local (rear wheel well)           | 4 AWG      | Short    | 50A                 | Negligible      | None (charging)          |
-| [Firewall CONSTANT Bus][constant-bus] | Firewall (cabin side, passenger) | 2/0 AWG    | ~13 ft   | ~152A max           | 1.3% @ 20°C     | 300A CB at battery (<7") |
+| [Firewall CONSTANT Bus][constant-bus] | Firewall (cabin side, passenger) | 2/0 AWG    | ~13 ft   | ~154A max           | 1.3% @ 20°C     | 300A CB at battery (<7") |
 | [SafetyHub 150][aux-safetyhub]       | Local (rear wheel well)           | 2 AWG      | ~2 ft    | ~100A max           | <0.5% @ 20°C    | 150A CB at battery (<7") |
 | [JL Audio MV800/8i Amp][audio]       | Under rear seat                   | 4 AWG      | ~3-4 ft  | 80A max (fuse)      | <0.5% @ 20°C    | 100A CB at battery (<7") |
 | [Winch][recovery]                    | Front bumper                      | 1/0 AWG    | 13 ft    | 250A typ, 409A peak | 4.9% @ 250A / 7.9% @ 409A | [None][winch-protection] |

--- a/docs/jeep_lj/01-power-systems/04-pmu/01-pmu-overview.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/01-pmu-overview.md
@@ -56,15 +56,15 @@ tags:
 | Outputs   |  Rating  | Total  |  Used  | Available |
 | :-------- | :------: | :----: | :----: | :-------: |
 | 1-10      | 25A each |   10   |   5    |     5     |
-| 11-16     | 15A each |   6    |   3    |     3     |
+| 11-16     | 15A each |   6    |   2    |     4     |
 | 17-24     | 7A each  |   8    |   6    |     2     |
-| **Total** |    -     | **24** | **14** |  **10**   |
+| **Total** |    -     | **24** | **13** |  **11**   |
 
-**Utilization:** 14 of 24 outputs used (58%) — 7 freed by relocating the radiator fan, iBooster, and TCU
+**Utilization:** 13 of 24 outputs used (54%) — 7 freed by relocating the radiator fan, iBooster, and TCU; OUT15 freed when the winch trigger was reallocated to BODY PDU CB43 (2026-05-30)
 
-**Primary loads:** HVAC (OUT5: 25A), GMRS radio (OUT6: 25A), aux cooling fans (OUT7+8: 2×15A), Dakota Digital (OUT9: 25A), wipers (OUT11: 15A), CT4 (OUT13: 15A), winch trigger (OUT15: 15A), A/C clutch (OUT17: 7A), horn (OUT18: 7A), intercom (OUT20: 7A), brake lights (OUT21: 7A), reverse lights (OUT22: 7A), DRL/parking (OUT23: 7A). _Radiator fan (was OUT2+3+4), iBooster main + enable (was OUT1+10, OUT19), and Turbolamik TCU (was OUT16) relocated to the [START+ Forward Distribution Bus][start-fwd-bus] — OUT1–4, 10, 16, 19 now free._
+**Primary loads:** HVAC (OUT5: ~20A load), GMRS radio (OUT6: ~15A load), aux cooling fans (OUT7+8: 2×15A), Dakota Digital (OUT9: ~25A), wipers (OUT11: 15A), CT4 (OUT13: ~9A), A/C clutch (OUT17: 7A), horn (OUT18: 7A), intercom (OUT20: 7A), brake lights (OUT21: 7A), reverse lights (OUT22: 7A), DRL/parking (OUT23: 7A). _Radiator fan (was OUT2+3+4), iBooster main + enable (was OUT1+10, OUT19), and Turbolamik TCU (was OUT16) relocated to the [START+ Forward Distribution Bus][start-fwd-bus]; the winch contactor trigger (was OUT15) reallocated to BODY PDU CB43 — OUT1–4, 10, 15, 16, 19 now free._
 
-**Load:** With the radiator fan, iBooster, and TCU relocated to the START+ Forward Bus, PMU peak drops to ~145A theoretical (all radios transmitting), ~85-115A typical continuous — comfortably within the 300A PMU capacity, with 10 of 24 outputs now free.
+**Load:** With the radiator fan, iBooster, and TCU relocated to the START+ Forward Bus, PMU peak drops to ~145A theoretical (all radios transmitting), ~85-115A typical continuous — comfortably within the 170A continuous PMU capacity. **7 outputs were freed by the fan/iBooster/TCU relocation** and OUT15 by the winch-trigger reallocation; counting the always-spare outputs, **11 of 24 outputs are now unassigned**.
 
 **Mounting:** Engine bay, accessible for LED diagnostics and USB configuration
 

--- a/docs/jeep_lj/01-power-systems/04-pmu/02-pmu-inputs.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/02-pmu-inputs.md
@@ -33,7 +33,7 @@ See [Ignition Signal Distribution][ignition-signal] for complete wiring architec
 | **In 6** | **\[Available\]**    | -                            | -                       | Available for future expansion           |
 | **In 7** | CT4 SW3 (Headlights) | CT4 lever pull               | Out 23 (DRL) logic      | 12V when headlights active, disables DRL |
 | **In 8** | **\[Available\]**      | -                            | -                       | Available for future expansion           |
-| **In 9** | A/C Request          | Factory TJ A/C button signal | Out 17 (A/C Clutch)     | 12V when factory dash A/C button pressed |
+| **In 9** | A/C Request          | Factory TJ A/C button — 12V source {{ tbd(146) }} (undefined post-PCM-delete) | Out 17 (A/C Clutch)     | 12V when factory dash A/C button pressed |
 
 **Note:** Keyless ignition is handled entirely by the self-contained Digital Guard Dawg PBS-I module — PMU is not in the keyless logic path. See [Keyless Ignition][keyless-ignition].
 

--- a/docs/jeep_lj/01-power-systems/04-pmu/02-pmu-inputs.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/02-pmu-inputs.md
@@ -33,12 +33,13 @@ See [Ignition Signal Distribution][ignition-signal] for complete wiring architec
 | **In 6** | **\[Available\]**    | -                            | -                       | Available for future expansion           |
 | **In 7** | CT4 SW3 (Headlights) | CT4 lever pull               | Out 23 (DRL) logic      | 12V when headlights active, disables DRL |
 | **In 8** | **\[Available\]**      | -                            | -                       | Available for future expansion           |
-| **In 9** | A/C Request          | Factory TJ A/C button — 12V source {{ tbd(146) }} (undefined post-PCM-delete) | Out 17 (A/C Clutch)     | 12V when factory dash A/C button pressed |
+| **In 9** | A/C Request          | Restomod Air control head compressor output, via trinary switch ({{ tbd(146) }} — verify kit wiring on arrival) | Out 17 (A/C Clutch)     | 12V when A/C commanded and refrigerant pressure in range — see [HVAC][hvac] |
 
 **Note:** Keyless ignition is handled entirely by the self-contained Digital Guard Dawg PBS-I module — PMU is not in the keyless logic path. See [Keyless Ignition][keyless-ignition].
 
 [keyless-ignition]: ../../05-control-interfaces/06-keyless-ignition.md
 [ignition-signal]: ../06-ignition-signal/index.md
+[hvac]: ../../02-engine-systems/03-hvac.md
 
 ## Analog Inputs
 

--- a/docs/jeep_lj/01-power-systems/04-pmu/03-pmu-outputs.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/03-pmu-outputs.md
@@ -21,7 +21,7 @@ Complete configuration of all 24 PMU outputs, load allocations, and combined out
 | **Out 6**  | GMRS Radio (Midland G1)      | 15A      | [Direct START battery-][starter-battery-distribution] | CONSTANT           | RF noise isolation             |
 | **Out 7**  | Oil Cooler Fan               | ~15A     | [Engine Bay Bus][engine-ground] Stud 8                | Auto (CAN temp)    | SPN 175 oil temp trigger       |
 | **Out 8**  | PS Cooler Fan                | ~15A     | [Engine Bay Bus][engine-ground] Stud 8                | 180°F inline thermostat | Mishimoto PS cooler fan; thermostat-switched on PS fluid temp (not engine coolant) |
-| **Out 9**  | Dakota Digital System        | ~25A     | [Firewall Stud Bus][firewall-ground] T4-5             | CONSTANT           | Cluster + 4 BIM modules        |
+| **Out 9**  | Dakota Digital System        | ~25A     | [Firewall Stud Bus][firewall-ground] T4-5             | CONSTANT           | Cluster + 4 BIM modules; gauge power architecture (OUT9 vs Critical Cabin PDU) {{ tbd(144) }} |
 | **Out 10** | **[Available]**             | -        | -                                                     | -                  | Freed — iBooster relocated to [START+ Forward Bus][start-fwd-bus] |
 
 ### 15A High-Side Outputs (OUT11-OUT16)
@@ -32,7 +32,7 @@ Complete configuration of all 24 PMU outputs, load allocations, and combined out
 | **Out 12** | **[Available]**           | -    | -                                                     | -                    | Future expansion (15A)                        |
 | **Out 13** | Command Touch CT4         | ~9A  | [Firewall Stud Bus][firewall-ground] T1               | CONSTANT             | Turn signals, headlights, hazards             |
 | **Out 14** | **[Available]**           | -    | -                                                     | -                    | Future expansion (15A)                        |
-| **Out 15** | Winch Contactor Trigger   | 1A   | Via winch contactor                                   | Manual (dash rocker) | Control signal only                           |
+| **Out 15** | **[Available]**           | -    | -                                                     | -                    | (Was Winch Contactor Trigger — reallocated 2026-05-30 to BODY PDU CB43) |
 | **Out 16** | **[Available]**           | -    | -                                                     | -                    | Freed — TCU relocated to [START+ Forward Bus][start-fwd-bus] |
 
 ### 7A High-Side Outputs (OUT17-OUT24)
@@ -52,7 +52,7 @@ Complete configuration of all 24 PMU outputs, load allocations, and combined out
 
 ## Combined Outputs
 
-_The radiator fan (formerly OUT2+3+4) and iBooster main (formerly OUT1+10) were relocated to the [START+ Forward Distribution Bus][start-fwd-bus]. No PMU outputs are currently combined; OUT1–4, OUT10, OUT16, and OUT19 are now free (7 spare outputs). The combining rules below are retained for any future high-current output._
+_The radiator fan (formerly OUT2+3+4) and iBooster main (formerly OUT1+10) were relocated to the [START+ Forward Distribution Bus][start-fwd-bus]. No PMU outputs are currently combined; OUT1–4, OUT10, OUT15, OUT16, and OUT19 are now free (8 spare outputs). The combining rules below are retained for any future high-current output._
 
 **Combining Rules:**
 

--- a/docs/jeep_lj/01-power-systems/04-pmu/03-pmu-outputs.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/03-pmu-outputs.md
@@ -17,7 +17,7 @@ Complete configuration of all 24 PMU outputs, load allocations, and combined out
 | **Out 2**  | **[Available]**             | -        | -                                                     | -                  | Freed — radiator fan relocated to [START+ Forward Bus][start-fwd-bus] |
 | **Out 3**  | **[Available]**             | -        | -                                                     | -                  | Freed — radiator fan relocated     |
 | **Out 4**  | **[Available]**             | -        | -                                                     | -                  | Freed — radiator fan relocated     |
-| **Out 5**  | HVAC Blower Motor            | ~20A     | Factory HVAC ground                                   | Auto (ignition ON) | See [HVAC System][hvac-system] |
+| **Out 5**  | HVAC Blower Motor            | ~20A     | Restomod Air kit ground (verify on arrival)           | Auto (ignition ON) | Restomod Air kit blower; draw verification {{ tbd(146) }} — see [HVAC System][hvac-system] |
 | **Out 6**  | GMRS Radio (Midland G1)      | 15A      | [Direct START battery-][starter-battery-distribution] | CONSTANT           | RF noise isolation             |
 | **Out 7**  | Oil Cooler Fan               | ~15A     | [Engine Bay Bus][engine-ground] Stud 8                | Auto (CAN temp)    | SPN 175 oil temp trigger       |
 | **Out 8**  | PS Cooler Fan                | ~15A     | [Engine Bay Bus][engine-ground] Stud 8                | 180°F inline thermostat | Mishimoto PS cooler fan; thermostat-switched on PS fluid temp (not engine coolant) |
@@ -41,7 +41,7 @@ Complete configuration of all 24 PMU outputs, load allocations, and combined out
 
 | Output     | Circuit                  | Load | Ground                                                | Control Type        | Notes                          |
 | :--------- | :----------------------- | :--- | :---------------------------------------------------- | :------------------ | :----------------------------- |
-| **Out 17** | A/C Clutch               | 3-5A | Factory A/C ground                                    | Auto (A/C request)  | See [HVAC System][hvac-system] |
+| **Out 17** | A/C Clutch               | 3-5A | Compressor clutch ground (Restomod Air kit — verify)  | Auto (A/C request)  | Request via Restomod Air control head → trinary → In 9 — see [HVAC System][hvac-system] |
 | **Out 18** | Horn                     | 5.4A | [Engine Bay Bus][engine-ground] Stud 6                | External input      | PIAA horns (2.7A × 2)          |
 | **Out 19** | **[Available]**          | -    | -                                                     | -                   | Freed — iBooster enable now on ignition bus    |
 | **Out 20** | STX Intercom             | ~5A  | [Direct START battery-][starter-battery-distribution] | Auto (ignition ON)  | RF noise isolation             |

--- a/docs/jeep_lj/01-power-systems/04-pmu/04-pmu-programming.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/04-pmu-programming.md
@@ -51,7 +51,7 @@ ELSEIF (J1939_SPN110_CoolantTemp < 210°F) THEN Out8_PSFan = OFF
 
 ### Radiator Fan Control — relocated off the PMU
 
-The radiator fan no longer runs on PMU outputs. It is powered START-direct from the [START+ Forward Distribution Bus][start-fwd-bus] and speed-controlled by a **Lingenfelter VSFM-002** controller with its own coolant sensor, independent of the PMU and J1939 — see [Radiator Fan][radiator-fan]. The VSFM-002 is to be configured to command **full speed on lost/invalid sensor signal** (the former PMU/CAN PWM path defaulted the fan OFF on lost coolant-temp data — the failure mode this relocation closes).
+The radiator fan no longer runs on PMU outputs. It is powered START-direct from the [START+ Forward Distribution Bus][start-fwd-bus] and speed-controlled by a dedicated fan controller ({{ tbd(134) }}) with its own coolant sensor, independent of the PMU and J1939 — see [Radiator Fan][radiator-fan]. The controller must be configured to command **full speed on lost/invalid sensor signal** (the former PMU/CAN PWM path defaulted the fan OFF on lost coolant-temp data — the failure mode this relocation closes).
 
 ### Sequential Load Startup
 
@@ -93,9 +93,9 @@ IF (BatteryVoltage < 12.5V) AND (EngineRPM > 1000)
 
 ### ARB Compressor Load Shedding
 
-**Purpose:** Automatically shed non-critical loads when ARB compressor runs (90A) to prevent exceeding 270A alternator capacity.
+**Purpose:** Automatically shed non-critical PMU loads when the ARB compressor runs (90A on the AUX side) to preserve AUX battery capacity and maximize BCDC charging headroom.
 
-**Summary:** Detects ARB activation and disables DRL (~2.6A), A/C (5A), and conditionally oil/PS cooler fans (15A each) to reduce total load from 266A to 243A, providing +27A alternator margin during tire inflation.
+**Summary:** Detects ARB activation and disables DRL (~2.6A), A/C (5A), and conditionally oil/PS cooler fans (15A each), shedding ~8-38A from the START-side PMU load. See [ARB Load Shedding Logic][arb-load-shedding] for the current full-scenario totals.
 
 **See:** [ARB Load Shedding Logic][arb-load-shedding] for complete implementation details, load analysis, testing procedures, and operator guidelines.
 

--- a/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
@@ -48,7 +48,9 @@ The Dakota Lithium 135Ah combined with 50A BCDC makes extended air-up a non-issu
 - Shed cosmetic loads first (DRL)
 - Shed comfort loads second (A/C)
 - Conditionally shed cooling loads if temperatures allow (oil/PS cooler fans)
-- Maintain critical systems (iBooster, HVAC blower, lights, CT4)
+- Maintain critical PMU systems (HVAC blower, lights, CT4)
+
+_Note: the iBooster and radiator fan are no longer PMU loads — both relocated to the [START+ Forward Bus][start-fwd-bus] — so they are outside this PMU shed logic. They remain START-battery loads and still appear in the START-side totals below._
 
 ## Load Shedding Logic
 
@@ -321,3 +323,4 @@ LOG SwitchPros_OUT11_ARB (state or trigger input)
 [switchpros]: ../../05-control-interfaces/02-switchpros-sp1200.md
 [start-load-analysis]: ../08-load-analysis/02-start-battery.md
 [aux-load-analysis]: ../08-load-analysis/03-aux-battery.md
+[start-fwd-bus]: ../02-starter-battery-distribution/index.md#start-forward-bus

--- a/docs/jeep_lj/01-power-systems/04-pmu/CLAUDE.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/CLAUDE.md
@@ -23,17 +23,17 @@ Documents ECUMaster PMU24 programmable power management unit configuration and a
 
 **Use when:** Finding PMU specs, capacity, or physical installation details
 
-### `02-pmu-outputs.md` - PMU Outputs
-
-**Contains:** Complete output assignment table for all 24 outputs
-
-**Use when:** Finding what load is assigned to which output
-
-### `03-pmu-inputs.md` - PMU Inputs
+### `02-pmu-inputs.md` - PMU Inputs
 
 **Contains:** Digital/analog input assignments, CAN bus integration
 
 **Use when:** Finding input configuration or CAN bus details
+
+### `03-pmu-outputs.md` - PMU Outputs
+
+**Contains:** Complete output assignment table for all 24 outputs
+
+**Use when:** Finding what load is assigned to which output
 
 ### `04-pmu-programming.md` - PMU Programming
 
@@ -55,27 +55,27 @@ Documents ECUMaster PMU24 programmable power management unit configuration and a
 
 ## Navigation Scenarios
 
-**"What's connected to PMU OUT14?"** → `02-pmu-outputs.md` output table
+**"What's connected to PMU OUT14?"** → `03-pmu-outputs.md` output table
 
-**"How does PMU connect to J1939 CAN bus?"** → `03-pmu-inputs.md`
+**"How does PMU connect to J1939 CAN bus?"** → `02-pmu-inputs.md`
 
 **"What's the DRL auto-off logic?"** → `04-pmu-programming.md`
 
 **"Where does PMU get power?"** → START battery (1.2) circuit breakers
 
-**"What inputs does PMU use?"** → `03-pmu-inputs.md`
+**"What inputs does PMU use?"** → `02-pmu-inputs.md`
 
 ## When Updating
 
 **Changing output assignment:**
 
-1. Update `02-pmu-outputs.md` output table
+1. Update `03-pmu-outputs.md` output table
 2. Update affected system docs (Sections 2, 3, 4)
 3. Verify total load capacity
 
 **Adding new input:**
 
-1. Update `03-pmu-inputs.md` input table
+1. Update `02-pmu-inputs.md` input table
 2. Update programming logic in `04-pmu-programming.md` if needed
 
 **Adding logic example:**

--- a/docs/jeep_lj/01-power-systems/05-grounding/index.md
+++ b/docs/jeep_lj/01-power-systems/05-grounding/index.md
@@ -11,7 +11,7 @@ Multi-point grounding strategy with high-current grounds to frame rails and low-
 
 | Ground Point              | Type                   | Location                   | Capacity            | Notes                                              |
 | :------------------------ | :--------------------- | :------------------------- | :------------------ | :------------------------------------------------- |
-| **START battery (-)**     | Battery Terminal       | Driver rear wheel well     | 6 connections ({{ tbd(155) }}: possible 7th rear chassis bond) | See [START Battery Distribution][starter-battery]  |
+| **START battery (-)**     | Battery Terminal       | Driver rear wheel well     | 6 connections (no local chassis bond — by design) | See [START Battery Distribution][starter-battery]  |
 | **AUX battery (-)**       | Battery Terminal       | Passenger rear wheel well  | 5 connections       | See [AUX Battery Distribution][aux-battery]        |
 | **Engine Bay Ground Bus** | Blue Sea 2107 PowerBar | Firewall (engine bay)      | 8 studs (600A)      | See [Engine Bay Ground Bus][engine-bay-ground-bus] |
 | **Firewall Stud Bus**     | Blue Sea 2105 MaxiBus  | Firewall (cabin side)      | 14 terminals (250A) | See [Firewall Stud Bus][firewall-stud-bus]         |

--- a/docs/jeep_lj/01-power-systems/05-grounding/index.md
+++ b/docs/jeep_lj/01-power-systems/05-grounding/index.md
@@ -11,7 +11,7 @@ Multi-point grounding strategy with high-current grounds to frame rails and low-
 
 | Ground Point              | Type                   | Location                   | Capacity            | Notes                                              |
 | :------------------------ | :--------------------- | :------------------------- | :------------------ | :------------------------------------------------- |
-| **START battery (-)**     | Battery Terminal       | Driver rear wheel well     | 7 connections       | See [START Battery Distribution][starter-battery]  |
+| **START battery (-)**     | Battery Terminal       | Driver rear wheel well     | 6 connections ({{ tbd(155) }}: possible 7th rear chassis bond) | See [START Battery Distribution][starter-battery]  |
 | **AUX battery (-)**       | Battery Terminal       | Passenger rear wheel well  | 5 connections       | See [AUX Battery Distribution][aux-battery]        |
 | **Engine Bay Ground Bus** | Blue Sea 2107 PowerBar | Firewall (engine bay)      | 8 studs (600A)      | See [Engine Bay Ground Bus][engine-bay-ground-bus] |
 | **Firewall Stud Bus**     | Blue Sea 2105 MaxiBus  | Firewall (cabin side)      | 14 terminals (250A) | See [Firewall Stud Bus][firewall-stud-bus]         |

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/02-firewall-ingress.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/02-firewall-ingress.md
@@ -62,7 +62,7 @@ RF interference analysis determined that with ferrite chokes on radio power lead
 | 6 | DRL/Parking | 16 AWG | PMU OUT23 | Rear tail lights | #16 |
 | 12 | PBS-I PINK IGN (ignition signal) | 14 AWG | PBS-I ICM | Ignition bus (cabin) | #16 |
 
-### Cabin → Engine Bay (10 wires)
+### Cabin → Engine Bay (11 wires)
 
 Pin 12 carries the PBS-I PINK IGN ignition signal; the keyswitch was removed when the PBS-I self-contained keyless system was adopted.
 

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/02-firewall-ingress.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/02-firewall-ingress.md
@@ -74,7 +74,7 @@ Pin 12 carries the PBS-I PINK IGN ignition signal; the keyswitch was removed whe
 | 10 | High beam headlights | 14 AWG | CT4 SW4 | LP6 Pin 4 (both) | #16 |
 | 11 | Horn button trigger | 18 AWG | Steering wheel button | PMU In 1 | #16 |
 | 13 | Brake switch | 18 AWG | Brake pedal switch | PMU In 2 | #16 |
-| 14 | A/C request | 18 AWG | HVAC controls | PMU In 9 | #16 |
+| 14 | A/C request | 18 AWG | Restomod Air control head (via trinary switch) | PMU In 9 | #16 |
 | 15 | PURPLE START | 16 AWG | PBS-I PURPLE START output | Cole Hersee 24213 coil | #16 |
 | 16 | Winch control IN | 18 AWG | Dash rocker switch | Winch contactor | #16 |
 | 17 | Winch control OUT | 18 AWG | Dash rocker switch | Winch contactor | #16 |

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/03-harness-inventory.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/03-harness-inventory.md
@@ -135,7 +135,7 @@ Wrap preference for this build:
        │  H2 ↑ (4 cables)    │ (under  │  H1 ↑ (3 cables)   │         │
        │  driver floor/wall  │  rear   │  passenger         │         │
        │  to engine bay      │  bench) │  floor/wall to     │         │
-       │                     │         │  3× bulkhead studs │         │
+       │                     │         │  sealed grommet    │         │
        └─────────────────────┘         │  at firewall;      │         │
                                        │  winch portion     │         │
                                        │  continues to      │         │
@@ -161,7 +161,7 @@ Two harnesses (H1 and H5) bundle multiple originally-separate runs into a single
 
 - All three conductors carry power only — no sense lines, no signal returns, no CAN/audio/analog.
 - Inductive coupling between adjacent power conductors is irrelevant for distribution (the coupled noise has no signal path to corrupt; loads see CB-protected DC).
-- Winch peak current (~400A, seconds) raises a strong transient B-field but does not couple to the parallel forward-feed cable in any way that matters at the firewall CONSTANT bus.
+- Winch peak current (~409A, seconds) raises a strong transient B-field but does not couple to the parallel forward-feed cable in any way that matters at the firewall CONSTANT bus.
 - **Verdict: no interference risk. Safe to bundle.**
 
 **H5 (Rear Cabin Trunk Bundle) — SP lighting outputs + PMU OUT-21/22/23 + 1 SP trigger return:**
@@ -189,7 +189,7 @@ The **cabin trunk** (trans tunnel / sill, firewall ↔ rear wheel wells) carries
 | Rearward (firewall → rear) | CT4 rear turn signals | 2 | 14 AWG | Trans tunnel (could merge into H5) |
 | Rearward (firewall → under pass seat) | SwitchPros control + pressure (ARB) | 2 | 14–18 AWG | Trans tunnel (per H6 optimization) |
 
-**Passenger sill/floor (H1):** ~3 cables, ~1.5" OD bundle, terminates at 3× bulkhead studs at firewall
+**Passenger sill/floor (H1):** ~3 cables, ~1.5" OD bundle, continuous through a sealed 2-piece grommet at the firewall (no bulkhead studs — see optimization note below)
 
 **Driver sill/floor (H2):** ~4 cables (3× 2/0 AWG + 1× 2 AWG), ~1.6" OD bundle, terminates at heavy power grommet at firewall
 
@@ -203,7 +203,7 @@ The **cabin trunk** (trans tunnel / sill, firewall ↔ rear wheel wells) carries
 
 These were noted inline on the build sheets; consolidated here for review:
 
-1. ~~Old H4 + old H1 share rear-well → firewall path~~ **Resolved (2026-05-30):** Merged into single **H1 Passenger Rear Power Trunk**. Firewall transition uses a **single sealed 2-piece rubber grommet** (e.g., Steele Rubber) — cables run continuously, no service break. Bulkhead studs (Blue Sea 2203/2204) max at 250A and were underrated for the winch peaks (400A); Anderson SB175 was also undersized. Continuous-cable + grommet is WARN's documented standard for high-current firewall pass-through.
+1. ~~Old H4 + old H1 share rear-well → firewall path~~ **Resolved (2026-05-30):** Merged into single **H1 Passenger Rear Power Trunk**. Firewall transition uses a **single sealed 2-piece rubber grommet** (e.g., Steele Rubber) — cables run continuously, no service break. Bulkhead studs (Blue Sea 2203/2204) max at 250A and were underrated for the winch peaks (409A); Anderson SB175 was also undersized. Continuous-cable + grommet is WARN's documented standard for high-current firewall pass-through.
 2. ~~Old H6 + old H7 + CT4 rear turn + old H8 SP signal wires share cabin trunk → rear~~ **Partially resolved (2026-05-30):** Old H6 + old H7 merged into **H5 Rear Cabin Trunk Bundle** with single multi-pin breakout (Deutsch DT15 or AMP CPC ~15-pin) at rear cargo bulkhead. CT4 rear turn signals and ARB control wires *could* still join — pending decision.
 3. **H5 sub-harness (firewall → rear breakout) is a single straight pull;** R&R of any individual rear light becomes a pigtail swap.
 4. **H6 motor cables only.** Move control/pressure wires into H5 since they originate at SwitchPros.

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/04-harness-power-distribution.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/04-harness-power-distribution.md
@@ -24,7 +24,7 @@ Workbench specs for the high-current power harnesses: **H1** Passenger Rear Powe
 
 **Build:** 3 conductors · longest run ~13 ft to firewall (+13 ft for the winch pair to the bumper) · ~1.5" OD black braided sleeve, red tracer · ring lugs both ends.
 
-**Route:** Passenger rear wheel well (AUX battery) → up inside passenger rear quarter sill → forward along **inside floor board / side wall** (passenger side) → A-pillar area → **3× bulkhead studs through firewall** → engine bay → forward along passenger inner fender → through grille area → front bumper (winch portion only)
+**Route:** Passenger rear wheel well (AUX battery) → up inside passenger rear quarter sill → forward along **inside floor board / side wall** (passenger side) → A-pillar area → **single sealed 2-piece grommet through firewall** (continuous cables, no firewall break) → engine bay → forward along passenger inner fender → through grille area → front bumper (winch portion only)
 
 **Length:** ~13 ft to firewall (all 3 cables); ~13 ft additional for winch cables continuing to bumper
 
@@ -32,9 +32,9 @@ Workbench specs for the high-current power harnesses: **H1** Passenger Rear Powe
 
 | Wire | Gauge | Color | Function | Termination at battery | Termination at firewall | Continues to |
 |:-----|:-----:|:-----:|:---------|:----------------------|:------------------------|:-------------|
-| Forward feed (+) | 2/0 AWG | Red | Powers SwitchPros + BODY PDU + Fusion via Firewall CONSTANT bus | Ring lug to 300A CB output stud | Ring lug to bulkhead stud | (terminates at firewall — bus input stud on engine bay side via short jumper) |
-| Winch power (+) | 1/0 AWG | Red | AUX battery+ → winch contactor B+ | Ring lug to AUX battery+ stud | Ring lug to bulkhead stud | Lug to winch contactor B+ |
-| Winch ground (−) | 1/0 AWG | Black | AUX battery- → winch contactor B− | Ring lug to AUX battery- stud | Ring lug to bulkhead stud | Lug to winch motor / chassis at front |
+| Forward feed (+) | 2/0 AWG | Red | Powers SwitchPros + BODY PDU via Firewall CONSTANT bus (Fusion head unit rides the BODY PDU via CB30) | Ring lug to 300A CB output stud | Continuous through grommet — no firewall break | Ring lug to Firewall CONSTANT bus input stud (cabin side) |
+| Winch power (+) | 1/0 AWG | Red | AUX battery+ → winch contactor B+ | Ring lug to AUX battery+ stud | Continuous through grommet — no firewall break | Lug to winch contactor B+ |
+| Winch ground (−) | 1/0 AWG | Black | AUX battery- → winch contactor B− | Ring lug to AUX battery- stud | Continuous through grommet — no firewall break | Lug to winch motor / chassis at front |
 
 **Firewall pass-through:** **Single sealed 2-piece rubber grommet** sized for the ~1.5" OD bundle (~1.75" firewall hole). Cables run continuously from rear wheel well to their respective destinations — no service break at the firewall. The grommet seals the firewall penetration only; the cables themselves are uninterrupted.
 
@@ -42,7 +42,7 @@ Workbench specs for the high-current power harnesses: **H1** Passenger Rear Powe
 
 - WARN install documentation references this approach as standard for winch firewall pass-through
 - No amperage limit at the pass-through (the cable is the conductor; grommet just seals the hole)
-- Common feed-through marine bulkhead studs (Blue Sea 2203/2204, Cole Hersee 46211) max at 250A continuous — borderline for the forward feed (232A) and underrated for the winch leg (400A peak)
+- Common feed-through marine bulkhead studs (Blue Sea 2203/2204, Cole Hersee 46211) max at 250A continuous and were underrated for the winch leg (409A peak); continuous cable + grommet sidesteps any pass-through current limit (the cable is the conductor; the grommet only seals the hole)
 - Anderson SB175 is undersized for the winch leg (175A continuous); SBE320/SB350 would work but adds complexity
 - Service is rare in practice — when needed, pulling the entire cable end-to-end is acceptable
 - Steele Rubber or similar 2-piece grommet, ~$5–15

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/index.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/index.md
@@ -72,7 +72,7 @@ All wire runs require appropriate protection based on location and environment:
 | :------------------------------------- | :--------- | :------- | :------------------------------------------------ | :------------------ | :------------------------------------------------------------------- |
 | **Warn ZEON 10-S Winch power**       | 1/0 AWG    | 13 ft    | TO Front bumper winch                             | 250A typ, 409A peak | Direct connection (no CB) - see [Recovery Systems][recovery-systems] |
 | **Warn ZEON 10-S Winch ground**      | 1/0 AWG    | 13 ft    | TO Winch motor ground                             | 250A typ, 409A peak | Return path - routing {{ tbd(106) }}                                 |
-| **Forward feed (Firewall CONSTANT bus)** | 2/0 AWG  | ~13 ft   | TO Firewall CONSTANT Bus (cabin trunk)            | ~232A max           | Protected by 300A CB at battery - feeds SwitchPros, BODY PDU, Fusion |
+| **Forward feed (Firewall CONSTANT bus)** | 2/0 AWG  | ~13 ft   | TO Firewall CONSTANT Bus (cabin trunk)            | ~154A max           | Protected by 300A CB at battery - feeds SwitchPros + BODY PDU (Fusion head unit rides the BODY PDU via CB30) |
 | **SafetyHub local feed**               | 2 AWG      | ~2 ft    | TO SafetyHub 150 (local in wheel well)            | ~100A max           | Protected by 150A CB at battery                                      |
 | **BCDC output**                        | 4 AWG      | Short    | FROM BCDC (local in wheel well)                   | 50A                 | Charging input to AUX battery                                        |
 | **Primary ground**                     | 2/0 AWG    | 3 ft     | TO Rear frame rail                                | {{ tbd(124) }}      | Chassis-grounded accessory return only — winch returns via dedicated 1/0 H1 cable to AUX battery−, not chassis |
@@ -80,7 +80,7 @@ All wire runs require appropriate protection based on location and environment:
 
 **Routing:**
 
-- **Forward feed (2/0 AWG) + Winch power/ground (2× 1/0 AWG) (H1):** Passenger rear wheel well → up inside passenger rear quarter sill → forward along **inside floor board / side wall (passenger side)** → A-pillar area → through passenger firewall (forward feed terminates at Firewall CONSTANT bus; winch cables continue to engine bay → grille → front bumper). Three heavy cables bundled together. Fully inside body, no exposed frame rail.
+- **Forward feed (2/0 AWG) + Winch power/ground (2× 1/0 AWG) (H1):** Passenger rear wheel well → up inside passenger rear quarter sill → forward along **inside floor board / side wall (passenger side)** → A-pillar area → through a **single sealed 2-piece grommet** at the passenger firewall (continuous cables, no firewall break) → forward feed terminates at Firewall CONSTANT bus; winch cables continue to engine bay → grille → front bumper. Three heavy cables bundled together. Fully inside body, no exposed frame rail.
 - **BCDC input + cross-ground reference (H3):** **Under the rear bench seat** cushion → passenger rear wheel well. Short, dry, physically protected.
 - **SafetyHub local feed (2 AWG):** ~2 ft local in wheel well, no routing concern.
 
@@ -115,7 +115,7 @@ All wire runs require appropriate protection based on location and environment:
 | **Bus → SwitchPros**                   | 2 AWG      | ~2 ft    | TO SwitchPros power module                 | Via 150A CB                                     |
 | **Bus → BODY PDU**                     | 2 AWG      | ~2 ft    | TO BODY PDU                                | Via 100A CB                                     |
 | **AUX bat → JL Audio MV800/8i Amp**    | 4 AWG      | ~3-4 ft  | TO MV800/8i amp (under rear seat)          | Via 100A CB at AUX battery (not via firewall bus) |
-| **SwitchPros Ground Bus**              | 1 AWG      | ~3 ft    | TO chassis ground at firewall              | Lighting/aux load returns                       |
+| **SwitchPros Ground Bus**              | 1/0 AWG    | ~3 ft    | TO chassis ground at firewall              | Lighting/aux load returns                       |
 | **SwitchPros control cable**           | Multi-pin  | ~5 ft    | TO SwitchPros panel on dash                | Standard SwitchPros cable                       |
 | **SwitchPros outputs (12 circuits)**   | Various    | {{ tbd(107) }} | TO various loads (front/cabin/rear/roof) | Mostly short forward fan-out from firewall      |
 
@@ -195,7 +195,7 @@ J1939 CAN High/Low wires tap into Cummins harness at firewall punch-through, the
 | 🔋 **Passenger rear wheel well**   | Rear frame rail       | 2/0 AWG    | AUX battery-                                          | AUX battery ground point  |
 | 🏠 **Firewall (cabin side)**  | Firewall stud bus     | 4 AWG max  | Body electronics, sensors                             | Cabin electronics ground  |
 | ⚙️ **Firewall (engine side)** | Engine bay ground bus | Various    | PMU, controllers, accessories                         | Engine bay ground hub     |
-| 🌐 **SwitchPros controller**  | SwitchPros ground bus | 1 AWG      | Lighting/aux loads                                    | Dedicated lighting ground |
+| 🌐 **SwitchPros controller**  | SwitchPros ground bus | 1/0 AWG    | Lighting/aux loads                                    | Dedicated lighting ground |
 
 ---
 

--- a/docs/jeep_lj/01-power-systems/08-load-analysis/02-start-battery.md
+++ b/docs/jeep_lj/01-power-systems/08-load-analysis/02-start-battery.md
@@ -21,7 +21,6 @@ All circuits powered by START battery (alternator charging):
 | OUT9             | Dakota Digital    |     25A |      25A | Continuous             | Gauges always on      |
 | OUT11            | Wiper Controller  |      0A |      15A | Intermittent           | Rain only             |
 | OUT13            | CT4 Controller    |     10A |      10A | Continuous             | Street lighting       |
-| OUT15            | Winch Trigger     |      0A |       1A | Recovery only          | Control signal only   |
 | OUT17            | A/C Clutch        |      0A |       5A | Summer only            | Seasonal              |
 | OUT18            | Horn              |      0A |     5.4A | Seconds                | Emergency only        |
 | OUT20            | STX Intercom      |      1A |       5A | Brief TX bursts        | Standby vs transmit   |
@@ -30,7 +29,7 @@ All circuits powered by START battery (alternator charging):
 | OUT23            | DRL               |    2.6A |     2.6A | Daytime only           | Auto-off at night     |
 | **Fwd Dist Bus (START-direct)** | |       |          |                        | relocated off the PMU |
 | Fwd Bus          | iBooster main     |   0.25A |      40A | Seconds during braking | Brief peak            |
-| Fwd Bus          | Radiator Fan      |     20A |      53A | Variable (own controller) | Lingenfelter VSFM-002    |
+| Fwd Bus          | Radiator Fan      |     20A |      53A | Variable (own controller) | Controller {{ tbd(134) }} |
 | Fwd Bus          | Turbolamik TCU    |     15A |      15A | Continuous             | Must stay on          |
 | Ign bus          | iBooster Enable   |      5A |       5A | Continuous             | Ignition-switched     |
 | **BCDC Charger** |                   |         |          |                        |                       |
@@ -188,7 +187,7 @@ All circuits powered by START battery (alternator charging):
 | Emergency Braking | 165A       | 270A       | 61%         | Excellent |
 | Parked Idling     | 122A       | 270A       | 45%         | Excellent |
 
-**Worst Realistic Case:** 201A (offroad with hot engine), or ~216A including the now-itemized TCU = **54-69A margin**
+**Worst Realistic Case:** 201A (offroad with hot engine) = **69A margin** (74% utilization). Folding in the now-itemized TCU (~15A continuous) raises this to ~216A (54A margin) — still within capacity.
 
 **Key Insight:** All realistic scenarios stay well within alternator capacity. The 270A alternator provides adequate margin for all operating conditions.
 
@@ -200,8 +199,8 @@ The following high-current loads are **NOT** supplied by the alternator:
 | :----------------------- | :-------- | :------------ | :------------------------ |
 | SwitchPros (all outputs) | 127A max  | AUX battery   | BCDC-fed, isolated        |
 | ARB Compressor           | 90A       | AUX battery   | Via SafetyHub on AUX      |
-| Winch                    | 400A peak | AUX battery   | Direct connection         |
-| BODY PDU circuits        | 56A max   | AUX battery   | CONSTANT bus fed          |
+| Winch                    | 409A peak | AUX battery   | Direct connection         |
+| BODY PDU circuits        | 54A max   | AUX battery   | CONSTANT bus fed          |
 | Starter                  | 400-600A  | START battery | Cranking only, engine off |
 | Grid Heater              | 250A      | START battery | 3-5 sec cold start only   |
 

--- a/docs/jeep_lj/01-power-systems/08-load-analysis/03-aux-battery.md
+++ b/docs/jeep_lj/01-power-systems/08-load-analysis/03-aux-battery.md
@@ -30,24 +30,23 @@ All circuits powered by AUX battery (charged by BCDC at 50A max):
 | **SafetyHub 150**      |                          |         |      |                   |                           |
 | MIDI-1                 | ARB Compressor Motor 1   |      0A |  45A | Airing up         | Half of twin              |
 | MIDI-2                 | ARB Compressor Motor 2   |      0A |  45A | Airing up         | Half of twin              |
-| ATC-1                  | Winch Trigger            |      0A |  10A | Recovery only     | Contactor coil            |
 | **BODY PDU**           |                          |         |      |                   |                           |
 | CB30                   | Fusion Radio (memory)    |      1A |   1A | Continuous        | Clock/presets             |
-| CB44                   | Fusion Radio (head unit) |      0A |  15A | Audio playing     | Ignition-triggered        |
+| CB30                   | Fusion Radio (head unit) |      0A |  15A | Audio playing     | Ignition-triggered (consolidated on CB30) |
 | CB48                   | USB Charging (2x 75W)    |      2A |  13A | Devices charging  | Always on                 |
 | CB39                   | WolfBox Camera           |      2A |  10A | Continuous        | Dash + backup             |
 | CB45                   | Driver Heated Seat       |      0A |   5A | Winter            | Relay K21                 |
 | CB42                   | Passenger Heated Seat    |      0A |   5A | Winter            | Relay K22                 |
 | CB43                   | Winch Control (dash)     |      0A |   2A | Recovery only     | Rocker signal             |
 | **Direct**             |                          |         |      |                   |                           |
-| -                      | Winch Motor              |      0A | 400A | 10-30 sec bursts  | Recovery only             |
+| -                      | Winch Motor              |      0A | 409A | 10-30 sec bursts  | Recovery only             |
 
 ## Charging Source
 
 **BCDC Alpha 50:** Charges AUX battery at up to 50A from START battery/alternator
 
-- **Solar input:** Up to 6.7A additional (80W panel)
-- **Combined max:** ~57A charging rate (sunny day, engine running)
+- **Solar input:** Up to ~5.8A additional, battery-side (80W panel; see [Solar Charging][solar])
+- **Combined max:** ~56A charging rate (sunny day, engine running)
 - **Typical charging:** 30-50A depending on AUX battery SOC
 
 **AUX Battery:** Dakota Lithium DL+ 135Ah LiFePO4
@@ -189,17 +188,16 @@ All circuits powered by AUX battery (charged by BCDC at 50A max):
 | Circuit                        |     Load | Reason         |
 | :----------------------------- | -------: | :------------- |
 | **Winch Motor**                | **250A** | Moderate pull  |
-| **Winch Trigger (ATC-1)**      |  **10A** | Contactor coil |
-| **Winch Control (CB43)**       |   **2A** | Dash rocker    |
+| **Winch Control (CB43)**       |   **2A** | Dash push, control signal via BODY PDU CB43 |
 | **Fusion Radio memory (CB30)** |   **1A** | Always on      |
 | **WolfBox Camera (CB39)**      |   **2A** | Recording      |
-| **TOTAL**                      | **265A** |                |
+| **TOTAL**                      | **255A** |                |
 
 **BCDC Charging:** 50A (full rate)
 
-**Net Battery Effect:** -215A (heavy discharge)
+**Net Battery Effect:** -205A (heavy discharge)
 
-**30-second pull:** 215A × (30/3600)h = **1.8Ah used** (1.7% of usable capacity)
+**30-second pull:** 205A × (30/3600)h = **1.7Ah used** (1.6% of usable capacity)
 
 **Assessment:** Winch operations have negligible battery impact. Can perform 50+ pulls before approaching 20% SOC.
 
@@ -221,7 +219,7 @@ All circuits powered by AUX battery (charged by BCDC at 50A max):
 
 **BCDC Charging:** 0A (engine off)
 
-**Solar (daytime):** ~5-6A (80W panel)
+**Solar (daytime):** ~5.8A battery-side (80W panel — see [Solar Charging][solar])
 
 **Net Battery Effect (day):** -21A
 
@@ -248,7 +246,7 @@ All circuits powered by AUX battery (charged by BCDC at 50A max):
 | Night Offroad     | 45A        | 50A  | +5A        | N/A (charging)  | Excellent |
 | Air Up (5-10 min) | 110A       | 50A  | -60A       | 108 minutes     | Excellent |
 | Air Up Extended   | 110A       | 50A  | -60A       | 108 minutes     | Excellent |
-| Winch Recovery    | 265A       | 50A  | -215A      | 50+ pulls       | Excellent |
+| Winch Recovery    | 255A       | 50A  | -205A      | 50+ pulls       | Excellent |
 | Camp Mode         | 27A        | 0A   | -27A       | **4 hours**     | Good      |
 
 **Key Insight:** With corrected XL Sport specs (2.2A/pod vs 6A), full night offroad lighting (45A) is now fully covered by 50A BCDC charging. The Dakota Lithium 135Ah upgrade provides effectively unlimited runtime for all driving scenarios including full lighting. Camp mode provides 4+ hours without engine.
@@ -263,6 +261,7 @@ All circuits powered by AUX battery (charged by BCDC at 50A max):
 - [PMU ARB Load Shedding][arb-load-shedding] - Load management during ARB operation
 
 [bcdc]: ../01-power-generation/03-bcdc.md
+[solar]: ../01-power-generation/04-solar.md
 [safetyhub]: ../03-aux-battery-distribution/04-safetyhub.md
 [switchpros]: ../../05-control-interfaces/02-switchpros-sp1200.md
 [body-pdu]: ../03-aux-battery-distribution/03-body-pdu.md

--- a/docs/jeep_lj/01-power-systems/08-load-analysis/index.md
+++ b/docs/jeep_lj/01-power-systems/08-load-analysis/index.md
@@ -14,7 +14,7 @@ The Jeep LJ uses a dual battery architecture with isolated power domains:
 | Battery   | Location             | Charging                | Primary Loads                   |
 | :-------- | :------------------- | :---------------------- | :------------------------------ |
 | **START** | Driver rear wheel well    | Alternator (270A)       | PMU, engine systems, BCDC       |
-| **AUX**   | Passenger rear wheel well | BCDC (50A) + Solar (6A) | SwitchPros, SafetyHub, BODY PDU |
+| **AUX**   | Passenger rear wheel well | BCDC (50A) + Solar (~5.8A) | SwitchPros, SafetyHub, BODY PDU |
 
 **Key Principle:** The BCDC is the only connection between batteries during normal operation. AUX battery loads do NOT draw from the alternator directly.
 
@@ -76,7 +76,7 @@ These loads are **NOT** included in running alternator calculations:
 | :---------------- | :------- | :------------------------- |
 | Starter           | 400-600A | Cranking only (engine off) |
 | Grid Heater       | 250A     | 3-5 sec cold start only    |
-| Winch             | 400A     | AUX battery (isolated)     |
+| Winch             | 409A     | AUX battery (isolated)     |
 | ARB Compressor    | 90A      | AUX battery (isolated)     |
 | SwitchPros lights | 100A+    | AUX battery (isolated)     |
 
@@ -86,13 +86,13 @@ These loads are **NOT** included in running alternator calculations:
 
 | Scenario          | Total Load | Alternator | Utilization | Status    |
 | :---------------- | :--------- | :--------- | :---------- | :-------- |
-| Highway Driving   | 107A       | 270A       | 40%         | Excellent |
-| Hot City Driving  | 194A       | 270A       | 72%         | Good      |
-| Offroad Trail     | 207A       | 270A       | 77%         | Good      |
-| Emergency Braking | 166A       | 270A       | 61%         | Excellent |
-| Parked Idling     | 123A       | 270A       | 46%         | Excellent |
+| Highway Driving   | 101A       | 270A       | 37%         | Excellent |
+| Hot City Driving  | 188A       | 270A       | 70%         | Good      |
+| Offroad Trail     | 201A       | 270A       | 74%         | Good      |
+| Emergency Braking | 165A       | 270A       | 61%         | Excellent |
+| Parked Idling     | 122A       | 270A       | 45%         | Excellent |
 
-**Worst Case:** 207A (offroad) = 63A margin
+**Worst Case:** 201A (offroad) = 69A margin
 
 ### AUX Battery (BCDC-Charged)
 

--- a/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
+++ b/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
@@ -31,7 +31,7 @@ This document tracks intentional deviations from general electrical standards wh
 **Load Characteristics:**
 
 - Typical: 250A continuous during recovery
-- Peak: 400A brief (winch stall or heavy load)
+- Peak: 409A brief (winch stall or heavy load)
 - Duration: 10-30 seconds typical, 60 seconds maximum
 - Duty Cycle: Brief intermittent use (not continuous)
 
@@ -40,7 +40,7 @@ This document tracks intentional deviations from general electrical standards wh
 - Wire: 1/0 AWG copper (325A continuous rating @ 60°C)
 - Distance: 13 ft one-way (26 ft total circuit)
 - Voltage drop @ 250A: 5.32% (0.638V) - acceptable for brief accessory loads
-- Voltage drop @ 400A: 8.51% (1.021V) - acceptable for brief peak loads
+- Voltage drop @ 409A: 8.70% (1.044V) - acceptable for brief peak loads
 
 **Protection Mechanisms:**
 
@@ -56,7 +56,7 @@ This document tracks intentional deviations from general electrical standards wh
 
 3. **Cable Self-Protection**
    - 1/0 AWG fuses open at ~800A+ (thermal runaway)
-   - Well above 400A operating peak
+   - Well above 409A operating peak
    - Adequate for brief loads per SAE J1128
 
 4. **Manual Battery Disconnect**
@@ -117,7 +117,7 @@ This document tracks intentional deviations from general electrical standards wh
 
 **Normal Operating Conditions:**
 
-- 250-400A loads are within winch design parameters
+- 250-409A loads are within winch design parameters
 - Cable sizing adequate per voltage drop analysis
 - No fire hazard during normal recovery operations
 

--- a/docs/jeep_lj/02-engine-systems/02-brake-booster.md
+++ b/docs/jeep_lj/02-engine-systems/02-brake-booster.md
@@ -164,12 +164,12 @@ flowchart LR
     SWITCH["Stop-lamp switch<br/>Mopar 56045043AB<br/>(closes when pedal pressed)"]
     PMU["PMU In 2<br/>via Deutsch Pin 13"]
     LIGHTS["PMU OUT21 (7A)<br/>Brake lights"]
-    STARTER["Crank chain tap<br/>via Firewall Pin 15"]
+    PBSI["PBS-I Brake input<br/>(T-tapped with PMU In 2<br/>and Turbolamik TCU)"]
     TCU["Turbolamik TCU<br/>brake input"]
 
     SUPPLY --> SWITCH
     SWITCH -->|"Pole 1 tap"| PMU
-    SWITCH -->|"Pole 1 tap"| STARTER
+    SWITCH -->|"Pole 1 tap"| PBSI
     SWITCH -->|"Pole 1 tap"| TCU
     PMU -->|"In 2 closes → OUT21 ON"| LIGHTS
 
@@ -177,13 +177,13 @@ flowchart LR
     style SWITCH fill:#d1d5db,color:#000
     style PMU fill:#a5d8ff,color:#000
     style LIGHTS fill:#d1d5db,color:#000
-    style STARTER fill:#d1d5db,color:#000
+    style PBSI fill:#d1d5db,color:#000
     style TCU fill:#d1d5db,color:#000
 ```
 
 - **PMU is sensor + brain, not load path:** PMU In 2 senses pedal-pressed; PMU OUT21 (7A) carries the actual brake-light current. Switch itself only handles logic-level (<1A).
-- **Single pole used:** TJ/LJ 03-06 stop-lamp switches are 2-pole (4 pins). Pole 1 routes to PMU/starter/TCU; Pole 2 was the factory cruise-deactivation pole — leave disconnected, not in this design.
-- **Splice location:** Pole 1 output splices in the cabin into three branches — one to each downstream consumer.
+- **Single pole used:** TJ/LJ 03-06 stop-lamp switches are 2-pole (4 pins). Pole 1 routes to PMU/PBS-I/TCU; Pole 2 was the factory cruise-deactivation pole — leave disconnected, not in this design.
+- **Splice location:** Pole 1 output splices in the cabin into three branches — PMU In 2, PBS-I Brake input, and Turbolamik TCU brake input. Crank comes solely from the PBS-I PURPLE START output — brake switch Pole 1 does NOT connect to Firewall Pin 15.
 
 See [tail/brake][tail-brake] (PMU lighting flow), [starter][starter] (crank chain), and [transmission][transmission] (TCU brake input) for the downstream details.
 

--- a/docs/jeep_lj/02-engine-systems/03-hvac.md
+++ b/docs/jeep_lj/02-engine-systems/03-hvac.md
@@ -35,7 +35,7 @@ Factory 2005 TJ HVAC system retained. Uses vacuum-operated mode doors, cable-ope
 | Circuit      | PMU        | Load     | Control            | Notes                                |
 | :----------- | :--------- | :------- | :----------------- | :----------------------------------- |
 | Blower Motor | OUT5 (25A) | ~20A max | Auto (ignition ON) | Factory resistor pack controls speed |
-| A/C Clutch   | OUT17 (7A) | 3-5A     | In 9 trigger       | Factory A/C button → PMU In 9        |
+| A/C Clutch   | OUT17 (7A) | 3-5A     | In 9 trigger       | Factory A/C button → PMU In 9 (12V source for button signal undefined post-PCM-delete — {{ tbd(146) }}) |
 
 See [PMU Outputs][pmu-outputs] for complete configuration.
 

--- a/docs/jeep_lj/02-engine-systems/03-hvac.md
+++ b/docs/jeep_lj/02-engine-systems/03-hvac.md
@@ -12,38 +12,38 @@ tags:
 
 /// html | div.product-info
 
-**Type:** Factory HVAC System
+**Type:** Custom Electronic A/C + Heat System
 
-**Model:** 2005 TJ/LJ HVAC Assembly
+**Model:** Restomod Air custom kit — configuration {{ tbd(146) }} (confirm against order)
 
-**Manufacturer:** Chrysler/Jeep (OEM)
+**Manufacturer:** Restomod Air
 
-**Mounting:** Factory under-dash location
+**Mounting:** Under-dash (replaces factory TJ HVAC assembly)
 
 **Power Source:** PMU OUT5 (blower motor), OUT17 (A/C clutch)
 
-**Control:** Factory TJ HVAC control panel
+**Control:** Restomod Air electronic control head
 
 ///
 
 ## Overview
 
-Factory 2005 TJ HVAC system retained. Uses vacuum-operated mode doors, cable-operated temperature blend door, and factory dash control panel. Requires only 2 PMU outputs.
+Custom Restomod Air electronic HVAC system (on order) replaces the factory 2005 TJ HVAC.[^restomod-order] Restomod Air kits are fully electronic — mode and blend doors are servo-driven from the control head — so the factory vacuum mode doors, cable blend door, and dash control panel are all deleted.[^restomod-electronic] This removes the build's only vacuum consumer: no vacuum supply from the R2.8 is required (the diesel makes minimal manifold vacuum anyway, and braking is already vacuum-independent — see [iBooster][brake-booster]).
 
 ## PMU Integration
 
 | Circuit      | PMU        | Load     | Control            | Notes                                |
 | :----------- | :--------- | :------- | :----------------- | :----------------------------------- |
-| Blower Motor | OUT5 (25A) | ~20A max | Auto (ignition ON) | Factory resistor pack controls speed |
-| A/C Clutch   | OUT17 (7A) | 3-5A     | In 9 trigger       | Factory A/C button → PMU In 9 (12V source for button signal undefined post-PCM-delete — {{ tbd(146) }}) |
+| Blower Motor | OUT5 (25A) | {{ tbd(146) }} — verify kit blower draw ≤25A | Auto (ignition ON) | Blower speed controlled by Restomod Air control head, not PMU |
+| A/C Clutch   | OUT17 (7A) | 3-5A     | In 9 trigger       | Restomod Air control head compressor request → trinary switch → PMU In 9 ({{ tbd(146) }} — verify wire ID against kit diagram on arrival) |
 
 See [PMU Outputs][pmu-outputs] for complete configuration.
 
-## Vacuum System
+## A/C Request Circuit (PMU In 9)
 
-**Source:** R2.8 intake manifold → check valve → reservoir → firewall → factory HVAC controls
+The Restomod Air control head generates the A/C request: when A/C is commanded, its compressor-engage output goes to 12V. That output routes **through the kit's trinary pressure switch** (30 psi low-pressure cutout, 406 psi high-pressure cutout)[^trinary] and then to **PMU In 9**, so the PMU only sees a request when refrigerant pressure is in the safe range. PMU logic then drives OUT17 → compressor clutch.
 
-**Components:** 10-15 ft vacuum line (1/4" ID), check valve, vacuum reservoir, tee fittings
+The trinary switch's third function (electric fan request at 254 psi) is not wired — radiator fan control is handled by the dedicated fan controller with its own coolant sensor (see [Radiator Fan][radiator-fan]); revisit only if condenser airflow proves insufficient.
 
 ## R2.8 ECM A/C Integration
 
@@ -56,6 +56,15 @@ The CM2220 ECM used by the R2.8 has no A/C request input pin, so PMU-to-ECM A/C 
 ## Related Documentation
 
 - [PMU Outputs][pmu-outputs] - OUT5 and OUT17 configuration
+- [PMU Inputs][pmu-inputs] - In 9 A/C request
+- [iBooster][brake-booster] - Vacuum-independent braking (no engine vacuum used anywhere in the build)
+- [Radiator Fan][radiator-fan] - Fan control (independent of A/C trinary fan signal)
 
-[install-checklist]: ../09-installation/02-engine-systems-checklist.md
 [pmu-outputs]: ../01-power-systems/04-pmu/03-pmu-outputs.md
+[pmu-inputs]: ../01-power-systems/04-pmu/02-pmu-inputs.md
+[brake-booster]: 02-brake-booster.md
+[radiator-fan]: 06-radiator-fan.md
+
+[^restomod-order]: Owner confirmation, 2026-06-11 — custom kit ordered from restomodair.com. Model/configuration per order confirmation; update this page when the unit arrives.
+[^restomod-electronic]: Restomod Air product line is "fully electronic aftermarket a/c system kits" with electronic control heads (no vacuum actuation). restomodair.com, accessed 2026-06-11.
+[^trinary]: Restomod Air trinary switch: 30 psi low-pressure cutout, 406 psi high-pressure cutout, electric fan signal at 254 psi. restomodair.com/support/trinary-switch/, accessed 2026-06-11.

--- a/docs/jeep_lj/02-engine-systems/05-horn.md
+++ b/docs/jeep_lj/02-engine-systems/05-horn.md
@@ -49,7 +49,7 @@ tags:
 ```text
 START battery CONSTANT → PMU → Out 18 → PIAA Horns (5.4A) → Chassis Ground
                           ↑
-                      Horn Button → In 1 (trigger)
+                      Horn Button → In 1 (trigger)  [column path undefined — {{ tbd(152) }}]
 ```
 
 **Power Flow:**

--- a/docs/jeep_lj/02-engine-systems/07-grid-heater.md
+++ b/docs/jeep_lj/02-engine-systems/07-grid-heater.md
@@ -8,7 +8,7 @@ tags:
   - cummins
 ---
 
-# 2.9 Grid Heater System {#29-grid-heater-system}
+# 2.7 Grid Heater System {#27-grid-heater-system}
 
 /// html | div.product-info
 

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/01-hdx-control.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/01-hdx-control.md
@@ -100,7 +100,7 @@ Main control box for HDX instrument system. Processes sensor inputs, BIM module 
 | **HIGH**                 | 18 AWG ✓    | CT4 high beam output         | HDX HIGH input          | High beam indicator                              |
 | **LEFT**                 | 18 AWG ✓    | CT4 left turn output         | HDX LEFT input          | Left turn indicator                              |
 | **RIGHT**                | 18 AWG ✓    | CT4 right turn output        | HDX RIGHT input         | Right turn indicator                             |
-| **4x4/EX**               | 18 AWG ✓    | Transfer case switch ({{ tbd(145) }} — NV241 GenII Command-Trac has no position switch) | HDX 4x4/EX input | 4WD/4LO indicators                               |
+| 4x4/EX                   | -           | -                            | -                       | Not used — NV241 Command-Trac is cable-shifted with no electrical position switch; 4WD/4LO indicator omitted (lever position is visible). Retrofit a linkage switch later if dash indication is wanted. |
 | GEAR                     | -           | BIM-01-2 J1939               | -                       | Gear position read from Turbolamik J1939 broadcast (no discrete input wiring) |
 | **WAIT/EX**              | 18 AWG ✓    | ECM Pin 35 (yellow wire, WAIT TO START) | HDX WAIT/EX input | Sink-circuit per Cummins R2.8 Installation Guide 5504137 (§2, ECM pin 35, yellow) — wire is active LOW (~0V when WAIT on, ~+12V when off). HDX input documented as "active high" — polarity bench-verification pending {{ tbd(150) }}. |
 | EX                       | -           | -                            | -                       | Reserved                                         |
@@ -126,7 +126,6 @@ All BIM modules connect via single daisy-chain harness from HDX control 3.5mm po
 
 ## Build Tasks
 
-- [ ] Determine 4WD/4LO indicator signal types (NV241 GenII Command-Trac (JK Sport) — {{ tbd(145) }}: has no position switch; solution TBD)
 - [ ] Determine brake indicator source (brake switch vs CT4 output)
 - [ ] Bench-verify WAIT/EX polarity at HDX input — {{ tbd(150) }}: Cummins specifies active-low, HDX docs list "active high"; resolve before final wiring
 

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/01-hdx-control.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/01-hdx-control.md
@@ -7,7 +7,7 @@ tags:
   - control-module
 ---
 
-# 4.4.1 HDX Control Module {#hdx-control-module}
+# 2.9.1 HDX Control Module {#hdx-control-module}
 
 /// html | div.product-info
 ![Dakota Digital HDX Control Module](../../images/dakota-digital-hdx-control-module.jpg){ loading=lazy }
@@ -28,7 +28,7 @@ Main control box for HDX instrument system. Processes sensor inputs, BIM module 
 
 **Mounting:** HDPE panel on firewall behind dashboard
 
-**Power:** [PMU OUT9][pmu-outputs] (25A capacity, CONSTANT power)
+**Power:** [PMU OUT9][pmu-outputs] (25A capacity, CONSTANT power) — {{ tbd(144) }} (architecture decision: PMU OUT9 vs Critical Cabin PDU Slot 2)
 
 ## Specifications
 
@@ -93,16 +93,16 @@ Main control box for HDX instrument system. Processes sensor inputs, BIM module 
 | TACH WARN                | -           | -                            | -                       | Not used (J1939 provides tach via BIM-01-2)      |
 | TACH                     | -           | -                            | -                       | Not used (J1939 provides tach via BIM-01-2)      |
 | **IGNITION PWR**         | 16 AWG      | Ignition bus bar             | HDX ignition input      | Switched 12V for ignition-controlled features    |
-| **12 VDC CONSTANT**      | 16 AWG ✓    | Critical Cabin PDU Slot 2    | HDX power input         | 10A fuse, CONSTANT power, ~2 ft                  |
+| **12 VDC CONSTANT**      | 16 AWG ✓    | Critical Cabin PDU Slot 2 ({{ tbd(144) }}) | HDX power input | 10A fuse, CONSTANT power, ~2 ft                  |
 | **DIM**                  | 18 AWG ✓    | Tail light circuit           | HDX DIM input           | Dash dimming control (variable voltage)          |
 | **ENGINE**               | 18 AWG ✓    | ECM Pin 22 (white wire, MIL) | HDX ENGINE input        | Check engine light / MIL signal — sink-circuit (active low at wire) per Cummins R2.8 Installation Guide 5504137 |
 | **BRAKE**                | 18 AWG ✓    | Brake switch or CT4          | HDX BRAKE input         | Brake pedal indicator                            |
 | **HIGH**                 | 18 AWG ✓    | CT4 high beam output         | HDX HIGH input          | High beam indicator                              |
 | **LEFT**                 | 18 AWG ✓    | CT4 left turn output         | HDX LEFT input          | Left turn indicator                              |
 | **RIGHT**                | 18 AWG ✓    | CT4 right turn output        | HDX RIGHT input         | Right turn indicator                             |
-| **4x4/EX**               | 18 AWG ✓    | Transfer case switch         | HDX 4x4/EX input        | 4WD/4LO indicators                               |
+| **4x4/EX**               | 18 AWG ✓    | Transfer case switch ({{ tbd(145) }} — NV241 GenII Command-Trac has no position switch) | HDX 4x4/EX input | 4WD/4LO indicators                               |
 | GEAR                     | -           | BIM-01-2 J1939               | -                       | Gear position read from Turbolamik J1939 broadcast (no discrete input wiring) |
-| **WAIT/EX**              | 18 AWG ✓    | ECM Pin 35 (yellow wire, WAIT TO START) | HDX WAIT/EX input | Sink-circuit per Cummins R2.8 Installation Guide 5504137 (§2, ECM pin 35, yellow) — wire is active LOW (~0V when WAIT on, ~+12V when off). HDX input documented as "active high" — polarity needs bench verification during install (HDX may invert internally, or LJ build docs may be mislabeled). |
+| **WAIT/EX**              | 18 AWG ✓    | ECM Pin 35 (yellow wire, WAIT TO START) | HDX WAIT/EX input | Sink-circuit per Cummins R2.8 Installation Guide 5504137 (§2, ECM pin 35, yellow) — wire is active LOW (~0V when WAIT on, ~+12V when off). HDX input documented as "active high" — polarity bench-verification pending {{ tbd(150) }}. |
 | EX                       | -           | -                            | -                       | Reserved                                         |
 | EX                       | -           | -                            | -                       | Reserved                                         |
 | WARN OUT                 | -           | -                            | -                       | Not used                                         |
@@ -126,9 +126,9 @@ All BIM modules connect via single daisy-chain harness from HDX control 3.5mm po
 
 ## Build Tasks
 
-- [ ] Determine 4WD/4LO indicator signal types (NP241 Rubicon transfer case outputs)
+- [ ] Determine 4WD/4LO indicator signal types (NV241 GenII Command-Trac (JK Sport) — {{ tbd(145) }}: has no position switch; solution TBD)
 - [ ] Determine brake indicator source (brake switch vs CT4 output)
-- [ ] Bench-verify WAIT/EX polarity at HDX input — Cummins manual specifies active-low sink-circuit, but HDX docs list "active high"; resolve before final wiring
+- [ ] Bench-verify WAIT/EX polarity at HDX input — {{ tbd(150) }}: Cummins specifies active-low, HDX docs list "active high"; resolve before final wiring
 
 ## Related Documentation
 

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/02-dashboard-cluster.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/02-dashboard-cluster.md
@@ -7,7 +7,7 @@ tags:
   - dashboard
 ---
 
-# 4.4.2 HDX Dashboard Cluster {#hdx-dashboard-cluster}
+# 2.9.2 HDX Dashboard Cluster {#hdx-dashboard-cluster}
 
 /// html | div.product-info
 ![Dakota Digital HDX-96J-TJ Dashboard Cluster](../../images/dakota-digital-hdx-96j-tj-cluster.jpg){ loading=lazy }

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/03-bim-j1939.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/03-bim-j1939.md
@@ -8,7 +8,7 @@ tags:
   - j1939
 ---
 
-# 4.4.3 BIM-01-2-J1939 (J1939 CAN Interface) {#bim-j1939-interface}
+# 2.9.3 BIM-01-2-J1939 (J1939 CAN Interface) {#bim-j1939-interface}
 
 /// html | div.product-info
 ![Dakota Digital BIM-01-2-J1939 CAN Interface](../../images/dakota-digital-bim-01-2-j1939.jpg){ loading=lazy }
@@ -82,7 +82,7 @@ Specific J1939 parameters vary by ECM configuration and vehicle application. Cum
 | :----------- | :-------------------------------- | :------------- | :---------- | :------------------------------- |
 | **CAN High** | Cummins body harness (cabin side) | BIM-01-2 CAN H | 18-22 AWG ✓ | Twisted pair with CAN Low        |
 | **CAN Low**  | Cummins body harness (cabin side) | BIM-01-2 CAN L | 18-22 AWG ✓ | Twisted pair with CAN High       |
-| **Constant** | Critical Cabin PDU Slot 3         | BIM-01-2 power | 18 AWG ✓    | BIM CONSTANT power               |
+| **Constant** | Critical Cabin PDU Slot 3 ({{ tbd(144) }}) | BIM-01-2 power | 18 AWG ✓ | BIM CONSTANT power — may be bus-powered via BIM/IO cable instead |
 | **BIM/IO**   | HDX control box                   | BIM-01-2 input | Proprietary | Daisy-chain to other BIM modules |
 
 **J1939 Connection:**

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/04-bim-gps.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/04-bim-gps.md
@@ -8,7 +8,7 @@ tags:
   - gps
 ---
 
-# 4.4.4 GPS-50-2 (GPS Speed/Compass Module) {#bim-gps-module}
+# 2.9.4 GPS-50-2 (GPS Speed/Compass Module) {#bim-gps-module}
 
 /// html | div.product-info
 ![Dakota Digital GPS-50-2 Module](../../images/dakota-digital-gps-50-2.jpg){ loading=lazy }
@@ -66,7 +66,7 @@ GPS speedometer is legally required for on-road operation. Ensure antenna has cl
 
 | Connection       | Source                    | Destination           | Wire Gauge  | Notes                       |
 | :--------------- | :------------------------ | :-------------------- | :---------- | :-------------------------- |
-| **Constant**     | Critical Cabin PDU Slot 4 | GPS-50-2 power        | 18 AWG ✓    | BIM CONSTANT power          |
+| **Constant**     | Critical Cabin PDU Slot 4 ({{ tbd(144) }}) | GPS-50-2 power | 18 AWG ✓ | BIM CONSTANT power — may be bus-powered via BIM/IO cable instead |
 | **BIM/IO**       | HDX control box           | GPS-50-2 input        | Proprietary | Data via daisy-chain        |
 | **GPS Antenna**  | GPS-50-2 module           | Dash/windshield mount | Coax cable  | Included antenna cable      |
 | **Outside Temp** | GPS-50-2 (optional)       | SEN-15-1 probe        | Sensor wire | If used instead of BIM-17-2 |

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/05-bim-tpms.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/05-bim-tpms.md
@@ -8,7 +8,7 @@ tags:
   - tpms
 ---
 
-# 4.4.5 BIM-22-3 (Tire Pressure Monitoring System) {#bim-tpms-module}
+# 2.9.5 BIM-22-3 (Tire Pressure Monitoring System) {#bim-tpms-module}
 
 /// html | div.product-info
 ![Dakota Digital BIM-22-3 TPMS](../../images/dakota-digital-bim-22-3-tpms.jpg){ loading=lazy }
@@ -62,7 +62,7 @@ Wireless TPMS module displaying real-time tire pressure for all four wheels on H
 
 | Connection   | Source                    | Destination       | Wire Gauge  | Notes                        |
 | :----------- | :------------------------ | :---------------- | :---------- | :--------------------------- |
-| **Constant** | Critical Cabin PDU Slot 5 | BIM-22-3 power    | 18 AWG ✓    | BIM CONSTANT power           |
+| **Constant** | Critical Cabin PDU Slot 5 ({{ tbd(144) }}) | BIM-22-3 power | 18 AWG ✓ | BIM CONSTANT power — may be bus-powered via BIM/IO cable instead |
 | **BIM/IO**   | HDX control box           | BIM-22-3 input    | Proprietary | Data via daisy-chain         |
 | **Sensors**  | Wireless                  | BIM-22-3 receiver | -           | No wiring - RF communication |
 

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/06-bim-compass.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/06-bim-compass.md
@@ -9,7 +9,7 @@ tags:
   - temperature
 ---
 
-# 4.4.6 BIM-17-2 (Compass/Outside Temperature Module) {#bim-compass-temp-module}
+# 2.9.6 BIM-17-2 (Compass/Outside Temperature Module) {#bim-compass-temp-module}
 
 /// html | div.product-info
 ![Dakota Digital BIM-17-2 Compass/Temperature](../../images/dakota-digital-bim-17-2-compass.jpg){ loading=lazy }
@@ -52,7 +52,7 @@ tags:
 
 | Connection     | Wire Gauge  | Source                    | Destination            | Distance | Notes                      |
 | :------------- | :---------- | :------------------------ | :--------------------- | :------- | :------------------------- |
-| **Constant**   | 18 AWG ✓    | Critical Cabin PDU Slot 6 | BIM-17-2 power         | ~1-2 ft  | BIM CONSTANT power         |
+| **Constant**   | 18 AWG ✓    | Critical Cabin PDU Slot 6 ({{ tbd(144) }}) | BIM-17-2 power | ~1-2 ft | BIM CONSTANT power — may be bus-powered via BIM/IO cable instead |
 | **BIM/IO**     | Proprietary | HDX control box           | BIM-17-2 input         | Varies   | Data via daisy-chain       |
 | **Temp Probe** | Sensor wire | BIM-17-2                  | SEN-15-1 (grille area) | ~6-8 ft  | Through firewall Grommet 6 |
 

--- a/docs/jeep_lj/02-engine-systems/index.md
+++ b/docs/jeep_lj/02-engine-systems/index.md
@@ -18,7 +18,7 @@ Engine bay systems and critical vehicle subsystems required for safe vehicle ope
 - **[2.5 Horn System][horn]** - PIAA twin-tone horn with relay control
 - **[2.6 Radiator Fan][radiator-fan]** - Electric radiator cooling fan system
 - **[2.7 Grid Heater][grid-heater]** - Cummins R2.8 cold-start grid heater relay and control
-- **[2.8 Fuel System][fuel-system]** - Lift pump control circuit (replaces factory PDC/PCM logic)
+- **[2.8 Fuel System][fuel-system]** - Gear-driven mechanical fuel pump (no electric lift pump; no electrical requirements)
 - **[2.11 Runaway Protection][runaway-protection]** - Mishimoto catch can + AMOT 4261M manual air shutoff
 
 ## System Overview

--- a/docs/jeep_lj/03-lighting-systems/03-turn-signals.md
+++ b/docs/jeep_lj/03-lighting-systems/03-turn-signals.md
@@ -35,6 +35,7 @@ Each CT4 output (SW1 right, SW2 left) splices to three destinations:
 **Type:** Amber LED turn signals
 **Quantity:** 2 (left and right fenders)
 **Function:** Turn signal only (CT4 controlled)
+**Part #:** {{ tbd(153) }}
 **Size:** 0.8" × 0.8" × 1.1"
 **Draw:** ~0.2A each (~0.4A total, estimated)
 

--- a/docs/jeep_lj/03-lighting-systems/06-dome-lights.md
+++ b/docs/jeep_lj/03-lighting-systems/06-dome-lights.md
@@ -51,6 +51,9 @@ Physical switch on KC #6337 bracket for rear dome control independent of SwitchP
 - KC switch output: Rear dome lights positive (parallel with SwitchPros OUTPUT-4)
 - Either switch can turn on rear domes independently
 
+!!! warning "Backfeed risk — isolation design pending"
+    As drawn, the CONSTANT-fed override tap is wired in parallel with OUTPUT-4 with no isolation diode. When the override switch is on, 12V CONSTANT backfeeds into OUTPUT-4 regardless of the SwitchPros state. Isolation design is pending — {{ tbd(148) }}.
+
 ## Outstanding Items
 
 {{ tbds() }}

--- a/docs/jeep_lj/04-offroad-lighting/07-cargo-lights.md
+++ b/docs/jeep_lj/04-offroad-lighting/07-cargo-lights.md
@@ -47,7 +47,7 @@ Interior cargo area lighting controlled by physical switch (Baja Designs Zone 7)
 
 **Switch Location:** Top of rear wheel well (accessible from tailgate)
 
-**Wiring:** BODY PDU CB20 (10A) → Switch → Cargo lights → Ground
+**Wiring:** BODY PDU CB20 (10A) → Switch → Cargo lights → Ground (power-source conflict with OUTPUT-13/TRIGGER-2 open — {{ tbd(147) }})
 
 | Spec | Value |
 | :--- | ----: |

--- a/docs/jeep_lj/04-offroad-lighting/index.md
+++ b/docs/jeep_lj/04-offroad-lighting/index.md
@@ -43,7 +43,7 @@ Lighting organized by [Baja Designs Zone System][bd-zones], optimized for specif
 | :--------------------------------------- | :--------------------------------------- | :--------------------------------- |
 | Roof, Ditch, Fog, Rock, Chase, Rear Work | [SwitchPros SP-1200][switchpros-sp-1200] | See controller for wiring          |
 | Cargo Lights                             | Physical switch                          | [Cargo Lights][cargo-lights]       |
-| Reverse Lights                           | [PMU Out 18][tail-brake-reverse]         | [Reverse Lights][reverse-lights]   |
+| Reverse Lights                           | [PMU Out 22][tail-brake-reverse]         | [Reverse Lights][reverse-lights]   |
 | RTL-S Brake/Running                      | PMU/OEM                                  | [Chase Lights][chase-lights]       |
 | Footwell                                 | [JL Audio MLC-RW][audio-systems]         | [Footwell Lights][footwell-lights] |
 

--- a/docs/jeep_lj/05-control-interfaces/02-switchpros-sp1200.md
+++ b/docs/jeep_lj/05-control-interfaces/02-switchpros-sp1200.md
@@ -50,14 +50,14 @@ tags:
 
 | Button |       Circuit       | Draw |                                  Details                                  |    Output Pin(s)     |
 | :----: | :-----------------: | :--: | :-----------------------------------------------------------------------: | :------------------: |
-|   1    |    Roof Lights      | 18A  |                  8x BD XL Sport (Linkable, single circuit)                |       OUTPUT-1       |
+|   1    |    Roof Lights      | 17.6A|                  8x BD XL Sport (Linkable, single circuit)                |       OUTPUT-1       |
 |   2    |    Ditch Lights     |  8A  |                   2x BD LP4 Pro (Driving/Combo Pattern)                   |       OUTPUT-2       |
 |   3    |      Fog Light      |  6A  |                   1x BD S8 10" (Amber, Wide Cornering)                    |       OUTPUT-3       |
 |   4    |     Dome Lights     |  2A  |                4x KC Cyclone V2 (manual + door-triggered)                 |       OUTPUT-4       |
 |   5    |   Interior LEDs     |  5A  |                   MLC-RW controller (speaker + footwell RGB)              |       OUTPUT-5       |
 |   6    |     Rock Lights     |  3A  |                          6x KC Cyclone V2 Lights                          |       OUTPUT-6       |
 |   7    |     Chase Light     |  1A  |                      BD RTL-S 30" (Amber chase mode)                      |       OUTPUT-7       |
-|   8    |     Navigation      |  2A  |                        Garmin Tread XL GPS                                |       OUTPUT-8       |
+|   8    |     Navigation      |  2A  |                  Garmin Tread 2 - Overland Edition GPS                     |       OUTPUT-8       |
 |   9    |    Front Locker     |  2A  |     ARB Locker (see [Air System][air-system-arb-compressor-lockers])      | OUTPUT-17 (low-side) |
 |   10   |     Rear Locker     |  2A  |     ARB Locker (see [Air System][air-system-arb-compressor-lockers])      |      OUTPUT-10       |
 |   11   |     Compressor      | 15A  | ARB Twin Compressor (see [Air System][air-system-arb-compressor-lockers]) |      OUTPUT-11       |
@@ -69,10 +69,9 @@ tags:
   - Driver door switch + Passenger door switch (wired in parallel) → TRIGGER-1 → OUTPUT-4
   - Either door opening or Button 4 press activates dome lights
 - **Button 7:** RTL-S amber chase function only - brake/running/work functions powered separately
-- **Buttons 5, 8:** Available for future use
 - **Button 11:** OUTPUT-11 provides control signal to ARB compressor (main power is separate: CONSTANT bus → dual 60A fuses → compressor)
-- **Cargo Light:** Not assigned to button - controlled by rear rocker switch via TRIGGER-2 → OUTPUT-13
-- Total lighting draw if all on simultaneously: 44A (within 150A capacity)
+- **Cargo Light:** Not assigned to button - controlled by rear rocker switch via TRIGGER-2 → OUTPUT-13 (power source conflict with BODY PDU CB20 — see {{ tbd(147) }})
+- Total lighting draw if all on simultaneously: 43.6A (within 150A capacity)
 
 ## Wiring Pinout
 
@@ -80,12 +79,12 @@ tags:
 
 | Pin |   Label   |    Color    | Gauge  |  Max Load   | Assigned Circuit                   | Load |                      Notes                      |
 | :-: | :-------: | :---------: | :----: | :---------: | ---------------------------------- | :--: | :---------------------------------------------: |
-|  1  | OUTPUT-5  |    GREEN    | 14 AWG |     15A     | _AVAILABLE_                        |  —   |                                                 |
+|  1  | OUTPUT-5  |    GREEN    | 14 AWG |     15A     | Interior LEDs (MLC-RW controller)  |  5A  |                                                 |
 |  2  | OUTPUT-6  |    BLUE     | 14 AWG |     15A     | Rock Lights                        |  3A  |                                                 |
 |  3  | IGNITION  |   LT BLUE   |   -    |      -      | Connect to ignition signal         |  -   |              For auto-off features              |
 |  4  |  LIGHTS   |    WHITE    |   -    |      -      | Connect to parking lights          |  -   |               For DRL integration               |
 |  5  | OUTPUT-7  |   PURPLE    | 14 AWG |     15A     | Chase Light (amber)                |  1A  |         RTL-S amber chase function only         |
-|  6  | OUTPUT-8  |    GREY     | 14 AWG |     15A     | _AVAILABLE_                        |  —   |                                                 |
+|  6  | OUTPUT-8  |    GREY     | 14 AWG |     15A     | Navigation (Garmin Tread 2)        |  2A  |                                                 |
 |  7  | TRIGGER-1 |    PINK     |   -    |      -      | Door switches (driver + passenger) |  -   | Triggers OUTPUT-4 (dome lights) when doors open |
 |  8  | TRIGGER-2 |    PINK     |   -    |      -      | Rear cargo rocker switch           |  -   |        Triggers OUTPUT-13 (cargo light)         |
 |  9  | OUTPUT-9  |    WHITE    | 14 AWG | 30A (2x15A) | SPARE (can combine 9+10)           |  -   |                                                 |
@@ -105,7 +104,7 @@ tags:
 
 | Pin |  Label   | Color  | Gauge | Max Load | Assigned Circuit | Load |    Notes    |
 | :-: | :------: | :----: | :---: | :------: | ---------------- | :--: | :---------: |
-|  1  | OUTPUT-1 | BROWN  | 10AWG |   35A    | Roof Lights (8x) | 18A  |             |
+|  1  | OUTPUT-1 | BROWN  | 10AWG |   35A    | Roof Lights (8x) | 17.6A|             |
 |  2  | OUTPUT-2 |  RED   | 10AWG |   35A    | Ditch Lights     |  8A  |             |
 |  3  | OUTPUT-3 | ORANGE | 10AWG |   35A    | Fog Light        |  6A  |             |
 |  4  | OUTPUT-4 | YELLOW | 10AWG |   35A    | Dome Lights      |  2A  |             |
@@ -207,7 +206,7 @@ and ground bus install are tracked in the [Power Systems Checklist][power-checkl
 - [ ] Program Button 4: OUTPUT-4 OR TRIGGER-1 → dome lights
 - [ ] Install rear cargo rocker switch → TRIGGER-2 (determine tailgate-accessible location)
 - [ ] Program TRIGGER-2 → OUTPUT-13 (cargo light)
-- [ ] Confirm cargo light wiring (OUTPUT-13) and ditch light wiring (OUTPUT-2)
+- [ ] Confirm cargo light wiring (OUTPUT-13) — power-source conflict pending {{ tbd(147) }}
 - [ ] Confirm ARB pressure switch → TRIGGER-3
 - [ ] Program TRIGGER-3 OR Button 11 → OUTPUT-11 (compressor auto/manual)
 - [ ] Test automatic pressure control (compressor on/off at setpoints)

--- a/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
+++ b/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
@@ -105,7 +105,7 @@ See [PMU DRL Auto-Off Logic](#pmu-drl-auto-off-logic) section below for complete
 | Yellow      | SW4, PUSH  | High Beams              | LP6 Pin 4 (high beam, both lights)                                       | 10A output, 5.6A load, disabled when ignition off        |
 | Red (thick) | 12V Supply | Main power input        | PMU Out 13 (15A CONSTANT)                                                | Powers all SW outputs, allows hazards when ignition off  |
 | Black       | Ground     | Ground return           | Chassis ground or firewall ground stud                                   | Via ignition/ground harness                              |
-| White/Gray  | Ignition   | Ignition signal input   | Ignition switch RUN output (18 AWG, splits to PMU Pin 7, SwitchPros, CT4) | Disables SW3/SW4 when ignition off, keeps SW1/SW2 active |
+| White/Gray  | Ignition   | Ignition signal input   | Cabin ignition bus bar Terminal 1 (18 AWG, ~20 mA, fused per bus doc)     | Disables SW3/SW4 when ignition off, keeps SW1/SW2 active |
 
 ## Programming Configuration
 
@@ -171,7 +171,7 @@ in the [Power Systems Checklist][power-checklist].
 
 - [ ] Confirm CT4 12V supply (PMU Out 13) landed at steering column
 - [ ] Confirm CT4 ground connected
-- [ ] Confirm CT4 ignition signal connected (shared Y-split with PMU Pin 7, SwitchPros)
+- [ ] Confirm CT4 ignition signal connected (cabin ignition bus bar Terminal 1)
 - [ ] Verify SW3/SW4 (headlights) disabled when ignition off
 - [ ] Verify SW1/SW2 (turn signals/hazards) work with ignition off (safety feature)
 

--- a/docs/jeep_lj/08-exterior-systems/01-winch.md
+++ b/docs/jeep_lj/08-exterior-systems/01-winch.md
@@ -60,7 +60,7 @@ No external circuit breaker — per the [WARN ZEON 10-S installation manual][war
   - **UP (momentary):** Winch OUT (let out cable)
   - **CENTER:** Off (spring return to center)
   - **DOWN (momentary):** Winch IN (pull in cable)
-- **Power:** SafetyHub ATC-1 (15A fuse)
+- **Power:** BODY PDU CB43 (10A)
 - **Use case:** In-cab winch control (self-recovery, convenient operation from driver seat)
 
 **Handheld Remote:**

--- a/docs/jeep_lj/08-exterior-systems/index.md
+++ b/docs/jeep_lj/08-exterior-systems/index.md
@@ -36,7 +36,7 @@ Recovery equipment and air systems for offroad capability.
 | Component      | Power Source            | Protection      | Control            |
 | -------------- | ----------------------- | --------------- | ------------------ |
 | Winch Motor    | AUX battery direct      | None (internal) | Dash rocker/remote |
-| Winch Control  | SafetyHub ATC-1         | 15A ATC         | Dash rocker        |
+| Winch Control  | BODY PDU CB43           | 10A             | Dash rocker        |
 | Compressor     | SafetyHub MIDI-1/MIDI-2 | 2× 60A MIDI     | SwitchPros OUT-11  |
 | Front Locker   | SwitchPros OUTPUT-17    | Low-side driver | Button 9           |
 | Rear Locker    | SwitchPros OUTPUT-10    | 15A             | Button 10          |

--- a/docs/jeep_lj/09-installation/01-power-systems-checklist.md
+++ b/docs/jeep_lj/09-installation/01-power-systems-checklist.md
@@ -210,7 +210,6 @@ live in the linked source docs, not here.
 - [ ] Confirm Dakota Digital system → OUT9
 - [ ] Confirm wipers (WS-51C) → OUT11
 - [ ] Confirm CT4 → OUT13
-- [ ] Confirm winch contactor trigger → OUT15
 - [ ] Confirm A/C clutch → OUT17
 - [ ] Confirm horn → OUT18
 - [ ] Confirm STX Intercom → OUT20
@@ -241,7 +240,6 @@ live in the linked source docs, not here.
 
 - [ ] Confirm ARB compressor motor 1 → MIDI-1
 - [ ] Confirm ARB compressor motor 2 → MIDI-2
-- [ ] Confirm winch contactor trigger → ATC-1
 
 ### Solar Panel Installation
 

--- a/docs/jeep_lj/09-installation/02-engine-systems-checklist.md
+++ b/docs/jeep_lj/09-installation/02-engine-systems-checklist.md
@@ -46,7 +46,7 @@ parts to buy live in the [Purchase Tracker][purchase-tracker].
 - [ ] Remove factory manual-trans pedal assembly
 - [ ] Verify donor auto pedal: stop-lamp switch + clip present, bushing OK, arm not bent
 - [ ] Install 03-06 auto brake pedal assembly
-- [ ] Reconnect stop-lamp switch wiring: PMU In 2, Pin 15 crank-chain tap, Turbolamik brake input
+- [ ] Reconnect stop-lamp switch wiring: PMU In 2, PBS-I Brake input, Turbolamik brake input (T-tap, cabin splice)
 - [ ] Plug clutch master cylinder firewall hole
 - [ ] Bench-measure pedal ratio vs factory pedal (confirm MC stroke + iBooster rod travel headroom)
 - [ ] Re-measure iBooster pushrod length after pedal install; adjust per harness vendor instructions
@@ -155,7 +155,7 @@ parts to buy live in the [Purchase Tracker][purchase-tracker].
 - [ ] Verify iBooster ground continuity to battery negative
 - [ ] Verify brake pedal feel with iBooster powered
 - [ ] Verify fail-safe mode (disconnect ignition signal, confirm basic assist)
-- [ ] Verify iBooster standby current within spec (ignition OFF)
+- [ ] Verify iBooster standby current within spec (ignition OFF) — {{ tbd(151) }}: standby spec not yet sourced
 - [ ] Road test: light braking, hard braking, engine-off coasting
 
 ### HVAC Testing

--- a/docs/jeep_lj/09-installation/02-engine-systems-checklist.md
+++ b/docs/jeep_lj/09-installation/02-engine-systems-checklist.md
@@ -80,9 +80,10 @@ parts to buy live in the [Purchase Tracker][purchase-tracker].
 
 ## Phase 4: HVAC
 
-- [ ] Confirm factory TJ HVAC system complete and functional
-- [ ] Confirm vacuum system installed: R2.8 manifold → check valve → reservoir → firewall → dash
-- [ ] Verify vacuum system holds vacuum
+- [ ] Confirm Restomod Air kit model/configuration against order on arrival ({{ tbd(146) }})
+- [ ] Install Restomod Air HVAC kit per included instructions (factory TJ HVAC assembly, vacuum lines, and cable linkage removed)
+- [ ] Verify Restomod Air blower draw ≤25A on PMU OUT5
+- [ ] Wire control head compressor request → trinary switch → PMU In 9 (verify wire colors against kit diagram)
 
 ---
 

--- a/docs/jeep_lj/09-installation/03-purchase-tracker.md
+++ b/docs/jeep_lj/09-installation/03-purchase-tracker.md
@@ -2,7 +2,7 @@
 
 Components organized by estimated cost for purchase planning (Black Friday, sales, etc.).
 
-**Last Updated:** 2026-05-30
+**Last Updated:** 2026-06-11
 
 ---
 
@@ -45,6 +45,7 @@ Components organized by estimated cost for purchase planning (Black Friday, sale
 | ARB CKBLTA12 Brushless Twin Compressor | ARB | ~$900 | [Air Compressor][air-compressor] |
 | ARB Pressure Switch (180901) | ARB | ~$50 | [Air Compressor][air-compressor] |
 | 4-6 Port Air Manifold | Generic | ~$30 | [Air Compressor][air-compressor] |
+| Restomod Air Custom HVAC Kit | Restomod Air | — (confirm) | Ordered 2026-06; replaces factory TJ HVAC — model/config {{ tbd(146) }} - [HVAC][hvac] |
 
 ---
 
@@ -213,6 +214,7 @@ _(Most electrical distribution components already purchased - see Purchased Item
 [winch]: ../08-exterior-systems/01-winch.md
 [air-compressor]: ../08-exterior-systems/02-air-compressor.md
 [ibooster]: ../02-engine-systems/02-brake-booster.md
+[hvac]: ../02-engine-systems/03-hvac.md
 [tulays]: https://tulayswirewerks.com/product/bosch-ibooster-gen-2-universal-wire-harness/
 [batteries]: ../01-power-systems/01-power-generation/01-batteries.md
 [amplifier]: ../06-audio-systems/02-amplifier.md

--- a/docs/jeep_lj/09-installation/03-purchase-tracker.md
+++ b/docs/jeep_lj/09-installation/03-purchase-tracker.md
@@ -107,6 +107,7 @@ Major components - watch for sales, consider financing options.
 | Item | Quantity | Est. Unit Price | Est. Total | Priority | Notes |
 |:-----|:--------:|:----------------|:-----------|:---------|:------|
 | LED4Life RGBW Pods (Footwell) | 4 | ~$15 | ~$60 | Low | [Footwell Lights][footwell-lights] |
+| KC HiLiTES Dual Cyclone Dome Light Mount #6337 | 1 | — | — | Medium | ADC12 aluminum, roll cage mount; required by [Dome Lights][dome-lights] |
 
 ---
 
@@ -141,6 +142,7 @@ _(Most electrical distribution components already purchased - see Purchased Item
 | PIAA 85115 Sports Horn | PIAA | ~$50 | Low | [Horn][horn] |
 | Overvoltage Protection Relay | Generic | ~$15-25 | Low | Solar protection - [Solar][solar] |
 | Deutsch HDP24-24-29 Connector Kit | Deutsch | ~$80 | High | [Firewall Ingress][firewall-ingress] |
+| SwitchPros 2-pin Delphi connector hardware (~12 harnesses: bodies, terminals, seals) | SwitchPros | — | High | P/N {{ tbd(156) }}; plug-and-play output harnesses - [SwitchPros][switchpros-sp1200] |
 | ARB Air Line Installation Kit | ARB | ~$50 | Medium | [Air Lockers][air-lockers] |
 | 0-200 PSI Pressure Gauge | Generic | ~$20 | Medium | [Air Compressor][air-compressor] |
 | Air Chuck Plate and Fittings | Generic | ~$30 | Low | [Rear Air Chuck][rear-air-chuck] |
@@ -230,6 +232,8 @@ _(Most electrical distribution components already purchased - see Purchased Item
 [reverse-lights]: ../04-offroad-lighting/10-reverse-lights.md
 [rear-lights]: ../04-offroad-lighting/08-rear-lights.md
 [cargo-lights]: ../04-offroad-lighting/07-cargo-lights.md
+[dome-lights]: ../03-lighting-systems/06-dome-lights.md
+[switchpros-sp1200]: ../05-control-interfaces/02-switchpros-sp1200.md
 [chase-light]: ../04-offroad-lighting/04-chase-lights.md
 [footwell-lights]: ../04-offroad-lighting/09-footwell-lights.md
 [speakers]: ../06-audio-systems/03-speakers.md


### PR DESCRIPTION
Resolves the actionable findings from a full four-agent design review of the Jeep LJ build docs (power-path trace, signal-chain integration, wire-spec consistency sweep, channel/checklist audit), excluding everything already tracked in open `tbd` issues.

## What's fixed here

**Safety / mis-wire corrections**
- Brake booster diagram no longer taps the brake switch into the crank chain (Firewall Pin 15 is the PBS-I PURPLE START output — the tap would crank on brake press). Brake switch now correctly shown feeding the PBS-I Brake input, T-tapped with PMU In 2 + Turbolamik. Same fix in the engine-systems checklist.
- CT4 ignition input rewritten from the deleted keyswitch "RUN output Y-split" to the cabin ignition bus Terminal 1 (PBS-I PINK IGN).
- Winch contactor trigger: stale PMU OUT15 and SafetyHub ATC-1 references purged everywhere (winch page, exterior index, PMU outputs, SafetyHub totals, load analyses, checklist) — BODY PDU CB43 (10A, 2026-05-30 decision) is now the single documented source.

**Consistency reconciliations (authoritative source wins)**
- SwitchPros: OUTPUT-5/8 harness rows match control-panel assignments; Tread XL → Tread 2 Overland; roof lights 17.6A.
- Reverse lights Out 18 → Out 22 in offroad index (Out 18 is the horn).
- Forward-feed current, Fusion head unit location (BODY PDU CB30), PMU 170A capacity, alternator worst-realistic figure, solar MPPT battery-side current, SwitchPros ground bus 1/0 AWG, H1 grommet pass-through (bulkhead-stud remnants removed), BODY PDU totals, START− connection count, section numbering (2.7/2.9.x).

**Open decisions → new `tbd` issues** #144–#156 (gauge power architecture, 4WD indicator source, A/C request signal, cargo-light source conflict, amp CB sizing, dome override isolation, WAIT polarity, iBooster standby spec, horn signal path, turn-signal part, ARB feed length, START− chassis bond, Delphi hardware), with `tbd(N)` markers placed at the affected spec cells. Comments added to #134 (VSFM-002 is brushed — incompatible with the brushless GM fan) and #135 (150A CB vs 2 AWG 60°C ampacity).

## TBD resolutions (commit `bfc6335`)

Owner decisions applied to four of the issues above:

- **#145 — closed (omit indicator):** the NV241 Command-Trac is cable-shifted with no electrical position output; the HDX 4x4/EX input is documented as Not used (lever position is visible; a linkage switch can be retrofitted later).
- **#146 — re-scoped to Restomod Air:** the factory TJ HVAC is replaced by a custom Restomod Air electronic kit (ordered). The A/C request for PMU In 9 comes from the Restomod Air control head's compressor output via the trinary switch; the factory-panel plan and the R2.8 vacuum-supply section are deleted. HVAC page rewritten; PMU inputs/outputs, firewall ingress, checklist, and purchase tracker updated. Issue is now `priority/verify` — confirm kit wiring + blower draw on arrival.
- **#155 — closed (no bond):** START− has 6 connections by design; the "7 connections" header was an error. Grounding pages now state the 6-connection count as final (chassis reference via the engine-bay ground bus; rear frame bond stays on AUX−).
- **#156 — research posted to the issue:** Metri-Pack 280 sealed recommended over Weather-Pack (30A rating and 10 AWG support vs. 20A/12 AWG max — Weather-Pack can't terminate the 10 AWG, 17.6A roof-light circuit). No purchase yet; tracker row stays TBD pending owner sign-off.

https://claude.ai/code/session_01DH4puEzqJGwRSS7Ng8bjDX

---
_Generated by [Claude Code](https://claude.ai/code/session_01DH4puEzqJGwRSS7Ng8bjDX)_