### PR TITLE
docs: nightly tidiness — trim verbosity (2026-07-06)

### DIFF
--- a/docs/jeep_lj/01-power-systems/01-power-generation/03-bcdc.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/03-bcdc.md
@@ -97,12 +97,7 @@ The BCDC includes a battery temperature sensor (2-pin, polarity reversible) that
 - **Attachment:** Ring terminal under battery terminal bolt
 - **Why Positive Terminal:** Measures both voltage and temperature at the battery for accurate charge control
 
-**Why Required:**
-
-- AGM batteries are temperature-sensitive during charging
-- Overcharging at high temps causes thermal runaway risk
-- Undercharging at low temps leads to sulfation
-- BCDC adjusts charge voltage based on sensor reading (temperature compensation)
+**Why Required:** BCDC adjusts charge voltage based on sensor reading (temperature compensation).
 
 **Installation Notes:**
 

--- a/docs/jeep_lj/01-power-systems/01-power-generation/04-solar.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/04-solar.md
@@ -70,15 +70,13 @@ tags:
 
 **Panel-side vs battery-side current:** The 1.95A figure is the panel-side current at the panel's ~40V operating voltage (40V × 1.95A ≈ 78W). The BCDC's MPPT steps that down to the battery charge voltage, so the battery-side contribution is higher: 78W ÷ ~13.4V ≈ **~5.8A to the AUX battery**.
 
-**BCDC Green Power Priority:** Solar input used first when available, alternator supplements to reach 50A total charging current. In full sun, solar contributes ~5.8A battery-side, reducing alternator load by the same amount.
+**BCDC Green Power Priority:** Solar input used first when available, alternator supplements to reach 50A total charging current.
 
 **Charging Contribution (battery-side):**
 
 - **Full sun:** ~5.8A to AUX battery (78W ÷ ~13.4V; reduces alternator load from 50A to ~44A)
 - **Partial sun:** Variable, proportional to available irradiance
 - **Overcast/Night:** 0A (BCDC uses alternator only)
-
-**Alternator Load Relief:** Minimal but measurable — reduces worst-case alternator load by ~5.8A during sunny daytime operation
 
 See [BCDC Alpha 50][bcdc] for complete charging system details.
 

--- a/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
@@ -33,13 +33,7 @@ Usable capacity (80% DOD):  108Ah
 Time to 20% SOC:           ~144 minutes continuous (2.4 hours)
 ```
 
-The Dakota Lithium 135Ah combined with 50A BCDC makes extended air-up a non-issue. Load shedding provides additional margin and maintains optimal voltage for electronics.
-
-**Impact Without Load Shedding:**
-
-- Minor: AUX battery still has comfortable margin at 50A BCDC
-- START battery loads reduce BCDC charging efficiency slightly
-- Load shedding maximizes available margin for extended sessions
+**Impact Without Load Shedding:** Minor — the Dakota Lithium 135Ah combined with 50A BCDC makes extended air-up a non-issue even without shedding. START battery loads reduce BCDC charging efficiency slightly; load shedding maximizes available margin for extended sessions.
 
 ## Solution Overview
 

--- a/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
+++ b/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
@@ -541,16 +541,7 @@ The apparent CB > wire mismatch is intentional:
 
 ---
 
-## Summary of Intentional Design Decisions
-
-**All decisions documented above are intentional and based on:**
-
-1. **Manufacturer Specifications** - Following OEM installation requirements
-2. **Automotive Standards (SAE J1128)** - Primary standard for automotive electrical systems
-3. **Industry Practice** - Factory vehicle precedents and proven approaches
-4. **Engineering Analysis** - Load characteristics, wire sizing, fault scenarios
-
-**These are NOT oversights, errors, or safety issues.**
+## Standards Applicability
 
 **Marine standards (ABYC E-11) are referenced selectively:**
 

--- a/docs/jeep_lj/02-engine-systems/05-horn.md
+++ b/docs/jeep_lj/02-engine-systems/05-horn.md
@@ -59,11 +59,6 @@ START battery CONSTANT → PMU → Out 18 → PIAA Horns (5.4A) → Chassis Grou
 3. PMU Out 18 activated when In 1 closes
 4. PMU Out 18 → PIAA horns (5.4A) → chassis ground (engine bay)
 
-**Notes:**
-
-- PMU Out 18 switches directly (no external relay needed)
-- Works with ignition off (CONSTANT power for safety)
-
 ## Outstanding Items
 
 {{ tbds() }}

--- a/docs/jeep_lj/02-engine-systems/07-grid-heater.md
+++ b/docs/jeep_lj/02-engine-systems/07-grid-heater.md
@@ -46,7 +46,7 @@ tags:
 1. **ECM Control (Direct):**
    - ECM triggers grid heater relay directly via pins 46/21 (~0.5-1A)
    - ECM manages timing, temperature thresholds, and duty cycle
-   - No PMU involvement - ECM knows engine temperature better than external controller
+   - No PMU involvement
 
 2. **Grid Heater Relay (Cummins 5467024):**
    - Coil Power: ECM pins 46/21 (~1A) - direct connection
@@ -86,20 +86,9 @@ flowchart LR
 
 ## Why Direct ECM Control
 
-- ECM has accurate engine temperature data
-- ECM knows optimal grid heater timing for cold starts
-- Eliminates unnecessary complexity of PMU passthrough
-- Frees PMU output slots for other critical systems
-
-## Power Distribution
-
-**Bypasses all distribution systems:**
-
-- Does NOT use CONSTANT bus bar
-- Does NOT use PMU outputs
-- Direct battery connection with fusible link protection
-
-**Reason:** High current draw (40-80A) for very short duration (3-5 seconds). Direct connection minimizes voltage drop and connection complexity.
+- ECM has accurate engine temperature data and optimal grid heater timing for cold starts
+- Eliminates PMU passthrough complexity and frees a PMU output slot
+- Direct battery connection (bypassing the CONSTANT bus and PMU) minimizes voltage drop for the 40-80A pulse
 
 ## Outstanding Items
 


### PR DESCRIPTION
Nightly tidiness pass per `docs/jeep_lj/CLAUDE.md` "BE SUCCINCT". Surveyed the whole `docs/jeep_lj/**` tree with four parallel readers (power-systems/drivetrain/installation, engine-systems, lighting/offroad-lighting, control/audio/comms/exterior) and picked the six highest-confidence, lowest-risk, self-contained cuts. No specs, part numbers, wire gauges, TBD items, checkboxes, table rows, or links were changed — prose and structure only.

| File | Lines before → after | What was cut | Persona it failed |
|---|---|---|---|
| `01-power-systems/STANDARDS-EXCEPTIONS.md` | 593 → 584 | "Summary of Intentional Design Decisions" section that just re-listed the 4 rationale categories and repeated "these are not oversights" — already stated once per exception in that exception's own Review Guidance. Kept the one non-redundant bullet (which standards apply to which components) under a shorter heading. | Mechanic/Troubleshooter (had to read the same "don't flag this" conclusion a third time) |
| `02-engine-systems/07-grid-heater.md` | 116 → 108 | Deleted the "Power Distribution" section, which restated the Specifications table (40-80A, 3-5s) and the System Architecture bullets (bypasses CONSTANT bus/PMU) in prose. Folded its one new clause (voltage-drop rationale) into "Why Direct ECM Control" and trimmed a duplicate clause in System Architecture #1. | Parts-Buyer/Mechanic (table said it first) |
| `01-power-systems/04-pmu/05-pmu-arb-load-shedding.md` | 327 → 320 | "Load shedding provides additional margin and maintains optimal voltage" was stated 3 times (Dual Battery Architecture, Problem Statement, Impact Without Load Shedding). Kept the first mention, collapsed the other two into one sentence. | Troubleshooter (buried the shed-logic table under repeated preamble) |
| `01-power-systems/01-power-generation/04-solar.md` | 166 → 163 | The ~5.8A battery-side solar contribution was derived once, then restated in "Green Power Priority" and again as a standalone "Alternator Load Relief" line. Cut both restatements; the number still appears in its derivation and in the Charging Contribution table. | Mechanic (had to re-read the same number four times to confirm it wasn't changing) |
| `01-power-systems/01-power-generation/03-bcdc.md` | 119 → 113 | "Why Required" bullets gave a generic AGM-battery-chemistry lecture (thermal runaway, sulfation) not specific to this build. Kept only the one build-relevant fact (BCDC does temperature-compensated charging). | Mechanic (installing the sensor doesn't need battery-chemistry theory) |
| `02-engine-systems/05-horn.md` | 83 → 78 | "Notes" section restated the "PMU Configuration" bullets word-for-word (no external relay needed; CONSTANT/works with ignition off). Cut the duplicate section. | Mechanic (same 2 facts, 3rd telling) |

**Net diff:** 8 insertions, 46 deletions across 6 files. Verified `python3 -m mkdocs build --strict` (exit 0) and `npx markdownlint-cli2 "docs/jeep_lj/**/*.md"` — confirmed identical to the pre-existing lint error count on these 6 files (12 errors, all pre-existing table/heading/reference issues unrelated to this diff; zero new errors introduced).

## Left for human judgment

- **`08-exterior-systems/01-winch.md` (dash rocker switch description):** The survey turned up what looks like a stale/contradictory description of a center-off SPDT/DPDT rocker switch, while `05-control-interfaces/05-dashboard-controls.md` documents the actual selected hardware as the CH4X4-TOY-D-WINIO dual momentary push-button switch (and the same winch.md file even correctly cites the CH4X4 switch ~20 lines later). This reads as a correctness/staleness issue, not verbosity — fixing it requires knowing which description is actually current, so it's out of scope for this pass. Worth a look.
- **`01-power-systems/01-power-generation/03-bcdc.md` (AGM vs. LiFePO4):** The temperature-sensor section calls the requirement "REQUIRED for proper AGM charging," but the AUX battery is documented elsewhere (`04-solar.md`, `04-pmu/05-pmu-arb-load-shedding.md`) as a Dakota Lithium 135Ah **LiFePO4** pack. "Sulfation" (which I cut as generic filler) is specifically a lead-acid/AGM failure mode and doesn't apply to LiFePO4. This may be leftover text from an earlier battery-chemistry choice — a possible fact error, not something to silently rewrite in a tidiness pass.
- **`01-power-systems/STANDARDS-EXCEPTIONS.md` ("Review Checklist for Future Analysis"):** This section (checkbox-formatted) restates the same 7 conclusions a third time. It wasn't touched because it uses `- [ ]` checkbox syntax and the task guardrails call out never deleting checkbox items — even though these aren't "Outstanding Items" checkboxes in the doc's usual sense. Flagging in case a human wants to convert it to a plain list or trim it.
- **BIM module pages (`02-engine-systems/09-gauge-cluster/03-bim-j1939.md`, `04-bim-gps.md`, `05-bim-tpms.md`, `06-bim-compass.md`):** All four repeat an identical "Current Draw: Negligible..." paragraph verbatim. This is a clean cross-file dedup candidate (consolidate to one authoritative location + reference-style links per each), but it touches 4 files and was left out of this run to keep the diff small and reviewable; good candidate for next pass.
- Several smaller cross-file duplications surfaced by the survey (reverse-lights.md/tail-brake-reverse.md load calc; switchpros-sp1200.md/air-compressor.md trigger logic; gmrs-radio.md/intercom.md installation notes restating their own wiring tables) were lower-impact or multi-file and were left for a future pass to keep tonight's PR reviewable.

---
_Generated by [Claude Code](https://claude.ai/code/session_01C9eEwGZkTYNJFXBHsxbEMe)_