### PR TITLE
docs: nightly tidiness — trim verbosity (2026-07-04)

### DIFF
--- a/docs/jeep_lj/01-power-systems/01-power-generation/04-solar.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/04-solar.md
@@ -68,17 +68,13 @@ tags:
 
 80W panel maintains AUX battery during extended stops via BCDC solar input. Full sun panel output at optimal conditions: 80W (1.95A @ 40V), variable in partial sun/clouds.
 
-**Panel-side vs battery-side current:** The 1.95A figure is the panel-side current at the panel's ~40V operating voltage (40V × 1.95A ≈ 78W). The BCDC's MPPT steps that down to the battery charge voltage, so the battery-side contribution is higher: 78W ÷ ~13.4V ≈ **~5.8A to the AUX battery**.
+**Panel-side vs battery-side current:** The 1.95A figure is panel-side current at the panel's ~40V operating voltage (40V × 1.95A ≈ 78W). The BCDC's MPPT steps that down to battery charge voltage: 78W ÷ ~13.4V ≈ **~5.8A to the AUX battery**.
 
-**BCDC Green Power Priority:** Solar input used first when available, alternator supplements to reach 50A total charging current. In full sun, solar contributes ~5.8A battery-side, reducing alternator load by the same amount.
+**BCDC Green Power Priority:** Solar input used first when available, alternator supplements to reach 50A total charging current. Battery-side contribution by condition:
 
-**Charging Contribution (battery-side):**
-
-- **Full sun:** ~5.8A to AUX battery (78W ÷ ~13.4V; reduces alternator load from 50A to ~44A)
+- **Full sun:** ~5.8A (reduces alternator load from 50A to ~44A)
 - **Partial sun:** Variable, proportional to available irradiance
 - **Overcast/Night:** 0A (BCDC uses alternator only)
-
-**Alternator Load Relief:** Minimal but measurable — reduces worst-case alternator load by ~5.8A during sunny daytime operation
 
 See [BCDC Alpha 50][bcdc] for complete charging system details.
 

--- a/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
@@ -15,7 +15,7 @@ Automatic load management during ARB compressor operation to preserve AUX batter
 - **BCDC Charging (50A max):** Replenishes AUX battery from alternator
 - **Net AUX battery drain:** 90A - 50A = 40A during compressor operation
 
-The alternator is NOT overloaded during ARB operation. The 50A BCDC significantly reduces net discharge rate, making extended air-up practical. Load shedding provides additional margin and maintains optimal voltage.
+The alternator is NOT overloaded during ARB operation. The 50A BCDC significantly reduces net discharge rate, making extended air-up practical; load shedding adds further margin (see [Load Reduction Analysis](#load-reduction-analysis) below).
 
 ## Problem Statement
 
@@ -33,13 +33,7 @@ Usable capacity (80% DOD):  108Ah
 Time to 20% SOC:           ~144 minutes continuous (2.4 hours)
 ```
 
-The Dakota Lithium 135Ah combined with 50A BCDC makes extended air-up a non-issue. Load shedding provides additional margin and maintains optimal voltage for electronics.
-
-**Impact Without Load Shedding:**
-
-- Minor: AUX battery still has comfortable margin at 50A BCDC
-- START battery loads reduce BCDC charging efficiency slightly
-- Load shedding maximizes available margin for extended sessions
+The Dakota Lithium 135Ah combined with 50A BCDC makes extended air-up a non-issue on its own; load shedding maximizes the remaining margin for longer sessions.
 
 ## Solution Overview
 

--- a/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
+++ b/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
@@ -56,25 +56,12 @@ tags:
 
 ### Headlight Control
 
-- **Headlights (SW3 - PULL):** Baja Designs LP6 headlights (low beam)
-  - **Pull lever** → Activates headlights (low beam)
-  - Power: PMU Out 13 (CONSTANT) → CT4 internal switching → SW3 output
-  - CT4 SW3 output → LP6 Pin 1 (low beam, both lights in parallel)
-  - CT4 handles switching internally (10A output capacity, 3.6A actual load)
-  - Disabled when ignition off (via ignition signal from ignition switch RUN)
-  - Latching on/off control (pull once to turn on, pull again to turn off)
-  - Wire gauge: 14 AWG from CT4 SW3 output to LP6 headlights
-  - When active: Also triggers DRL cutoff relay to disable DRL circuit (SW3 output tapped to relay coil)
+Pin/gauge/load detail is in the [Wiring Pinout](#wiring-pinout) table below.
 
-- **High Beams (SW4 - PUSH):** Switches to high beams
-  - **Push lever** (while headlights on) → Activates high beams
-  - Power: PMU Out 13 (CONSTANT) → CT4 internal switching → SW4 output
-  - CT4 SW4 output → LP6 Pin 4 (high beam, both lights in parallel)
-  - CT4 handles switching internally (10A output capacity, 5.6A actual load)
-  - Disabled when ignition off (via ignition signal from ignition switch RUN)
-  - CT4 provides mutual exclusivity (high beam disables low beam automatically)
-  - Momentary or latching toggle (programmable)
-  - Wire gauge: 14 AWG from CT4 SW4 output to LP6 headlights
+- **Headlights (SW3 - PULL):** Latching on/off (pull once for on, again for off). Also trips the DRL cutoff relay (SW3 tapped to relay coil).
+- **High Beams (SW4 - PUSH):** Push while headlights on. CT4 enforces mutual exclusivity — high beam disables low beam automatically. Momentary or latching toggle (programmable).
+
+Both disabled when ignition off.
 
 ### DRL/Parking Lights
 
@@ -134,31 +121,7 @@ Recommended configuration for this build:
 
 ### PMU DRL Auto-Off Logic
 
-**Purpose:** Automatically turns off DRL when headlights are activated via CT4 SW3
-
-**Implementation:** PMU programming logic (no external relay needed)
-
-**PMU Configuration:**
-
-```text
-PMU Input 7 (In 7): CT4 SW3 headlight status signal (tapped from low beam circuit)
-PMU Pin 7: Ignition RUN signal (12V switched input)
-PMU Output 23 (Out 23): DRL/Parking lights circuit
-
-Programming Logic:
-IF (Pin7_IgnitionRUN == ON) AND (In7_CT4_Headlights == OFF)
-  THEN Out23_DRL = ON
-ELSE
-  Out23_DRL = OFF
-END
-```
-
-**Installation Notes:**
-
-- Tap CT4 SW3 output (low beam circuit) to PMU In 7 for headlight status monitoring
-- Run wire from PMU Out 23 to DRL junction
-- Total DRL/parking circuit load: ~2.6A — see [DRL & Parking][drl-parking] for the itemized load breakdown and wiring
-- PMU Out 23 capacity: 7A (sufficient for the ~2.6A load)
+CT4 SW3 (low beam) taps to PMU In 7; the PMU turns Out 23 (DRL/parking) off whenever SW3 is active. See [DRL & Parking][drl-parking] for the full PMU logic, operation-state table, and itemized ~2.6A load breakdown (Out 23 capacity: 7A).
 
 ## Installation Checklist
 

--- a/docs/jeep_lj/07-communication-systems/01-gmrs-radio.md
+++ b/docs/jeep_lj/07-communication-systems/01-gmrs-radio.md
@@ -73,8 +73,6 @@ tags:
 
 ## Installation Notes
 
-- Direct battery ground required for best RF performance
-- Route antenna coax away from power leads
 - Keep coax length <25 ft for minimal signal loss
 
 ## Outstanding Items

--- a/docs/jeep_lj/07-communication-systems/02-intercom.md
+++ b/docs/jeep_lj/07-communication-systems/02-intercom.md
@@ -77,7 +77,6 @@ tags:
 
 ## Installation Notes
 
-- Direct battery ground recommended for best audio quality
 - PMU output has integrated 5A protection - no inline fuse needed
 
 ## Outstanding Items

--- a/docs/jeep_lj/07-communication-systems/04-dash-camera.md
+++ b/docs/jeep_lj/07-communication-systems/04-dash-camera.md
@@ -48,21 +48,6 @@ Rearview mirror replacement with integrated front dash camera and rear backup ca
 - Lane departure warnings (model dependent)
 - Parking mode (with CONSTANT power)
 
-## Components
-
-**Main Unit (Mirror):**
-
-- Replaces factory rearview mirror
-- Integrated front camera
-- Touchscreen for settings/playback
-- CONSTANT power enables parking mode recording
-
-**Rear Camera:**
-
-- Mounts above license plate
-- Powered via cable from main unit
-- Auto-displays when reverse gear engaged
-
 ## Wiring
 
 | Connection      | Wire           | Source                | Notes                     |


### PR DESCRIPTION
Nightly tidiness pass per `docs/jeep_lj/CLAUDE.md` — Core Imperative #1 (BE SUCCINCT). No specs, numbers, identifiers, TBDs, checkboxes, table rows, or links were changed; only redundant prose was cut.

| File | Lines before → after | What was cut | Persona it failed |
|:---|:---|:---|:---|
| `01-power-systems/01-power-generation/04-solar.md` | 165 → 161 | The battery-side "~5.8A" figure and its rationale were derived once, then restated two more times across "BCDC Green Power Priority" and "Alternator Load Relief". Collapsed to one derivation + one condition table. | Troubleshooter/Mechanic (same number, no new info each repeat) |
| `01-power-systems/04-pmu/05-pmu-arb-load-shedding.md` | 326 → 320 | "Load shedding isn't critical, alternator/BCDC already handle it" was stated near-verbatim three times (Dual Battery Architecture, Problem Statement, Impact Without Load Shedding). Kept once, pointed the rest at the Load Reduction Analysis table. | Mechanic/Troubleshooter |
| `05-control-interfaces/03-command-touch-ct4.md` | 228 → 191 | "Headlight Control" bullets re-stated wire gauge/power path already in the file's own Wiring Pinout table. "PMU DRL Auto-Off Logic" was a byte-for-byte copy of the code block in `03-lighting-systems/05-drl-parking.md` (which also has the fuller Operation States walkthrough). Both trimmed to the unique facts + a cross-link. | Mechanic (same-file table restated in prose) / Owner (rationale duplicated verbatim across files instead of linked) |
| `07-communication-systems/04-dash-camera.md` | 97 → 82 | "Components" section restated the product-info block, Specifications table, Features list, and Wiring table with no new facts. Cut entirely. | Mechanic/Parts Buyer |
| `07-communication-systems/01-gmrs-radio.md` | 96 → 94 | Two "Installation Notes" bullets ("direct battery ground for RF performance", "route antenna away from power leads") duplicated the Wiring table's Notes column verbatim. | Mechanic |
| `07-communication-systems/02-intercom.md` | 99 → 98 | One "Installation Notes" bullet duplicated the Wiring table's ground note verbatim. | Mechanic |

**Verification:** `python3 -m mkdocs build --strict` succeeds; `npx markdownlint-cli2 "docs/jeep_lj/**/*.md"` shows no new errors (pre-existing `MD060` table-alignment errors in the generated `tbd-tracker.md` are unrelated to this diff and present on `main` as well).

### Left for human judgment

- `01-power-systems/08-load-analysis/index.md` duplicates the "Why Not Sum All Loads?" example verbatim from `CLAUDE.md`. Per `CLAUDE.md`'s own rules it should be navigation-only and `index.md` should hold the authoritative content, but `CLAUDE.md` is off-limits for this pass — left both as-is rather than guess which direction to de-duplicate.
- `01-power-systems/07-wire-routing/02-firewall-ingress.md` has a ~75-line "Pin Budget Audit (Historical)" section that the file itself calls superseded by the summary two sections above. Reads as real duplication but is rationale-shaped (design history), so left alone rather than risk cutting build-relevant context.
- `04-offroad-lighting/10-reverse-lights.md` "Load Verification" repeats a load breakdown already given in `03-lighting-systems/04-tail-brake-reverse.md` (which it links to) — small, but not touched this run to keep the diff focused.
- Several files (e.g., grid-heater.md, horn.md) restate the same wiring/power-flow facts across a diagram + prose + notes section; real but lower-confidence than what's fixed here, left for a future pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Cxeb6JGMUxtCbq1dgfMDnu)_