### PR TITLE
docs: nightly tidiness — trim verbosity (2026-07-12)

### DIFF
--- a/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/index.md
+++ b/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/index.md
@@ -16,9 +16,7 @@ The AUX battery ([Dakota Lithium 135Ah LiFePO4][batteries]) in the passenger rea
 5. **Inline 100A CB** → 4 AWG short feed → [JL Audio MV800/8i Amp][audio] (mounted under rear seat)
 
 !!! info "Two-Stage Distribution Architecture"
-The AUX battery has **no local CONSTANT bus** — protected feeds run from inline CBs at the battery to two distribution points: the firewall CONSTANT bus (most loads) and SafetyHub (local). This places distribution near the loads, minimizes the cabin trunk to a single heavy cable, and keeps the rear wheel well compartment uncluttered.
-
-See [Firewall CONSTANT Bus][constant-bus] for downstream distribution, [SafetyHub][aux-safetyhub] for fused recovery circuits, and [Circuit Breakers][circuit-breakers] for full CB list.
+The AUX battery has **no local CONSTANT bus** — protected feeds run from inline CBs at the battery to two distribution points instead. See [Firewall CONSTANT Bus][constant-bus] for the full rationale and downstream distribution, [SafetyHub][aux-safetyhub] for fused recovery circuits, and [Circuit Breakers][circuit-breakers] for full CB list.
 
 !!! info "Single Source of Truth"
 This page is the authoritative source for all AUX battery wire specs (gauge, distance, voltage drop). Component pages reference here. For battery specs see [Section 1.1][batteries]. For ground bus bars see [Section 1.5][grounding].

--- a/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
@@ -15,7 +15,7 @@ Automatic load management during ARB compressor operation to preserve AUX batter
 - **BCDC Charging (50A max):** Replenishes AUX battery from alternator
 - **Net AUX battery drain:** 90A - 50A = 40A during compressor operation
 
-The alternator is NOT overloaded during ARB operation. The 50A BCDC significantly reduces net discharge rate, making extended air-up practical. Load shedding provides additional margin and maintains optimal voltage.
+The alternator is NOT overloaded during ARB operation — the 50A BCDC significantly reduces net discharge rate, making extended air-up practical.
 
 ## Problem Statement
 
@@ -33,13 +33,7 @@ Usable capacity (80% DOD):  108Ah
 Time to 20% SOC:           ~144 minutes continuous (2.4 hours)
 ```
 
-The Dakota Lithium 135Ah combined with 50A BCDC makes extended air-up a non-issue. Load shedding provides additional margin and maintains optimal voltage for electronics.
-
-**Impact Without Load Shedding:**
-
-- Minor: AUX battery still has comfortable margin at 50A BCDC
-- START battery loads reduce BCDC charging efficiency slightly
-- Load shedding maximizes available margin for extended sessions
+The Dakota Lithium 135Ah combined with 50A BCDC makes extended air-up a non-issue; load shedding below adds margin on top of that and keeps voltage optimal for electronics. START battery loads reduce BCDC charging efficiency slightly, which shedding also helps offset.
 
 ## Solution Overview
 

--- a/docs/jeep_lj/02-engine-systems/07-grid-heater.md
+++ b/docs/jeep_lj/02-engine-systems/07-grid-heater.md
@@ -41,25 +41,6 @@ tags:
 | Duty cycle        | 3–5 s during cold start (ECM-controlled)           |
 | Protection        | Integrated fusible link                            |
 
-## System Architecture
-
-1. **ECM Control (Direct):**
-   - ECM triggers grid heater relay directly via pins 46/21 (~0.5-1A)
-   - ECM manages timing, temperature thresholds, and duty cycle
-   - No PMU involvement - ECM knows engine temperature better than external controller
-
-2. **Grid Heater Relay (Cummins 5467024):**
-   - Coil Power: ECM pins 46/21 (~1A) - direct connection
-   - Main Power: Direct from START battery+ via fusible link (bypasses all bus bars and PMU)
-   - Main Ground: START battery- or NEGATIVE bus
-   - Output: 80A to grid heater element (design value - verify via resistance measurement during installation)
-   - Protection: Integrated fusible link
-
-3. **Grid Heater Element:**
-   - Location: Intake manifold
-   - Power: 80A from relay (design value)
-   - Duty Cycle: 3-5 seconds during cold start (ECM controlled)
-
 ## Wiring Summary
 
 **Two-Stage Design:** ECM pins 46/21 (1A) → relay coil → relay switches high current (40-80A) directly from battery to element.
@@ -84,22 +65,10 @@ flowchart LR
     style ELEMENT fill:#d1d5db,color:#000
 ```
 
-## Why Direct ECM Control
+## Design Rationale
 
-- ECM has accurate engine temperature data
-- ECM knows optimal grid heater timing for cold starts
-- Eliminates unnecessary complexity of PMU passthrough
-- Frees PMU output slots for other critical systems
-
-## Power Distribution
-
-**Bypasses all distribution systems:**
-
-- Does NOT use CONSTANT bus bar
-- Does NOT use PMU outputs
-- Direct battery connection with fusible link protection
-
-**Reason:** High current draw (40-80A) for very short duration (3-5 seconds). Direct connection minimizes voltage drop and connection complexity.
+- **ECM controls it directly** (not PMU): the ECM already has engine temperature and timing data, so triggering the relay itself avoids a PMU signal passthrough and frees a PMU output slot.
+- **Power bypasses the CONSTANT bus bar and PMU outputs**: 40-80A for only 3-5 seconds doesn't justify routing through distribution — a direct battery connection with fusible link protection minimizes voltage drop and connection complexity.
 
 ## Outstanding Items
 

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/01-hdx-control.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/01-hdx-control.md
@@ -119,6 +119,7 @@ All BIM modules connect via single daisy-chain harness from HDX control 3.5mm po
 - HDX Control → BIM-01-2-J1939 → GPS-50-2 → BIM-22-3 → BIM-17-2
 - Power and data carried over BIM/IO cables (no separate power wiring)
 - Modules auto-detect and configure via Bluetooth app
+- Dakota Digital publishes no per-module current draw for these data modules (only power modules like the BIM-RGB, 7.4A, list a figure) — each module's draw is negligible and folds into the HDX system's overall current draw above (which sizes the 10A fuse)
 
 ## Outstanding Items
 

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/03-bim-j1939.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/03-bim-j1939.md
@@ -39,7 +39,7 @@ Interfaces Cummins R2.8 ECM J1939 CAN bus data with HDX instrument system. Provi
 - **Compatible ECUs:** Cummins R2.8, Mercury Racing SBF, BIGStuff EFI
 - **Wiring:** CAN High, CAN Low (twisted pair)
 - **Power:** Via BIM harness from HDX control
-- **Current Draw:** Negligible — bus-powered via the HDX BIM/IO cable (no separate feed); draw is included in the HDX system budget on PMU OUT9 (25A cap, ~12A typ). Dakota Digital publishes no per-module current for these data modules (only power modules like the BIM-RGB, 7.4A, list a figure).
+- **Current Draw:** Negligible — bus-powered via the HDX BIM/IO cable; included in the [HDX system budget][hdx-control] (PMU OUT9, 25A cap, ~12A typ).
 
 ## J1939 Data Available
 
@@ -131,6 +131,7 @@ Specific J1939 parameters vary by ECM configuration and vehicle application. Cum
 [i110]: https://github.com/sob/shopmanual.io/issues/110
 [gauge-system]: index.md
 [dashboard-cluster]: 02-dashboard-cluster.md
+[hdx-control]: 01-hdx-control.md
 [ecm]: ../../02-engine-systems/index.md
 [firewall-ingress]: ../../01-power-systems/07-wire-routing/02-firewall-ingress.md
 [radiator-fan]: ../../02-engine-systems/06-radiator-fan.md

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/04-bim-gps.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/04-bim-gps.md
@@ -41,7 +41,7 @@ GPS-based speedometer, compass, altimeter, and clock sync module. Eliminates nee
 - **Accuracy:** ±0.1 MPH (GPS-dependent)
 - **Output Signals:** 4k, 8k, 16k PPM (selectable)
 - **Signal Types:** Sine wave or square wave (configurable)
-- **Current Draw:** Negligible — bus-powered via the HDX BIM/IO cable (no separate feed); draw is included in the HDX system budget on PMU OUT9 (25A cap, ~12A typ). Dakota Digital publishes no per-module current for these data modules (only power modules like the BIM-RGB, 7.4A, list a figure).
+- **Current Draw:** Negligible — bus-powered via the HDX BIM/IO cable; included in the [HDX system budget][hdx-control] (PMU OUT9, 25A cap, ~12A typ).
 - **Antenna:** Integrated omni-directional (optional external antenna available)
 - **Warranty:** 2 years
 
@@ -97,5 +97,6 @@ GPS speedometer is legally required for on-road operation. Ensure antenna has cl
 [manual-link]: https://www.dakotadigital.com/pdf/GPS-50-2.pdf
 [gauge-system]: index.md
 [dashboard-cluster]: 02-dashboard-cluster.md
+[hdx-control]: 01-hdx-control.md
 [bim-compass]: 06-bim-compass.md
 [firewall-ingress]: ../../01-power-systems/07-wire-routing/02-firewall-ingress.md

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/05-bim-tpms.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/05-bim-tpms.md
@@ -41,7 +41,7 @@ Wireless TPMS module displaying real-time tire pressure for all four wheels on H
 - **Communication:** Wireless RF (sensors → BIM-22-3 receiver)
 - **Display:** Dashboard message center shows all 4 tire pressures
 - **Programming:** Sensors easily reprogrammed via Bluetooth app
-- **Current Draw:** Negligible — bus-powered via the HDX BIM/IO cable (no separate feed); draw is included in the HDX system budget on PMU OUT9 (25A cap, ~12A typ). Dakota Digital publishes no per-module current for these data modules (only power modules like the BIM-RGB, 7.4A, list a figure).
+- **Current Draw:** Negligible — bus-powered via the HDX BIM/IO cable; included in the [HDX system budget][hdx-control] (PMU OUT9, 25A cap, ~12A typ).
 - **Compatibility:** HDX, RTX, GRFX systems (limited VFD3/VHX compatibility)
 
 ## Display Integration

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/06-bim-compass.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/06-bim-compass.md
@@ -39,7 +39,7 @@ tags:
 - Directions: 8-point (N, NE, E, SE, S, SW, W, NW)
 - Internal Resolution: 1° (displayed as 8 directions)
 - Calibration: Automatic via internal accelerometers
-- Current Draw: Negligible — bus-powered via the HDX BIM/IO cable (no separate feed); draw is included in the HDX system budget on PMU OUT9 (25A cap, ~12A typ). Dakota Digital publishes no per-module current for these data modules (only power modules like the BIM-RGB, 7.4A, list a figure).
+- Current Draw: Negligible — bus-powered via the HDX BIM/IO cable; included in the [HDX system budget][hdx-control] (PMU OUT9, 25A cap, ~12A typ).
 
 **Temperature (SEN-15-1 Sender Included):**
 
@@ -105,5 +105,6 @@ tags:
 [product-link]: https://www.dakotadigital.com/index.cfm?ptype=product&product_id=760&category_id=646&mode=prod
 [gauge-system]: index.md
 [dashboard-cluster]: 02-dashboard-cluster.md
+[hdx-control]: 01-hdx-control.md
 [bim-gps]: 04-bim-gps.md
 [firewall-ingress]: ../../01-power-systems/07-wire-routing/02-firewall-ingress.md

--- a/docs/jeep_lj/03-lighting-systems/05-drl-parking.md
+++ b/docs/jeep_lj/03-lighting-systems/05-drl-parking.md
@@ -49,25 +49,11 @@ END
 
 ## Operation States
 
-**1. Ignition ON, Headlights OFF:**
-
-- PMU Pin 7 = ON (ignition RUN)
-- PMU In 7 = OFF (CT4 SW3 not active)
-- PMU Out 23 = ON
-- **Result:** All DRL/parking lights illuminated
-
-**2. Ignition ON, Headlights ON:**
-
-- PMU Pin 7 = ON (ignition RUN)
-- PMU In 7 = ON (CT4 SW3 active)
-- PMU Out 23 = OFF
-- **Result:** Headlights active, DRL off
-
-**3. Ignition OFF:**
-
-- PMU Pin 7 = OFF
-- PMU Out 23 = OFF (regardless of headlight status)
-- **Result:** All DRL/parking lights off
+| Ignition | Headlights (CT4 SW3) | Pin 7 | In 7 | Out 23 | Result |
+| :------- | :-------------------- | :---- | :--- | :----- | :----------------------------- |
+| ON | OFF | ON | OFF | ON | All DRL/parking lights illuminated |
+| ON | ON | ON | ON | OFF | Headlights active, DRL off |
+| OFF | — | OFF | — | OFF | All DRL/parking lights off |
 
 ## Wiring
 

--- a/docs/jeep_lj/08-exterior-systems/03-air-lockers.md
+++ b/docs/jeep_lj/08-exterior-systems/03-air-lockers.md
@@ -86,33 +86,13 @@ ARB RD116 air-operated locking differentials for front and rear Dana 44 axles.
 
 ### Engagement Sequence
 
-**Front Locker:**
-
-1. Press Button 9 (OUTPUT-17)
-2. Solenoid opens, pressurized air from tank → front locker
-3. Front differential locks **instantly** (no waiting for compressor)
-4. Release Button 9 to disengage
-
-**Rear Locker:**
-
-1. Press Button 10 (OUTPUT-10)
-2. Solenoid opens, pressurized air from tank → rear locker
-3. Rear differential locks **instantly**
-4. Release Button 10 to disengage
+Press the button (Front: Button 9/OUTPUT-17, Rear: Button 10/OUTPUT-10) to open the solenoid — pressurized air from the tank locks the differential **instantly** (no waiting for the compressor). Release the button to disengage.
 
 **Automatic Refill:**
 
 - After multiple locker uses, tank pressure drops below 135 PSI
 - Pressure switch automatically activates compressor to refill tank
 - No user action required
-
-## Safety Considerations
-
-!!! warning "Locker Operation"
-    - Only engage lockers at low speeds (typically <5 mph)
-    - Disengage lockers before returning to normal speeds
-    - Never engage lockers on dry pavement
-    - Ensure adequate air pressure before engaging lockers
 
 ## Outstanding Items
 


### PR DESCRIPTION
Nightly tidiness pass per `docs/jeep_lj/CLAUDE.md`'s BE SUCCINCT imperative. Trims prose that restated an adjacent table/diagram or repeated the same rationale across sibling files. No numbers, identifiers, TBD items, table rows, or `[ref]:` link definitions were touched — only prose and structure.

| File | Lines before → after | What was cut | Persona it failed |
| :--- | :--- | :--- | :--- |
| `01-power-systems/03-aux-battery-distribution/index.md` | 67 → 65 | Info-box rationale for the AUX two-stage distribution architecture that duplicated the fuller explanation already on `02-constant-bus.md` (the authoritative page for that bus); replaced with a pointer | Owner (read the same design justification twice one click apart) |
| `01-power-systems/04-pmu/05-pmu-arb-load-shedding.md` | 327 → 321 | The line "Load shedding provides additional margin and maintains optimal voltage" repeated verbatim twice; a 3-bullet "Impact Without Load Shedding" list that just re-stated the surrounding math, merged into one sentence | Mechanic/Troubleshooter (had to read past 2 restatements of the same conclusion) |
| `02-engine-systems/07-grid-heater.md` | 116 → 92 | "System Architecture" section that re-described the same ECM→relay→element circuit already shown in the Specifications table and the Mermaid diagram; "Why Direct ECM Control" and "Power Distribution" sections merged (both explained "bypasses PMU" separately) | Mechanic (4 formats of the same circuit to cross-check), Troubleshooter |
| `02-engine-systems/09-gauge-cluster/01-hdx-control.md` | 149 → 150 | N/A — gained one line consolidating the BIM current-draw rationale here as the single authoritative copy | (authoritative source for the dedup below) |
| `02-engine-systems/09-gauge-cluster/03-bim-j1939.md` | 136 → 137 | Identical "Dakota Digital publishes no per-module current..." sentence, now a cross-link to `01-hdx-control.md` | Mechanic/Buyer (same boilerplate crowding out module-specific specs) |
| `02-engine-systems/09-gauge-cluster/04-bim-gps.md` | 101 → 102 | Same identical sentence, same fix | Mechanic/Buyer |
| `02-engine-systems/09-gauge-cluster/05-bim-tpms.md` | 94 → 94 | Same identical sentence, same fix | Mechanic/Buyer |
| `02-engine-systems/09-gauge-cluster/06-bim-compass.md` | 109 → 110 | Same identical sentence, same fix | Mechanic/Buyer |
| `03-lighting-systems/05-drl-parking.md` | 105 → 91 | "Operation States" — three verbose prose blocks that walked the pseudocode logic above them line-by-line, converted to a compact truth table (same info, faster lookup) | Mechanic (doubled reading to confirm one piece of logic), Troubleshooter |
| `08-exterior-systems/03-air-lockers.md` | 132 → 111 | Two near-identical 4-step "Engagement Sequence" lists (front/rear differ only by button number) merged into one sentence; generic ARB-manual "Safety Considerations" callout (low speed, no dry pavement) removed as not build-specific | Owner/Mechanic (no build-specific value) |

## Left for human judgment

- `01-power-systems/08-load-analysis/index.md` — its "Summary Results" tables restate numbers that also live in `02-start-battery.md` / `03-aux-battery.md` / `01-scenarios.md`, and one pair (AUX "Night Offroad" scenario) appears to have **drifted out of sync** between copies. Consolidating this safely means resolving which number is correct, which is outside a prose-only tidiness pass — flagging for you to reconcile.
- `08-exterior-systems/01-winch.md` "Control System" section describes a generic center-off rocker switch, but the file's own Wiring section (and `05-control-interfaces/05-dashboard-controls.md`) documents the actual installed part as CH4X4-TOY-D-WINIO dual-momentary push buttons — not a rocker. This reads as stale pre-selection language rather than pure verbosity; didn't touch it since correcting it risks stating a spec I can't verify.
- `01-power-systems/STANDARDS-EXCEPTIONS.md` has heavy internal repetition (a template repeated across six sections, then summarized twice more), but it exists specifically to prevent future reviewers from re-litigating settled engineering decisions — left alone since single-file repetition here may be intentional, not verbosity.
- Several smaller cross-file rationale echoes noted by the survey (subwoofer/amplifier wiring rationale, air-compressor/SwitchPros trigger logic, GMRS/intercom grounding notes) were lower-confidence and are not included in this batch to keep the diff small and reviewable.

## Verification

- `python3 -m mkdocs build --strict` — passes (exit 0), no new broken links/anchors introduced.
- `npx markdownlint-cli2 "docs/jeep_lj/**/*.md"` — 1161 pre-existing errors unchanged (baseline, unrelated to this diff); this PR introduces zero net-new lint errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Xkhy7FJvdau5byjgT9k4hm

---
_Generated by [Claude Code](https://claude.ai/code/session_01Xkhy7FJvdau5byjgT9k4hm)_