### PR TITLE
docs: nightly tidiness — trim verbosity (2026-07-20)

### DIFF
--- a/docs/jeep_lj/01-power-systems/01-power-generation/03-bcdc.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/03-bcdc.md
@@ -94,21 +94,8 @@ The BCDC includes a battery temperature sensor (2-pin, polarity reversible) that
 **Installation Location:**
 
 - **Mount Position:** AUX battery positive terminal
-- **Attachment:** Ring terminal under battery terminal bolt
-- **Why Positive Terminal:** Measures both voltage and temperature at the battery for accurate charge control
-
-**Why Required:**
-
-- AGM batteries are temperature-sensitive during charging
-- Overcharging at high temps causes thermal runaway risk
-- Undercharging at low temps leads to sulfation
-- BCDC adjusts charge voltage based on sensor reading (temperature compensation)
-
-**Installation Notes:**
-
-1. Install ring terminal on AUX battery positive terminal bolt
-2. Route sensor cable to BCDC (short run - both in passenger rear wheel well)
-3. Plug into BCDC temperature sensor port (2-pin connector)
+- **Attachment:** Ring terminal under battery terminal bolt, cable routed to BCDC's 2-pin temperature sensor port (short run — both in passenger rear wheel well)
+- **Why Positive Terminal:** Measures both voltage and temperature at the battery for accurate charge control; BCDC uses this reading for temperature-compensated charge voltage
 
 [redarc-bcdc]: https://www.redarcelectronics.com/products/the-manager30
 [bcdc-install]: https://cdn.intelligencebank.com/au/share/yE9N/zJpl/NNRlJ/original/Install+Guide+BCDC+Alpha+50R+EN

--- a/docs/jeep_lj/01-power-systems/01-power-generation/04-solar.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/04-solar.md
@@ -70,15 +70,13 @@ tags:
 
 **Panel-side vs battery-side current:** The 1.95A figure is the panel-side current at the panel's ~40V operating voltage (40V × 1.95A ≈ 78W). The BCDC's MPPT steps that down to the battery charge voltage, so the battery-side contribution is higher: 78W ÷ ~13.4V ≈ **~5.8A to the AUX battery**.
 
-**BCDC Green Power Priority:** Solar input used first when available, alternator supplements to reach 50A total charging current. In full sun, solar contributes ~5.8A battery-side, reducing alternator load by the same amount.
+**BCDC Green Power Priority:** Solar input used first when available, alternator supplements to reach 50A total charging current.
 
 **Charging Contribution (battery-side):**
 
 - **Full sun:** ~5.8A to AUX battery (78W ÷ ~13.4V; reduces alternator load from 50A to ~44A)
 - **Partial sun:** Variable, proportional to available irradiance
 - **Overcast/Night:** 0A (BCDC uses alternator only)
-
-**Alternator Load Relief:** Minimal but measurable — reduces worst-case alternator load by ~5.8A during sunny daytime operation
 
 See [BCDC Alpha 50][bcdc] for complete charging system details.
 

--- a/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
@@ -33,13 +33,7 @@ Usable capacity (80% DOD):  108Ah
 Time to 20% SOC:           ~144 minutes continuous (2.4 hours)
 ```
 
-The Dakota Lithium 135Ah combined with 50A BCDC makes extended air-up a non-issue. Load shedding provides additional margin and maintains optimal voltage for electronics.
-
-**Impact Without Load Shedding:**
-
-- Minor: AUX battery still has comfortable margin at 50A BCDC
-- START battery loads reduce BCDC charging efficiency slightly
-- Load shedding maximizes available margin for extended sessions
+**Impact Without Load Shedding:** Minor — the 135Ah AUX battery retains comfortable margin at 50A BCDC charging; load shedding simply maximizes that margin for extended sessions.
 
 ## Solution Overview
 
@@ -219,10 +213,7 @@ ELSE:
 
 **Best Practices for ARB Use:**
 
-1. **Increase Engine RPM:** Run engine at 1500+ RPM during tire inflation
-   - Alternator output increases with RPM
-   - Better voltage regulation at higher speeds
-   - Faster tire inflation
+1. **Increase Engine RPM:** Run at 1500+ RPM during tire inflation for better voltage regulation and faster inflation (alternator output scales with RPM).
 
 2. **Monitor Voltage:** Watch Dakota Digital voltage gauge during ARB use
    - Normal: 14.0-14.4V (load shedding working)

--- a/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
+++ b/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
@@ -123,16 +123,7 @@ This document tracks intentional deviations from general electrical standards wh
 
 ### Winch Review Guidance
 
-**This is NOT an oversight or safety issue.**
-
-It is intentional adherence to:
-
-1. Manufacturer specifications (WARN)
-2. Automotive standards (SAE J1128)
-3. Industry standard practice (factory winch installations)
-4. Engineering analysis (load, wire sizing, fault scenarios)
-
-**Do NOT flag as requiring correction in future reviews.**
+**Intentional, not an oversight — do NOT flag in future reviews.** Adherence to WARN spec, SAE J1128, and factory precedent, per the analysis above.
 
 **Documentation References:**
 
@@ -241,17 +232,7 @@ It is intentional adherence to:
 
 ### Starter Review Guidance
 
-**Current design (no CB) is acceptable per automotive standards.**
-
-**Enhancement (timer relay) is recommended but not critical:**
-
-- Adds protection for stuck solenoid scenario
-- Low cost, simple implementation
-- Common in heavy-duty truck applications
-
-**Do NOT flag as critical safety issue** - cable sizing provides adequate protection for normal operation per SAE J1128.
-
-**Consider implementing timer relay as build enhancement** - provides additional fault protection beyond baseline automotive practice.
+**Acceptable per SAE J1128 — do NOT flag as a critical safety issue.** Timer relay (Option 1 above) remains a recommended, non-critical enhancement for the stuck-solenoid scenario.
 
 **Documentation References:**
 
@@ -306,11 +287,7 @@ It is intentional adherence to:
 
 ### Grid Heater Review Guidance
 
-**This is intentional per manufacturer specifications.**
-
-Grid heater brief, high-current load characteristics make circuit breaker unnecessary - fusible link and ECM control provide adequate protection.
-
-**Do NOT flag as requiring circuit breaker.**
+**Intentional per Cummins spec — do NOT flag as requiring a circuit breaker.**
 
 **Documentation References:**
 
@@ -358,11 +335,7 @@ Grid heater brief, high-current load characteristics make circuit breaker unnece
 
 ### Alternator Review Guidance
 
-**This is standard automotive practice.**
-
-Alternators NEVER use circuit breakers on output circuits in factory or aftermarket applications.
-
-**Do NOT flag as missing protection.**
+**Standard automotive practice — do NOT flag as missing protection.** Alternators never use output circuit breakers, factory or aftermarket.
 
 **Documentation References:**
 
@@ -400,11 +373,7 @@ Alternators NEVER use circuit breakers on output circuits in factory or aftermar
 
 ### BCDC Review Guidance
 
-**Circuit breaker AT BATTERY TERMINAL is correct protection point.**
-
-No additional CB required at BCDC - entire circuit protected from battery terminal CB.
-
-**Do NOT flag as missing protection at BCDC.**
+**The battery-terminal CB is the correct, sole protection point — do NOT flag BCDC as missing protection.** It protects the entire run from battery to BCDC.
 
 **Documentation References:**
 
@@ -521,16 +490,7 @@ The CB is sized for _device capacity_, not actual load. Actual loads are well wi
 
 ### Review Guidance
 
-**This is NOT a safety issue.**
-
-The apparent CB > wire mismatch is intentional:
-
-1. Actual loads (82-100A) well within wire rating (130A)
-2. CB sized for device capacity and inrush tolerance
-3. Fault protection adequate (CB trips before wire damage)
-4. Intermittent duty cycle (not continuous operation)
-
-**Do NOT flag as requiring wire upgrade or CB downgrade.**
+**Not a safety issue — do NOT flag as requiring wire upgrade or CB downgrade.** The CB > wire mismatch is intentional, per the load, protection-strategy, and wire-sizing analysis above.
 
 **Documentation References:**
 

--- a/docs/jeep_lj/02-engine-systems/07-grid-heater.md
+++ b/docs/jeep_lj/02-engine-systems/07-grid-heater.md
@@ -84,22 +84,10 @@ flowchart LR
     style ELEMENT fill:#d1d5db,color:#000
 ```
 
-## Why Direct ECM Control
+## Why Direct Connection (No PMU)
 
-- ECM has accurate engine temperature data
-- ECM knows optimal grid heater timing for cold starts
-- Eliminates unnecessary complexity of PMU passthrough
-- Frees PMU output slots for other critical systems
-
-## Power Distribution
-
-**Bypasses all distribution systems:**
-
-- Does NOT use CONSTANT bus bar
-- Does NOT use PMU outputs
-- Direct battery connection with fusible link protection
-
-**Reason:** High current draw (40-80A) for very short duration (3-5 seconds). Direct connection minimizes voltage drop and connection complexity.
+- ECM has the most accurate engine-temperature data and manages duty cycle itself — a PMU passthrough adds complexity with no benefit, and frees a PMU output slot for other systems.
+- High current (40-80A) for a brief 3-5s pulse: bypassing the CONSTANT bus and PMU for a direct battery connection with fusible link protection minimizes voltage drop and wiring complexity.
 
 ## Outstanding Items
 

--- a/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
+++ b/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
@@ -134,31 +134,9 @@ Recommended configuration for this build:
 
 ### PMU DRL Auto-Off Logic
 
-**Purpose:** Automatically turns off DRL when headlights are activated via CT4 SW3
+CT4 SW3 (headlight status) feeds PMU In 7. The auto-off logic, operation states, and output wiring are documented on the authoritative [DRL & Parking][drl-parking] page.
 
-**Implementation:** PMU programming logic (no external relay needed)
-
-**PMU Configuration:**
-
-```text
-PMU Input 7 (In 7): CT4 SW3 headlight status signal (tapped from low beam circuit)
-PMU Pin 7: Ignition RUN signal (12V switched input)
-PMU Output 23 (Out 23): DRL/Parking lights circuit
-
-Programming Logic:
-IF (Pin7_IgnitionRUN == ON) AND (In7_CT4_Headlights == OFF)
-  THEN Out23_DRL = ON
-ELSE
-  Out23_DRL = OFF
-END
-```
-
-**Installation Notes:**
-
-- Tap CT4 SW3 output (low beam circuit) to PMU In 7 for headlight status monitoring
-- Run wire from PMU Out 23 to DRL junction
-- Total DRL/parking circuit load: ~2.6A — see [DRL & Parking][drl-parking] for the itemized load breakdown and wiring
-- PMU Out 23 capacity: 7A (sufficient for the ~2.6A load)
+**Installation:** Tap CT4 SW3 output (low beam circuit) to PMU In 7 for headlight status monitoring.
 
 ## Installation Checklist
 


### PR DESCRIPTION
Nightly tidiness pass per `docs/jeep_lj/CLAUDE.md` (BE SUCCINCT). Trims prose that re-restated an adjacent table, code block, or analysis already stated earlier on the same page — or duplicated the same design rationale across two files, now cross-linked to the authoritative page instead. No specs, part numbers, wire gauges, TBD items, Outstanding Items checkboxes, table rows, frontmatter, or `div.product-info` blocks were touched.

| File | Lines before → after | What was cut | Which persona it failed |
| :--- | :--- | :--- | :--- |
| `01-power-systems/STANDARDS-EXCEPTIONS.md` | 592 → 552 | Each of 6 "Review Guidance" subsections (Winch, Starter, Grid Heater, Alternator, BCDC, SwitchPros/SafetyHub) fully restated the numbered analysis directly above it; compressed each to one sentence pointing back at that analysis. Left the final "Summary" and "Review Checklist" (checkbox items) untouched. | Mechanic/Owner — pure restatement, no new fact |
| `01-power-systems/04-pmu/05-pmu-arb-load-shedding.md` | 326 → 317 | The "load shedding adds margin" conclusion was stated 3× in the first 40 lines; removed the 2nd/3rd restatements. Trimmed the generic "alternator output increases with RPM" explainer to one clause (textbook fact, not build-specific). | Owner (redundant, not incremental) / generic-practice rule |
| `05-control-interfaces/03-command-touch-ct4.md` | 228 → 206 | The "PMU DRL Auto-Off Logic" section (full code block + install notes) was a near-verbatim copy of the authoritative logic already owned by `03-lighting-systems/05-drl-parking.md`; replaced with a one-line cross-link. | Mechanic/Owner — same rationale/logic duplicated across files |
| `02-engine-systems/07-grid-heater.md` | 115 → 103 | "Direct battery connection, bypasses PMU, brief high-current" was stated 4× (product-info, System Architecture, "Why Direct ECM Control", "Power Distribution"); merged the last two sections into one non-redundant paragraph. | Mechanic/Owner — restated System Architecture bullets above |
| `01-power-systems/01-power-generation/03-bcdc.md` | 119 → 106 | Removed generic AGM/LiFePO4 charging theory ("Why Required" bullets — standard textbook fact, not build-specific) and folded the 3-step "Installation Notes" (which restated the Installation Location bullets) into one bullet. | Fails all four personas — standard practice, not build rationale |
| `01-power-systems/01-power-generation/04-solar.md` | 165 → 163 | The "~5.8A alternator load relief" conclusion was stated 3× in a row (derivation, prose recap, table, standalone callout); removed the 2nd and 4th restatements, kept the derivation and the table. | Owner — redundant, not incremental |

**Verification:**
- `mkdocs build --strict` — exit 0. One pre-existing INFO-level broken anchor (`#wiring` on the CT4 page) was already present on `main`; not introduced or worsened by this PR.
- `markdownlint-cli2 "docs/jeep_lj/**/*.md"` — the 6 edited files carry the exact same lint issues (same count, same rules) as they did on `main` before this PR; nothing new introduced. (The full doc tree has pre-existing lint failures in files this PR does not touch — `03-purchase-tracker.md`, `10-drivetrain/01-transmission.md`, `CLAUDE.md`, `tbd-tracker.md` — confirmed present on `main` at the base commit.)

## Left for human judgment

- `STANDARDS-EXCEPTIONS.md` also has some redundancy between the "Summary of Intentional Design Decisions" section and the individual per-component sections above it, and the "Review Checklist" restates every verdict once more. Left alone: the checklist uses `- [ ]` items (guardrail: never delete checkbox items), and the Summary adds non-duplicate framing (which marine-standard sections apply where) not stated elsewhere.
- A handful of smaller duplication candidates surfaced in the survey but were left out to keep this PR's diff small: `pmu-arb-load-shedding.md`'s "Operational Procedures" section still has some borderline generic driving advice (RPM/voltage/heat guidance) that is arguably build-specific enough to keep; `07-wire-routing/03-harness-inventory.md` repeats a wire-sizing rationale already stated in `04-harness-power-distribution.md`; `08-load-analysis/01-scenarios.md` and `03-aux-battery.md` restate the same "corrected XL Sport specs" conclusion; `06-audio-systems/01-head-unit.md`, `07-communication-systems/01-gmrs-radio.md`, and `02-intercom.md` each have a couple of "Installation Notes" lines that restate their Wiring table. None were touched this run — candidates for a future pass.
- Not verbosity, but noticed during the survey: `03-lighting-systems/06-dome-lights.md`'s "Rear Seat Override" and `05-control-interfaces/05-dashboard-controls.md`'s "Rear Seat Switch" appear to describe the same physical feature with different wiring sources (KC bracket switch/CONSTANT-fed vs. Blue Sea 4160/OUTPUT-4) — looks like a correctness inconsistency worth a human look, out of scope for a tidiness pass.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019S3WVUpX4NUJW2KCux2gA8

---
_Generated by [Claude Code](https://claude.ai/code/session_019S3WVUpX4NUJW2KCux2gA8)_