### PR TITLE
docs: nightly tidiness — trim verbosity (2026-07-27)

### DIFF
--- a/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
+++ b/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
@@ -53,7 +53,7 @@ The radiator fan, iBooster, and TCU were relocated off the PMU onto START-direct
 The master feed carries the combined load (~68A continuous, ~108A brief peak); voltage drop and breaker sizing are set on that single cable.[^fwd-bus-vdrop] The iBooster's separate ignition **enable** (~5A) is sourced from the [Ignition Signal bus][ignition-signal], not this bus. Fan speed is set by a dedicated fan controller ({{ tbd(134) }}) with its own coolant sensor, independent of the PMU and J1939.
 
 !!! info "Shared forward feed — intentional tradeoff"
-    The three loads share one master feed + busbar (a passive cable, breaker, and bus bar — no active electronics), versus three independent runs from the battery. This is the same tradeoff the [AUX side][constant-bus] accepts, and is far more robust than their former shared dependency on the PMU module. Each load keeps its own breaker. See [Standards Exceptions][standards-exceptions].
+    The three loads share one master feed + busbar (a passive cable, breaker, and bus bar — no active electronics), versus three independent runs from the battery. This is the same tradeoff the [AUX side][constant-bus] accepts, and removes their former shared dependency on the PMU module. Each load keeps its own breaker. See [Standards Exceptions][standards-exceptions].
 
 [^fwd-bus-vdrop]: Master feed 2 AWG @ ~108A brief peak (~68A continuous), ~8 ft, 60°C-derated (×1.2) ≈ 1.3% — sized on the combined load. Load feeds are short from the engine-bay bus, so per-load drop is negligible: fan 4 AWG @ 53A, iBooster 8 AWG @ 40A brief, TCU 12 AWG @ 15A. Final master-feed length and breaker selective-coordination pending {{ tbd(136) }} and {{ tbd(135) }}.
 

--- a/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
@@ -7,15 +7,15 @@ hide:
 
 Automatic load management during ARB compressor operation to preserve AUX battery capacity and maintain system voltage.
 
-## Dual Battery Architecture
+## AUX-Isolated Draw
 
-**Critical Understanding:** ARB compressor draws from **AUX battery**, NOT directly from alternator:
+ARB compressor draws from **AUX battery**, not directly from the alternator (see [dual-battery architecture][load-analysis-architecture]):
 
 - **ARB Compressor (90A):** Powered by AUX battery via SafetyHub 150
 - **BCDC Charging (50A max):** Replenishes AUX battery from alternator
 - **Net AUX battery drain:** 90A - 50A = 40A during compressor operation
 
-The alternator is NOT overloaded during ARB operation. The 50A BCDC significantly reduces net discharge rate, making extended air-up practical. Load shedding provides additional margin and maintains optimal voltage.
+The alternator is not overloaded during ARB operation; the 50A BCDC keeps net AUX discharge low enough to make extended air-up practical.
 
 ## Problem Statement
 
@@ -33,13 +33,7 @@ Usable capacity (80% DOD):  108Ah
 Time to 20% SOC:           ~144 minutes continuous (2.4 hours)
 ```
 
-The Dakota Lithium 135Ah combined with 50A BCDC makes extended air-up a non-issue. Load shedding provides additional margin and maintains optimal voltage for electronics.
-
-**Impact Without Load Shedding:**
-
-- Minor: AUX battery still has comfortable margin at 50A BCDC
-- START battery loads reduce BCDC charging efficiency slightly
-- Load shedding maximizes available margin for extended sessions
+The Dakota Lithium 135Ah combined with 50A BCDC makes extended air-up a non-issue even without load shedding; shedding cosmetic and comfort loads below simply maximizes the margin for extended sessions.
 
 ## Solution Overview
 
@@ -324,3 +318,4 @@ LOG SwitchPros_OUT11_ARB (state or trigger input)
 [start-load-analysis]: ../08-load-analysis/02-start-battery.md
 [aux-load-analysis]: ../08-load-analysis/03-aux-battery.md
 [start-fwd-bus]: ../02-starter-battery-distribution/index.md#start-forward-bus
+[load-analysis-architecture]: ../08-load-analysis/index.md#system-architecture

--- a/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
+++ b/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
@@ -83,16 +83,7 @@ This document tracks intentional deviations from general electrical standards wh
 - Direct battery connection specified ✓
 - Internal protection designed for fault scenarios ✓
 
-### Factory Vehicle Precedent
-
-**OEM winch installations do NOT use external circuit breakers:**
-
-- **Ford Super Duty** with factory winch prep: No CB on winch circuit
-- **RAM Power Wagon** factory winch: No external CB, direct battery connection
-- **Toyota TRD Pro** winch ready: No CB specified in prep package
-- **Jeep Rubicon** winch-capable: Power runs via relay, no CB
-
-**Industry Standard Practice:** Winch manufacturers design internal protection for automotive fault scenarios, making external CBs redundant.
+**Factory Precedent:** OEM winch preps (Ford Super Duty, RAM Power Wagon, Toyota TRD Pro, Jeep Rubicon) also omit an external CB, running power via relay/direct connection instead — winch manufacturers design internal protection for automotive fault scenarios, making external CBs redundant.
 
 ### Winch Fault Scenarios Covered
 
@@ -541,21 +532,9 @@ The apparent CB > wire mismatch is intentional:
 
 ---
 
-## Summary of Intentional Design Decisions
+## Standards Note
 
-**All decisions documented above are intentional and based on:**
-
-1. **Manufacturer Specifications** - Following OEM installation requirements
-2. **Automotive Standards (SAE J1128)** - Primary standard for automotive electrical systems
-3. **Industry Practice** - Factory vehicle precedents and proven approaches
-4. **Engineering Analysis** - Load characteristics, wire sizing, fault scenarios
-
-**These are NOT oversights, errors, or safety issues.**
-
-**Marine standards (ABYC E-11) are referenced selectively:**
-
-- Applied to: Dual battery architecture, accessory circuits, grounding
-- **NOT applied to:** Starter, alternator, winch, grid heater (automotive components)
+Marine standards (ABYC E-11) are referenced selectively: applied to dual battery architecture, accessory circuits, and grounding; **not** applied to starter, alternator, winch, or grid heater (automotive components, governed by SAE J1128 instead).
 
 ---
 


### PR DESCRIPTION
Nightly tidiness pass per `docs/jeep_lj/CLAUDE.md` ("BE SUCCINCT"). A broad survey of `docs/jeep_lj/**/*.md` found the tree already fairly disciplined — most files carry no marketing language, hedging, or generic filler. Only 3 high-confidence, low-risk wins met the bar tonight, all contained to `01-power-systems/`; no numbers, identifiers, or ref-link targets were changed.

| File | Lines before → after | What was cut | Persona it failed |
| :--- | :--- | :--- | :--- |
| `01-power-systems/STANDARDS-EXCEPTIONS.md` | 592 → 571 | Condensed the winch "Factory Vehicle Precedent" subsection (4 bulleted OEM examples) into one sentence; replaced the closing "Summary of Intentional Design Decisions" section — which fully restated the meta-point already made in the intro and in each section's own "Review Guidance" — with a single "Standards Note" carrying the one fact that section actually added (which subsystems ABYC does/doesn't apply to). | Mechanic/Installer, Troubleshooter (the restated conclusions didn't help wiring or diagnosis; one line + the existing per-section guidance covers it) |
| `01-power-systems/04-pmu/05-pmu-arb-load-shedding.md` | 326 → 321 | Replaced the "Dual Battery Architecture" prose (which re-explained the same isolated-domain rationale that `08-load-analysis/index.md#system-architecture` already owns) with a cross-link, keeping only the ARB-specific numbers. Removed a "Load shedding provides additional margin and maintains optimal voltage" sentence duplicated twice in the same page, and merged the redundant "Impact Without Load Shedding" bullet list into the sentence above it. | Owner/Designer (same design rationale re-explained across files/within the page instead of linked to its authoritative source) |
| `01-power-systems/02-starter-battery-distribution/index.md` | 103 → 103 | Replaced the marketing adjective "far more robust than" with the concrete effect ("removes their former shared dependency on the PMU module"). | Mechanic/Installer, Owner/Designer (adjective carried no information beyond the fact already in the same sentence) |

## Verification

- `mkdocs build --strict` — succeeds, no new broken links/anchors introduced by this diff (pre-existing informational notices about unrelated pages are unchanged).
- `markdownlint-cli2 "docs/jeep_lj/**/*.md"` — the repo currently has ~1,161 pre-existing lint issues (mostly `MD060` table-pipe alignment in the generated `tbd-tracker.md`, plus a pre-existing `MD024` duplicate-heading warning in `STANDARDS-EXCEPTIONS.md` for two independently-named "Review Guidance" sections). Confirmed via `git stash` comparison that this diff introduces **zero new** lint issues — the same 17 issues in the same 2 files exist byte-for-byte on unmodified `main`. Fixing the pre-existing repo-wide lint drift is out of scope for a verbosity-trim pass.

## Left for human judgment

- `STANDARDS-EXCEPTIONS.md`'s per-decision "Review Guidance" blocks and the final "Review Checklist" still both restate each decision's conclusion. Left alone rather than merged, since the document's stated purpose is specifically to stop future reviews (AI or human) from re-flagging these as errors — collapsing that redundancy felt like a design-intent call, not a pure style cut.
- The pre-existing `MD024`/`MD060` markdownlint failures repo-wide (not touched — out of scope, would require a lint-config or generated-file fix, not a prose edit).

---

Generated by an automated nightly tidiness session.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01HwNn44oEZUQXFP51CMy7ri

---
_Generated by [Claude Code](https://claude.ai/code/session_01HwNn44oEZUQXFP51CMy7ri)_