### PR TITLE
docs: nightly tidiness — trim verbosity (2026-07-21)

### DIFF
--- a/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
+++ b/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
@@ -53,7 +53,7 @@ The radiator fan, iBooster, and TCU were relocated off the PMU onto START-direct
 The master feed carries the combined load (~68A continuous, ~108A brief peak); voltage drop and breaker sizing are set on that single cable.[^fwd-bus-vdrop] The iBooster's separate ignition **enable** (~5A) is sourced from the [Ignition Signal bus][ignition-signal], not this bus. Fan speed is set by a dedicated fan controller ({{ tbd(134) }}) with its own coolant sensor, independent of the PMU and J1939.
 
 !!! info "Shared forward feed — intentional tradeoff"
-    The three loads share one master feed + busbar (a passive cable, breaker, and bus bar — no active electronics), versus three independent runs from the battery. This is the same tradeoff the [AUX side][constant-bus] accepts, and is far more robust than their former shared dependency on the PMU module. Each load keeps its own breaker. See [Standards Exceptions][standards-exceptions].
+    The three loads share one master feed + busbar (a passive cable, breaker, and bus bar — no active electronics), versus three independent runs from the battery. This is the same tradeoff the [AUX side][constant-bus] accepts. Each load keeps its own breaker. See [Standards Exceptions][standards-exceptions].
 
 [^fwd-bus-vdrop]: Master feed 2 AWG @ ~108A brief peak (~68A continuous), ~8 ft, 60°C-derated (×1.2) ≈ 1.3% — sized on the combined load. Load feeds are short from the engine-bay bus, so per-load drop is negligible: fan 4 AWG @ 53A, iBooster 8 AWG @ 40A brief, TCU 12 AWG @ 15A. Final master-feed length and breaker selective-coordination pending {{ tbd(136) }} and {{ tbd(135) }}.
 

--- a/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
@@ -219,10 +219,7 @@ ELSE:
 
 **Best Practices for ARB Use:**
 
-1. **Increase Engine RPM:** Run engine at 1500+ RPM during tire inflation
-   - Alternator output increases with RPM
-   - Better voltage regulation at higher speeds
-   - Faster tire inflation
+1. **Increase Engine RPM:** Run engine at 1500+ RPM during tire inflation — alternator output and voltage regulation both improve with RPM.
 
 2. **Monitor Voltage:** Watch Dakota Digital voltage gauge during ARB use
    - Normal: 14.0-14.4V (load shedding working)

--- a/docs/jeep_lj/03-lighting-systems/05-drl-parking.md
+++ b/docs/jeep_lj/03-lighting-systems/05-drl-parking.md
@@ -32,42 +32,7 @@ PMU Out 23 splices to all running/marker lights:
 
 **Purpose:** Automatically turns off DRL when headlights activate
 
-**PMU Configuration:**
-
-```text
-PMU Input 7 (In 7): CT4 SW3 headlight status signal
-PMU Pin 7: Ignition RUN signal (12V switched input)
-PMU Output 23 (Out 23): DRL/Parking lights circuit
-
-Programming Logic:
-IF (Pin7_IgnitionRUN == ON) AND (In7_CT4_Headlights == OFF)
-  THEN Out23_DRL = ON
-ELSE
-  Out23_DRL = OFF
-END
-```
-
-## Operation States
-
-**1. Ignition ON, Headlights OFF:**
-
-- PMU Pin 7 = ON (ignition RUN)
-- PMU In 7 = OFF (CT4 SW3 not active)
-- PMU Out 23 = ON
-- **Result:** All DRL/parking lights illuminated
-
-**2. Ignition ON, Headlights ON:**
-
-- PMU Pin 7 = ON (ignition RUN)
-- PMU In 7 = ON (CT4 SW3 active)
-- PMU Out 23 = OFF
-- **Result:** Headlights active, DRL off
-
-**3. Ignition OFF:**
-
-- PMU Pin 7 = OFF
-- PMU Out 23 = OFF (regardless of headlight status)
-- **Result:** All DRL/parking lights off
+See [PMU Programming][pmu-programming] for the auto-off logic (Pin 7 ignition + In 7 CT4 headlight status → Out 23 DRL).
 
 ## Wiring
 
@@ -101,5 +66,6 @@ END
 - [Tail/Brake/Reverse][tail-brake-reverse-lights] - Maxbilt RED wire (marker/parking)
 
 [pmu-power-distribution]: ../01-power-systems/04-pmu/index.md
+[pmu-programming]: ../01-power-systems/04-pmu/04-pmu-programming.md
 [headlights]: 02-headlights.md
 [tail-brake-reverse-lights]: 04-tail-brake-reverse.md

--- a/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
+++ b/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
@@ -136,22 +136,7 @@ Recommended configuration for this build:
 
 **Purpose:** Automatically turns off DRL when headlights are activated via CT4 SW3
 
-**Implementation:** PMU programming logic (no external relay needed)
-
-**PMU Configuration:**
-
-```text
-PMU Input 7 (In 7): CT4 SW3 headlight status signal (tapped from low beam circuit)
-PMU Pin 7: Ignition RUN signal (12V switched input)
-PMU Output 23 (Out 23): DRL/Parking lights circuit
-
-Programming Logic:
-IF (Pin7_IgnitionRUN == ON) AND (In7_CT4_Headlights == OFF)
-  THEN Out23_DRL = ON
-ELSE
-  Out23_DRL = OFF
-END
-```
+**Implementation:** PMU programming logic (no external relay needed) — see [PMU Programming][pmu-programming] for the logic (Pin 7 ignition + In 7 CT4 headlight status → Out 23 DRL).
 
 **Installation Notes:**
 
@@ -224,5 +209,6 @@ in the [Power Systems Checklist][power-checklist].
 [control-interfaces-overview]: 01-overview.md
 [vehicle-lighting-overview]: ../03-lighting-systems/01-lighting-overview.md
 [pmu-power-distribution]: ../01-power-systems/04-pmu/index.md
+[pmu-programming]: ../01-power-systems/04-pmu/04-pmu-programming.md
 [drl-parking]: ../03-lighting-systems/05-drl-parking.md
 [power-checklist]: ../09-installation/01-power-systems-checklist.md


### PR DESCRIPTION
Nightly tidiness pass per `docs/jeep_lj/CLAUDE.md` "BE SUCCINCT". Small, conservative diff — 4 files, 6 insertions / 57 deletions.

| File | Lines before → after | What was cut | Which persona it failed |
| :--- | :--- | :--- | :--- |
| `03-lighting-systems/05-drl-parking.md` | 106 → ~68 | Duplicated "PMU DRL Auto-Off Logic" pseudocode (already canonical in `04-pmu-programming.md`, per that section's own PMU navigation guide) replaced with a cross-link; dropped the "Operation States" 3-case walkthrough that just re-narrated the same 4-line IF/THEN already stated above it | Owner/rationale rule — same logic restated 3× across the tree (`pmu-programming.md`, `drl-parking.md`, `command-touch-ct4.md`) |
| `05-control-interfaces/03-command-touch-ct4.md` | 229 → ~211 | Same duplicated DRL auto-off pseudocode block replaced with a cross-link to the canonical copy; kept the "Installation Notes" bullets (CT4-specific tap instructions) | Same rationale-duplication rule |
| `01-power-systems/04-pmu/05-pmu-arb-load-shedding.md` | 326 → 321 | Collapsed 3 generic explanatory sub-bullets under "Increase Engine RPM" ("alternator output increases with RPM," "better voltage regulation," "faster inflation") into one line — obvious automotive-electrical facts, not build-specific | Owner/Mechanic — generic explanation, not build-specific rationale |
| `01-power-systems/02-starter-battery-distribution/index.md` | 104 → 104 | Removed one unsourced comparative claim ("far more robust than their former shared dependency on the PMU module") | Marketing language / unnecessary adjective (Core Imperative #1) |

## Left for human judgment

The verbosity survey turned up something more serious than prose bloat, which I deliberately did **not** touch tonight since it's a correctness issue, not a style one, and the hard guardrails forbid changing numbers or deleting table rows unattended:

- **Numeric drift across duplicated load-analysis tables.** `01-power-systems/08-load-analysis/index.md` and `01-power-systems/08-load-analysis/01-scenarios.md` both re-derive START/AUX battery scenario totals that are already computed authoritatively in `02-start-battery.md` / `03-aux-battery.md` — and the recomputed numbers disagree with the source pages (e.g. Camp Mode runtime: 76 min in the recompute vs. 4 hours in `03-aux-battery.md`; Night Offroad net drain shows the opposite sign in one recompute vs. another). Similarly, `04-pmu/05-pmu-arb-load-shedding.md`'s "AUX Battery Impact Analysis" recomputes the ARB scenario but appears to drop the 15A Compressor Control (OUTPUT-11) load, landing on 95A/-45A vs. the source's 110A/-60A.
- This needs someone to determine which number is actually correct before any of these sections get consolidated or corrected — that's a factual-accuracy fix, not a tidiness edit, so it's out of scope for tonight's automated pass.
- Also flagged but left alone: `01-power-systems/STANDARDS-EXCEPTIONS.md` repeats a "do NOT flag as an oversight" disclaimer and a "Documentation References" block across its 7 component sections — possibly consolidatable, but the file's stated purpose is to be exhaustively explicit for future AI reviewers, so the repetition may be load-bearing. Left for Sean's call.

## Verification

- `python3 -m mkdocs build --strict` — passes (exit 0); the one pre-existing INFO-level broken anchor in `command-touch-ct4.md` (`#wiring`, heading is actually "Wiring Pinout") predates this change and wasn't touched.
- `npx markdownlint-cli2 "docs/jeep_lj/**/*.md"` — same error count/content as `main` (all pre-existing `MD060` table-style and one `MD051` anchor issue, none introduced by this diff).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>


---
_Generated by [Claude Code](https://claude.ai/code/session_01LQBEmbsfgUjVNzM2GcjeKU)_