### PR TITLE
docs: nightly tidiness — trim verbosity (2026-07-13)

### DIFF
--- a/docs/jeep_lj/01-power-systems/01-power-generation/index.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/index.md
@@ -7,7 +7,7 @@ hide:
 
 ## System Overview
 
-Dual battery system with Odyssey PC1500 AGM (START) and Dakota Lithium 135Ah LiFePO4 (AUX), RedArc BCDC Alpha 50 isolation/charging, and 270A alternator. START battery powers critical engine systems, AUX battery powers accessories. Batteries operate independently when isolated, AUX battery can assist starting via BCDC jump start mode. 80W hood solar panel maintains AUX battery.
+See [Power Systems Overview][power-systems] for the START/AUX battery specs and dual-battery charging architecture. This section covers the battery hardware, alternator, BCDC, and solar charging in detail. Beyond isolated charging, the BCDC also supports a jump-start assist mode (AUX → START), and an 80W hood solar panel maintains AUX battery charge.
 
 ## Components
 
@@ -21,3 +21,4 @@ Dual battery system with Odyssey PC1500 AGM (START) and Dakota Lithium 135Ah LiF
 - **[Grounding Architecture][grounding]** - Battery ground connections and distributed grounding system (Section 1.5)
 
 [grounding]: ../05-grounding/index.md
+[power-systems]: ../index.md

--- a/docs/jeep_lj/02-engine-systems/05-horn.md
+++ b/docs/jeep_lj/02-engine-systems/05-horn.md
@@ -52,18 +52,6 @@ START battery CONSTANT → PMU → Out 18 → PIAA Horns (5.4A) → Chassis Grou
                       Horn Button → In 1 (trigger)  [column path undefined — {{ tbd(152) }}]
 ```
 
-**Power Flow:**
-
-1. START battery+ → 250A inline CB → PMU
-2. Horn button (steering wheel) → PMU In 1 (trigger signal)
-3. PMU Out 18 activated when In 1 closes
-4. PMU Out 18 → PIAA horns (5.4A) → chassis ground (engine bay)
-
-**Notes:**
-
-- PMU Out 18 switches directly (no external relay needed)
-- Works with ignition off (CONSTANT power for safety)
-
 ## Outstanding Items
 
 {{ tbds() }}

--- a/docs/jeep_lj/02-engine-systems/07-grid-heater.md
+++ b/docs/jeep_lj/02-engine-systems/07-grid-heater.md
@@ -84,22 +84,9 @@ flowchart LR
     style ELEMENT fill:#d1d5db,color:#000
 ```
 
-## Why Direct ECM Control
-
-- ECM has accurate engine temperature data
-- ECM knows optimal grid heater timing for cold starts
-- Eliminates unnecessary complexity of PMU passthrough
-- Frees PMU output slots for other critical systems
-
 ## Power Distribution
 
-**Bypasses all distribution systems:**
-
-- Does NOT use CONSTANT bus bar
-- Does NOT use PMU outputs
-- Direct battery connection with fusible link protection
-
-**Reason:** High current draw (40-80A) for very short duration (3-5 seconds). Direct connection minimizes voltage drop and connection complexity.
+Direct ECM control (no PMU passthrough) and direct battery connection (no CONSTANT bus) — the ECM has better real-time engine temperature data than an external controller, and skipping PMU frees a PMU output slot. The brief high-current pulse (40-80A, 3-5s) doesn't justify bus-bar routing; the integrated fusible link is adequate protection. See [Standards Exceptions][standards-exceptions] for the full no-CB justification.
 
 ## Outstanding Items
 
@@ -113,3 +100,4 @@ flowchart LR
 [install-checklist]: ../09-installation/02-engine-systems-checklist.md
 [pmu-power-distribution]: ../01-power-systems/04-pmu/index.md
 [starter-battery-distribution]: ../01-power-systems/02-starter-battery-distribution/index.md
+[standards-exceptions]: ../01-power-systems/STANDARDS-EXCEPTIONS.md

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/04-bim-gps.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/04-bim-gps.md
@@ -50,7 +50,6 @@ GPS-based speedometer, compass, altimeter, and clock sync module. Eliminates nee
 **Integrated Antenna:**
 
 - Built-in omni-directional antenna
-- Requires clear sky view for reliable operation
 - Mounting: Dash top or windshield area
 
 **Optional External Antenna:**

--- a/docs/jeep_lj/03-lighting-systems/02-headlights.md
+++ b/docs/jeep_lj/03-lighting-systems/02-headlights.md
@@ -44,16 +44,14 @@ tags:
 
 - **Control:** Pull CT4 lever (latching on/off)
 - **Power:** START battery (40A) → CT4 → SW3 output (10A internal fusing)
-- **Disabled:** When ignition off (via ignition signal)
-- **Load:** 3.6A total (both lights in parallel)
 
 ## High Beam
 
 - **Control:** Push CT4 lever (momentary or latching - programmable)
 - **Power:** START battery (40A) → CT4 → SW4 output (10A internal fusing)
 - **Mutual Exclusivity:** CT4 automatically disables low beam when high beam activates
-- **Disabled:** When ignition off
-- **Load:** 5.6A total (both lights in parallel)
+
+Both beams disable when ignition is off (via ignition signal); current draw is per the pin table above.
 
 ## DRL (Daytime Running Light)
 

--- a/docs/jeep_lj/08-exterior-systems/02-air-compressor.md
+++ b/docs/jeep_lj/08-exterior-systems/02-air-compressor.md
@@ -57,11 +57,7 @@ ARB Twin Compressor system with air tank and automatic pressure management for l
 
 ## Control System
 
-- **Control:** SwitchPros OUTPUT-11 (15A output, Button 11)
-  - OUTPUT-11 provides switched 12V control signal to compressor
-  - Compressor has internal relay/control that handles high-current motor switching
-  - 14 AWG wire from OUTPUT-11 to compressor control terminal
-- **Ground:** 6 AWG black wire from compressor to AUX battery negative (direct connection for 90A return current)
+SwitchPros OUTPUT-11 (Button 11) provides a switched 12V control signal; the compressor's internal relay handles the high-current motor switching, so only a light 14 AWG control wire is needed alongside the 6 AWG motor power/ground (see Wiring table below).
 
 ## Wiring
 


### PR DESCRIPTION
Nightly tidiness pass per `docs/jeep_lj/CLAUDE.md` (BE SUCCINCT). No specs, numbers, part numbers, or link targets changed — prose and structure only.

| File | Lines before → after | What was cut | Persona it failed |
| :--- | :--- | :--- | :--- |
| `02-engine-systems/07-grid-heater.md` | 116 → 103 | Collapsed "Why Direct ECM Control" + "Power Distribution" (which duplicated the file's own System Architecture section and the fuller analysis in `STANDARDS-EXCEPTIONS.md`) into one short paragraph with a cross-link to the authoritative Standards Exceptions entry, matching the pattern already used in `08-exterior-systems/01-winch.md` | Owner/Designer (same rationale re-explained in two places in one file, and missing the cross-link to the authoritative source) |
| `02-engine-systems/05-horn.md` | 83 → 71 | Removed the "Power Flow" numbered list and "Notes" bullets, which restated the same battery→PMU→Out18→horn path already given in the wiring diagram and PMU Configuration bullets above them | Mechanic/Installer (same fact stated three times) |
| `03-lighting-systems/02-headlights.md` | 86 → 84 | Removed the per-beam "Disabled" and "Load" bullets that restated the Pin Configuration table's current values and ignition-off behavior; merged into one shared line | Mechanic/Installer (restating the adjacent table) |
| `08-exterior-systems/02-air-compressor.md` | 192 → 188 | Condensed the "Control System" bullet list, which restated the wire gauges/terminals already in the Wiring table below it, down to the one sentence that adds new information (why the control wire can be light-gauge) | Mechanic/Installer (restating the adjacent table) |
| `02-engine-systems/09-gauge-cluster/04-bim-gps.md` | 101 → 100 | Removed a bullet duplicating the more complete warning box below it (clear-sky-view requirement for GPS reliability) | Mechanic/Installer (same fact stated twice in one page) |
| `01-power-systems/01-power-generation/index.md` | 24 → 24 | Replaced the "System Overview" paragraph (which re-stated battery models/capacities and charging architecture already covered in the parent `01-power-systems/index.md`) with a cross-link plus only the facts unique to this page (BCDC jump-start assist, solar panel) | Owner/Designer (same architecture summary repeated across files) |

## Left for human judgment

- `01-power-systems/02-starter-battery-distribution/index.md:56` uses "far more robust than their former shared dependency on the PMU module" — borderline marketing adjective vs. a real engineering comparison; left alone since it's part of an intentional-tradeoff rationale box.
- `01-power-systems/08-load-analysis/index.md`'s "Why Not Sum All Loads?" section closely mirrors the "Load Analysis Guidelines" in the top-level `CLAUDE.md` — but `CLAUDE.md` is out of scope for this pass (never touched), so no action taken; worth a human look at whether `CLAUDE.md`'s copy should shrink to a cross-link instead.
- `06-audio-systems/02-amplifier.md`'s "Mounting Location" narrative and `01-power-generation/01-batteries.md`'s "Purpose" bullets partially restate adjacent specs/tables, but the overlap is partial (mixed with genuinely new mounting/categorization detail) — flagged as lower-confidence, left alone to keep this diff conservative.
- The GPS "clear sky view" duplication also appears (in different wording) in `02-engine-systems/09-gauge-cluster/02-dashboard-cluster.md` as a safety-legal warning; left both instances in place since repeating a safety-legal requirement across pages seemed intentional rather than pure redundancy.

## Verification

- `python3 -m mkdocs build --strict` — passes (exit 0), no broken links/anchors introduced.
- `npx markdownlint-cli2 "docs/jeep_lj/**/*.md"` — same 15 pre-existing errors as `main` (all in `08-exterior-systems/02-air-compressor.md`, `02-engine-systems/09-gauge-cluster/04-bim-gps.md`, `02-engine-systems/05-horn.md`, `02-engine-systems/07-grid-heater.md`, and unrelated `tbd-tracker.md`); no new errors introduced by this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FUxVMABzC9H3QEN1V7oPMq

---
_Generated by [Claude Code](https://claude.ai/code/session_01FUxVMABzC9H3QEN1V7oPMq)_