### PR TITLE
docs: nightly tidiness — trim verbosity (2026-07-04)

### DIFF
--- a/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
+++ b/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
@@ -83,17 +83,6 @@ This document tracks intentional deviations from general electrical standards wh
 - Direct battery connection specified ✓
 - Internal protection designed for fault scenarios ✓
 
-### Factory Vehicle Precedent
-
-**OEM winch installations do NOT use external circuit breakers:**
-
-- **Ford Super Duty** with factory winch prep: No CB on winch circuit
-- **RAM Power Wagon** factory winch: No external CB, direct battery connection
-- **Toyota TRD Pro** winch ready: No CB specified in prep package
-- **Jeep Rubicon** winch-capable: Power runs via relay, no CB
-
-**Industry Standard Practice:** Winch manufacturers design internal protection for automotive fault scenarios, making external CBs redundant.
-
 ### Winch Fault Scenarios Covered
 
 **Motor Stall (Extended Load):**
@@ -350,11 +339,6 @@ Grid heater brief, high-current load characteristics make circuit breaker unnece
    - Absorbs brief load spikes
    - Prevents alternator overload
    - Natural load smoothing
-
-4. **Factory Practice**
-   - No OEM vehicles use alternator output circuit breakers
-   - Proven safe over millions of vehicles
-   - Industry standard approach
 
 ### Alternator Review Guidance
 

--- a/docs/jeep_lj/02-engine-systems/05-horn.md
+++ b/docs/jeep_lj/02-engine-systems/05-horn.md
@@ -52,18 +52,6 @@ START battery CONSTANT → PMU → Out 18 → PIAA Horns (5.4A) → Chassis Grou
                       Horn Button → In 1 (trigger)  [column path undefined — {{ tbd(152) }}]
 ```
 
-**Power Flow:**
-
-1. START battery+ → 250A inline CB → PMU
-2. Horn button (steering wheel) → PMU In 1 (trigger signal)
-3. PMU Out 18 activated when In 1 closes
-4. PMU Out 18 → PIAA horns (5.4A) → chassis ground (engine bay)
-
-**Notes:**
-
-- PMU Out 18 switches directly (no external relay needed)
-- Works with ignition off (CONSTANT power for safety)
-
 ## Outstanding Items
 
 {{ tbds() }}

--- a/docs/jeep_lj/02-engine-systems/07-grid-heater.md
+++ b/docs/jeep_lj/02-engine-systems/07-grid-heater.md
@@ -40,25 +40,7 @@ tags:
 | Element current   | 40–80A (design estimate)[^grid-current]            |
 | Duty cycle        | 3–5 s during cold start (ECM-controlled)           |
 | Protection        | Integrated fusible link                            |
-
-## System Architecture
-
-1. **ECM Control (Direct):**
-   - ECM triggers grid heater relay directly via pins 46/21 (~0.5-1A)
-   - ECM manages timing, temperature thresholds, and duty cycle
-   - No PMU involvement - ECM knows engine temperature better than external controller
-
-2. **Grid Heater Relay (Cummins 5467024):**
-   - Coil Power: ECM pins 46/21 (~1A) - direct connection
-   - Main Power: Direct from START battery+ via fusible link (bypasses all bus bars and PMU)
-   - Main Ground: START battery- or NEGATIVE bus
-   - Output: 80A to grid heater element (design value - verify via resistance measurement during installation)
-   - Protection: Integrated fusible link
-
-3. **Grid Heater Element:**
-   - Location: Intake manifold
-   - Power: 80A from relay (design value)
-   - Duty Cycle: 3-5 seconds during cold start (ECM controlled)
+| Ground            | START battery- or NEGATIVE bus                     |
 
 ## Wiring Summary
 

--- a/docs/jeep_lj/04-offroad-lighting/10-reverse-lights.md
+++ b/docs/jeep_lj/04-offroad-lighting/10-reverse-lights.md
@@ -11,7 +11,7 @@ tags:
 
 # 4.10 Reverse Lights {#reverse-lights}
 
-High-output reverse lights that activate automatically via PMU reverse circuit.
+Reverse lights (4,520 lumens combined) that activate automatically via PMU reverse circuit.
 
 /// html | div.product-info
 ![Baja Designs Squadron Sport](../images/baja-designs-squadron-sport.jpg){ loading=lazy }
@@ -50,14 +50,7 @@ High-output reverse lights that activate automatically via PMU reverse circuit.
 
 Wired in parallel with Maxbilt Round Trail Tail WHITE (reverse) and WolfBox camera trigger.
 
-See [Tail/Brake/Reverse Lights][tail-brake-reverse] for PMU reverse circuit details.
-
-**Load Verification:**
-
-- Squadron Sport pair: 2.8A
-- Maxbilt WHITE: ~2A
-- WolfBox trigger: negligible
-- **Total: ~5A** (PMU Out 22 capacity: 7A, 71% utilization)
+See [Tail/Brake/Reverse Lights][tail-brake-reverse] for PMU reverse circuit details and combined load verification.
 
 ## Related Documentation
 

--- a/docs/jeep_lj/05-control-interfaces/05-dashboard-controls.md
+++ b/docs/jeep_lj/05-control-interfaces/05-dashboard-controls.md
@@ -67,8 +67,6 @@ The CH4X4 has **two independent momentary push circuits** (not a polarity-revers
 
 This is the **correct** design for the Warn ZEON 10-S contactor, which has separate IN and OUT trigger inputs that internally handle the motor polarity reversal. Two discrete push buttons are safer than a single rocker (can't accidentally activate both directions at once).
 
-**Dual Control:** Dash push switch + handheld remote work simultaneously in parallel (both wired to the contactor's same trigger inputs).
-
 ### Wiring
 
 | Connection | Wire | Source | Destination |

--- a/docs/jeep_lj/06-audio-systems/04-subwoofer.md
+++ b/docs/jeep_lj/06-audio-systems/04-subwoofer.md
@@ -57,7 +57,7 @@ Amp Ch 1+2 (+/−) bridged → Sub A (+/−)
 Amp Ch 3+4 (+/−) bridged → Sub B (+/−)
 ```
 
-Total amp output 400W into the pair (200W per sub) — exact RMS match, no headroom waste from series resistance, independent gain trim per side if the L/R quarter-panel locations end up acoustically asymmetric.
+Independent gain trim per side accommodates any L/R acoustic asymmetry between the quarter-panel locations.
 
 ## Infinite Baffle Requirements
 


### PR DESCRIPTION
Nightly tidiness pass per `docs/jeep_lj/CLAUDE.md`'s **BE SUCCINCT** rule. Surveyed all 108 pages under `docs/jeep_lj/**/*.md` with parallel read-only agents scoring content against the four reader personas (Mechanic/Installer, Owner/Designer, Parts Buyer, Troubleshooter), then edited the 6 pages with the clearest, highest-confidence wins. No specs, part numbers, wire gauges, table rows, TBD items, checklist items, or link definitions were touched — prose and structure only.

| File | Lines before → after | What was cut | Which persona it failed |
| :--- | :--- | :--- | :--- |
| `01-power-systems/STANDARDS-EXCEPTIONS.md` | 592 → 581 | Unsourced "Factory Vehicle Precedent" appeal-to-authority list (Ford/RAM/Toyota/Jeep claims with no citations); a redundant "Factory Practice" bullet under the alternator section restating the Industry Standard section above it, including the marketing phrase "proven safe over millions of vehicles" | Serves none of the four personas — no citation, no actionable spec |
| `02-engine-systems/07-grid-heater.md` | 116 → 98 | Whole "System Architecture" section, which fully restated the Specifications table above and the wiring diagram/rationale below (ECM control, direct battery connection, bypass PMU, 80A output, 3–5s duty cycle all said 3x); the one non-duplicate fact (ground path) was preserved by adding a "Ground" row to the Specifications table | Mechanic/Installer — table + diagram already say this |
| `02-engine-systems/05-horn.md` | 83 → 71 | "Power Flow" numbered list and "Notes" bullets, both restating the ASCII wiring diagram and Control section immediately above | Mechanic/Installer — diagram already shows the same 4-step path |
| `05-control-interfaces/05-dashboard-controls.md` | 127 → 125 | Middle of three restatements of "dash switch works in parallel with the handheld remote" (kept the Function-line summary and the Wiring-section electrical detail) | Mechanic/Installer — same fact said 3x |
| `04-offroad-lighting/10-reverse-lights.md` | 72 → 65 | Duplicate "Load Verification" bullet block, identical to the "Load Breakdown" already on the authoritative `03-lighting-systems/04-tail-brake-reverse.md` page (already linked from the line above); also replaced the unquantified adjective "High-output" with the actual lumen figure | Troubleshooter/Mechanic — stale copy of another page's numbers |
| `06-audio-systems/04-subwoofer.md` | 117 → 117 | Third restatement of the "bridged pair = exact RMS match, no series loss" rationale (already stated in prose and shown in the wiring table); kept the one new point (per-side gain trim for L/R asymmetry) | Owner/Mechanic — same claim in prose, table, and closing line |

**Verification:**
- `python3 -m mkdocs build --strict` — passes (exit 0), no broken links/anchors introduced.
- `npx markdownlint-cli2 "docs/jeep_lj/**/*.md"` — diffed before/after on the 6 edited files: identical set of pre-existing errors (table-alignment/duplicate-heading issues that predate this change, just shifted line numbers from the deletions). No new lint violations introduced.

**Left for human judgment** (found during the survey, deliberately not touched):
- `08-load-analysis/index.md` duplicates the per-battery Summary tables from `02-start-battery.md` / `03-aux-battery.md` almost verbatim — but the AUX numbers actually **disagree** between the two pages (e.g. Night Offroad: 70A/-20A/102min in `index.md` vs 45A/+5A in `03-aux-battery.md`). This is a correctness discrepancy, not just duplication — resolving it means picking which number is right, which is outside a verbosity-trim pass and outside the "never change a number" guardrail.
- `01-power-systems/07-wire-routing/02-firewall-ingress.md` repeats a SwitchPros connector BOM table verbatim in two places on the same page, and carries a ~75-line "Pin Budget Audit (Historical)" section whose conclusion is already stated in an admonition above it — flagged as a bigger structural edit than fits a small, reviewable nightly diff.
- Several `04-offroad-lighting/*.md` files (ditch, fog, roof, rock, rear lights) each carry one duplicate "see SwitchPros for wiring" sentence already covered by their own Related Documentation link — same fix, low risk, but touching 5 more files would have pushed this PR past a reviewable size for one night.
- The `01-power-systems/STANDARDS-EXCEPTIONS.md` "Standards Comparison" and per-component "Review Guidance" blocks repeat a similar rhetorical structure across 5 components — likely intentional given the file's stated purpose ("prevent future reviews from flagging intentional design decisions"), so left alone rather than risk cutting a reviewer-facing instruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SNGx2g9BzrFBeekSzbb85U

---
_Generated by [Claude Code](https://claude.ai/code/session_01SNGx2g9BzrFBeekSzbb85U)_