### PR TITLE
docs: nightly tidiness — trim verbosity (2026-07-31)

### DIFF
--- a/docs/jeep_lj/01-power-systems/04-pmu/03-pmu-outputs.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/03-pmu-outputs.md
@@ -62,7 +62,6 @@ _The radiator fan (formerly OUT2+3+4) and iBooster main (formerly OUT1+10) were 
 - **Non-adjacent terminals:** Each rated 23A @ 40°C individually = 46A combined capacity (much better thermal performance)
 - **Brief peak loads:** Thermal derating less critical for loads <5 seconds (e.g., brake booster)
 - **Load balancing:** Avoid placing heavily loaded outputs adjacent to each other - use non-adjacent combining for high-current loads
-- Use proper terminal crimping and wire gauge to maximize current capacity
 
 ## Thermal Analysis
 

--- a/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
+++ b/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
@@ -123,16 +123,7 @@ This document tracks intentional deviations from general electrical standards wh
 
 ### Winch Review Guidance
 
-**This is NOT an oversight or safety issue.**
-
-It is intentional adherence to:
-
-1. Manufacturer specifications (WARN)
-2. Automotive standards (SAE J1128)
-3. Industry standard practice (factory winch installations)
-4. Engineering analysis (load, wire sizing, fault scenarios)
-
-**Do NOT flag as requiring correction in future reviews.**
+**This is NOT an oversight or safety issue** — see Manufacturer Specification, Engineering Analysis, and Standards Comparison above. **Do NOT flag as requiring correction in future reviews.**
 
 **Documentation References:**
 
@@ -241,17 +232,7 @@ It is intentional adherence to:
 
 ### Starter Review Guidance
 
-**Current design (no CB) is acceptable per automotive standards.**
-
-**Enhancement (timer relay) is recommended but not critical:**
-
-- Adds protection for stuck solenoid scenario
-- Low cost, simple implementation
-- Common in heavy-duty truck applications
-
-**Do NOT flag as critical safety issue** - cable sizing provides adequate protection for normal operation per SAE J1128.
-
-**Consider implementing timer relay as build enhancement** - provides additional fault protection beyond baseline automotive practice.
+**Current design (no CB) is acceptable per automotive standards — do NOT flag as a critical safety issue.** Timer relay remains a recommended (not critical) enhancement; see Option 1 above.
 
 **Documentation References:**
 
@@ -306,11 +287,7 @@ It is intentional adherence to:
 
 ### Grid Heater Review Guidance
 
-**This is intentional per manufacturer specifications.**
-
-Grid heater brief, high-current load characteristics make circuit breaker unnecessary - fusible link and ECM control provide adequate protection.
-
-**Do NOT flag as requiring circuit breaker.**
+**This is intentional per manufacturer specifications** — see Engineering Analysis above. **Do NOT flag as requiring circuit breaker.**
 
 **Documentation References:**
 
@@ -358,11 +335,7 @@ Grid heater brief, high-current load characteristics make circuit breaker unnece
 
 ### Alternator Review Guidance
 
-**This is standard automotive practice.**
-
-Alternators NEVER use circuit breakers on output circuits in factory or aftermarket applications.
-
-**Do NOT flag as missing protection.**
+**This is standard automotive practice** — see Industry Standard and Engineering Analysis above. **Do NOT flag as missing protection.**
 
 **Documentation References:**
 
@@ -400,11 +373,7 @@ Alternators NEVER use circuit breakers on output circuits in factory or aftermar
 
 ### BCDC Review Guidance
 
-**Circuit breaker AT BATTERY TERMINAL is correct protection point.**
-
-No additional CB required at BCDC - entire circuit protected from battery terminal CB.
-
-**Do NOT flag as missing protection at BCDC.**
+**Circuit breaker at the battery terminal is the correct protection point** — see Engineering Analysis above. **Do NOT flag as missing protection at BCDC.**
 
 **Documentation References:**
 


### PR DESCRIPTION
Nightly tidiness pass per `docs/jeep_lj/CLAUDE.md` (BE SUCCINCT). Surveyed all 108 pages under `docs/jeep_lj/**/*.md` (excluding CLAUDE.md files), focusing on files touched since the last tidiness pass (#133, 2026-06-06). Most recent edits were factual/table maintenance with no added verbosity — the two cuts below were the only high-confidence, rule-qualifying wins found this run.

| File | Lines before → after | What was cut | Which persona it failed |
| :--- | :-------------------- | :------------ | :----------------------- |
| `01-power-systems/STANDARDS-EXCEPTIONS.md` | 592 → 557 | Five per-component "Review Guidance" sections (Winch, Starter, Grid Heater, Alternator, BCDC) that restated content already given earlier in the same section under Manufacturer Specification / Engineering Analysis / Standards Comparison. Kept the "do not flag" verdict each section exists to provide, replaced the restated enumeration with a pointer back to the analysis above. | Mechanic/Installer & Troubleshooter — no new circuit/spec info, pure restatement |
| `01-power-systems/04-pmu/03-pmu-outputs.md` | 140 → 139 | One generic bullet ("Use proper terminal crimping and wire gauge to maximize current capacity") in the Combining Rules list — standard shop practice with no build-specific gauge or spec, exactly the kind of line `CLAUDE.md` calls out to avoid. | Mechanic/Installer — generic advice, not build-specific |

No numbers, part numbers, identifiers, TBD items, checkboxes, table rows, or reference-link definitions were touched. `div.product-info` blocks and frontmatter are untouched (neither file has them).

## Left for human judgment

- `STANDARDS-EXCEPTIONS.md` also has a longer "Winch Fault Scenarios Covered" section that partially overlaps with the "Protection Mechanisms" section above it (same four mechanisms, reframed as scenario→mechanism instead of mechanism→scenario). It carries real troubleshooting value (maps a specific fault to its specific protection) so I left it as-is rather than risk cutting something useful — a human could judge whether to merge these into one combined table.
- Same file: the phrase "Cable sizing acceptable for brief peak loads ✓" appears verbatim in both the Winch and Starter "Standards Comparison" blocks. Consolidating this into a shared intro paragraph would touch structure beyond a single section, so left alone per the conservative-edit guardrail.
- `02-starter-battery-distribution/index.md` line 56: "...is far more robust than their former shared dependency on the PMU module" reads borderline-marketing but is attached to a genuine engineering tradeoff (Owner/Designer rationale), so it was left in place.
- The closing "Summary of Intentional Design Decisions" and "Review Checklist for Future Analysis" sections in `STANDARDS-EXCEPTIONS.md` also recap material covered elsewhere in the file, but the checklist uses `- [ ]` checkbox syntax and the guardrails say never delete a checkbox item — left both sections untouched.

## Verification

- `python3 -m mkdocs build --strict` — exit 0, no new warnings introduced by this change (pre-existing INFO-level nav/anchor notices only, unrelated to edited files).
- `npx markdownlint-cli2 "docs/jeep_lj/**/*.md"` — all errors are pre-existing `MD060` table-alignment issues in the generated `tbd-tracker.md` (confirmed present on `main` before this change); the two edited files lint clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RqiBb9UEbjjyZR1iM5ZJTq)_