### PR TITLE
docs: nightly tidiness — trim verbosity (2026-08-04)

### DIFF
--- a/docs/jeep_lj/01-power-systems/01-power-generation/04-solar.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/04-solar.md
@@ -66,19 +66,15 @@ tags:
 
 ## Function
 
-80W panel maintains AUX battery during extended stops via BCDC solar input. Full sun panel output at optimal conditions: 80W (1.95A @ 40V), variable in partial sun/clouds.
+80W panel maintains AUX battery during extended stops via BCDC solar input. Full sun panel output at optimal conditions: 80W (1.95A @ ~40V panel-side), variable in partial sun/clouds.
 
-**Panel-side vs battery-side current:** The 1.95A figure is the panel-side current at the panel's ~40V operating voltage (40V × 1.95A ≈ 78W). The BCDC's MPPT steps that down to the battery charge voltage, so the battery-side contribution is higher: 78W ÷ ~13.4V ≈ **~5.8A to the AUX battery**.
-
-**BCDC Green Power Priority:** Solar input used first when available, alternator supplements to reach 50A total charging current. In full sun, solar contributes ~5.8A battery-side, reducing alternator load by the same amount.
+The BCDC's MPPT steps panel voltage down to battery charge voltage, so the battery-side contribution is higher than the panel-side current suggests: 78W ÷ ~13.4V ≈ **~5.8A to the AUX battery** in full sun. BCDC Green Power Priority uses solar first, with the alternator supplementing to reach 50A total charging current — so full-sun solar reduces worst-case alternator load by the same ~5.8A (50A → ~44A).
 
 **Charging Contribution (battery-side):**
 
-- **Full sun:** ~5.8A to AUX battery (78W ÷ ~13.4V; reduces alternator load from 50A to ~44A)
+- **Full sun:** ~5.8A to AUX battery
 - **Partial sun:** Variable, proportional to available irradiance
 - **Overcast/Night:** 0A (BCDC uses alternator only)
-
-**Alternator Load Relief:** Minimal but measurable — reduces worst-case alternator load by ~5.8A during sunny daytime operation
 
 See [BCDC Alpha 50][bcdc] for complete charging system details.
 

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/02-firewall-ingress.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/02-firewall-ingress.md
@@ -210,78 +210,9 @@ Radio grounds do NOT go through firewall - they route through cab floor to START
 
 ## Pin Budget Audit (Historical) {#pin-budget-audit}
 
-*This audit drove the decision to upsize to HDP24-24-29 + add dedicated SwitchPros HDP24-18-14. Final architecture documented above.*
+*Final architecture documented above. Kept for context on the upsize decision.*
 
-### HDP24-24-21 (original)
-
-Architectural changes (SwitchPros relocated to firewall, Firewall CONSTANT bus, keyless ignition) added new circuits that must penetrate the firewall. This section accounts for them against current connector capacity.
-
-### Current usage
-
-| Bank | Capacity | Used | Spare |
-|:-----|:--------:|:----:|:-----:|
-| Size 16 (14-20 AWG, 13A) | 17 | 16 | 1 (pin 2) |
-| Size 12 (12-14 AWG, 25A) | 4 | 0 | 4 (all reserved) |
-| **TOTAL** | **21** | **16** | **5** |
-
-### Pending additions
-
-| Circuit | Direction | Gauge | Pins | Source | Destination |
-|:--------|:----------|:-----:|:----:|:-------|:------------|
-| SwitchPros OUT-3 (fog light) | Cabin → EB → front bumper | 14 AWG | 1 (chassis ground at light) | SP at firewall | BD S8 fog |
-| SwitchPros OUT-17 (front locker, low-side) | Cabin → EB → front axle | 18 AWG | 1 (chassis ground at solenoid) | SP at firewall | Front ARB solenoid |
-| SwitchPros OUT-6 (front rocks subset) | Cabin → EB → front rocks | 14 AWG | 1 (chassis ground at lights) | SP at firewall | Front bumper rock + front wheel well rocks |
-| Boomerang fob present | Cabin → EB | 18 AWG | 1 | Bullet 230 (cabin) | PMU In 4 |
-| Gated start return | Cabin → EB | 18 AWG | 1 | Brake switch start tap | EB P/N relay |
-| **TOTAL NEW** | | | **5** | | |
-
-!!! note "Ground strategy for forward-going SwitchPros outputs"
-Each SwitchPros output normally pairs a power wire (SP → load) with a ground wire (load → SP Ground Bus). For loads forward of the firewall, this doubles the firewall pin count per output.
-
-    **Recommended:** Ground forward-mounted loads to chassis locally. The SwitchPros Ground Bus has a 1/0 AWG bond to chassis at the firewall, so chassis-grounded loads share the same reference. This halves the pin count for forward-going SP outputs (1 pin per output instead of 2).
-
-    Trade-off: relies on chassis ground continuity from front bumper / axle / wheel wells back to the firewall bond. Already required for engine and chassis safety, so no incremental risk.
-
-### Capacity analysis
-
-| Scenario | Size-16 pins used | Spare | Headroom |
-|:---------|:-----------------:|:-----:|:--------:|
-| **Today (no expansion)** | 16 of 17 | 1 | Minimal |
-| **After 5 new circuits (chassis-gnd strategy)** | 21 of 21 (filling pin 2 + 4 size-12 reduced) | 0 | **NONE** |
-| **After 8 new circuits (separate-gnd strategy for SP outputs)** | 24 of 21 | -3 | **OVER CAPACITY** |
-
-### Verdict
-
-**Current HDP24-24-21 will work but leaves zero future headroom.**
-
-- The 1 size-16 spare (pin 2) + 4 size-12 reserved cavities can accommodate all 5 new circuits *only* if size-12 cavities accept 18 AWG wires via reducer crimps or 12 AWG dummy wires
-- Any future expansion (additional sensors, accessories, telematics) will require a connector change anyway
-
-### Recommendation
-
-**Upsize to Deutsch HDP24-24-29** (same shell size, same firewall hole, 29 size-16 contacts).
-
-| Aspect | HDP24-24-21 (current) | HDP24-24-29 (proposed) |
-|:-------|:----------------------|:-----------------------|
-| Total contacts | 21 (17 size-16 + 4 size-12) | 29 (all size-16) |
-| Used after pending additions | 21 of 21 (full) | 21 of 29 |
-| Future headroom | 0 | 8 |
-| Firewall hole size | 1.5" diameter | 1.5" diameter (same) |
-| Approx connector cost | ~$60 (recpt + plug) | ~$80 (recpt + plug) |
-| Crimping tool | HDT-48-00 | HDT-48-00 (same) |
-
-**Net change:** ~$20 extra, same install procedure, same hole, 8 pins of future headroom.
-
-### Alternative: Split into two connectors
-
-Adding a small secondary connector (e.g., HDP20-9-4 with 4 size-20 contacts) for keyless signals only, keeping HDP24-24-21 for current loads. Two penetrations, two sealing surfaces, more work. Not recommended unless HDP24-24-29 is unavailable.
-
-### Implementation order
-
-1. Order HDP24-24-29 receptacle + plug + 12 additional size-16 contacts (8 extra cavities require 8 pins + 8 sockets)
-2. Build harness with original 16 circuits + the 5 new circuits
-3. Plug-seal remaining 8 cavities for moisture protection
-4. Document pin assignments (update the [Pin Assignment](#pin-assignment) section above)
+The original HDP24-24-21 (17 size-16 + 4 size-12) was at 16/17 size-16 capacity when SwitchPros relocation, the Firewall CONSTANT bus, and keyless ignition added 5 new circuits — leaving zero headroom even before accounting for the doubled pin cost of grounding forward SwitchPros loads back through the connector. A two-connector split (small secondary connector for keyless signals only) was considered and rejected as extra sealing surfaces for no real benefit. Upsizing to HDP24-24-29 (same shell size, same firewall hole, same crimping tool) cost ~$20 more than the 24-21 and bought 8 pins of headroom, which is why it was adopted.
 
 ---
 

--- a/docs/jeep_lj/05-control-interfaces/02-switchpros-sp1200.md
+++ b/docs/jeep_lj/05-control-interfaces/02-switchpros-sp1200.md
@@ -158,34 +158,19 @@ Rear Cargo Rocker Switch (SPST) → TRIGGER-2 (Pin 8, PINK)
 
 ### TRIGGER-3: Air Pressure Switch → Auto Compressor Control
 
-ARB air tank pressure switch automatically activates compressor to maintain tank pressure between 135-150 PSI.
-
 **Wiring:**
 
 ```text
 ARB Pressure Switch (180901) → TRIGGER-3 (Pin 17, PINK)
 ```
 
+18 AWG signal wire, manifold under passenger seat to SwitchPros TRIGGER-3 at firewall (short run, low current).
+
 **Configuration:**
 
-Program TRIGGER-3 to activate compressor when tank pressure drops below 135 PSI:
+Program **TRIGGER-3 OR Button 11 → OUTPUT-11 (compressor)**. Button 11 overrides the pressure switch to force the compressor on regardless of tank pressure.
 
-**SwitchPros Logic:**
-
-- **TRIGGER-3 OR Button 11 → OUTPUT-11 (compressor)**
-- When tank pressure < 135 PSI: TRIGGER-3 closes → OUTPUT-11 activates → compressor runs
-- When tank pressure = 150 PSI: TRIGGER-3 opens → OUTPUT-11 deactivates → compressor stops
-- Manual override: Button 11 can force compressor on regardless of tank pressure
-
-**Signal Source:**
-
-- ARB Pressure Switch model 180901 (cut-in: 135 PSI, cut-out: 150 PSI)
-- Mounted on air manifold under passenger seat
-- Low current signal wire (18 AWG from manifold under passenger seat to SwitchPros TRIGGER-3 at firewall — short run)
-
-**Related Documentation:**
-
-- See [Air System][air-system-arb-compressor-lockers] for complete ARB compressor, tank, and pressure switch specifications
+See [Air System][air-system-arb-compressor-lockers] for pressure switch specifications and the full automatic pressure control logic.
 
 ## Outstanding Items
 

--- a/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
+++ b/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
@@ -134,31 +134,7 @@ Recommended configuration for this build:
 
 ### PMU DRL Auto-Off Logic
 
-**Purpose:** Automatically turns off DRL when headlights are activated via CT4 SW3
-
-**Implementation:** PMU programming logic (no external relay needed)
-
-**PMU Configuration:**
-
-```text
-PMU Input 7 (In 7): CT4 SW3 headlight status signal (tapped from low beam circuit)
-PMU Pin 7: Ignition RUN signal (12V switched input)
-PMU Output 23 (Out 23): DRL/Parking lights circuit
-
-Programming Logic:
-IF (Pin7_IgnitionRUN == ON) AND (In7_CT4_Headlights == OFF)
-  THEN Out23_DRL = ON
-ELSE
-  Out23_DRL = OFF
-END
-```
-
-**Installation Notes:**
-
-- Tap CT4 SW3 output (low beam circuit) to PMU In 7 for headlight status monitoring
-- Run wire from PMU Out 23 to DRL junction
-- Total DRL/parking circuit load: ~2.6A — see [DRL & Parking][drl-parking] for the itemized load breakdown and wiring
-- PMU Out 23 capacity: 7A (sufficient for the ~2.6A load)
+CT4 SW3 (low beam, tapped from the headlight circuit) feeds PMU In 7 for headlight-status monitoring; PMU Out 23 drives the DRL/parking circuit and turns off when In 7 goes active. See [DRL & Parking][drl-parking] for the full programming logic, operation states, and wiring.
 
 ## Installation Checklist
 


### PR DESCRIPTION
Nightly tidiness pass per `docs/jeep_lj/CLAUDE.md`'s BE SUCCINCT imperative. Trimmed prose that restated an already-documented decision or duplicated content that's authoritative elsewhere. No specs, numbers, part numbers, identifiers, or links were changed — prose and structure only.

| File | Lines before → after | What was cut | Persona it failed |
|---|---|---|---|
| `01-power-systems/07-wire-routing/02-firewall-ingress.md` | 354 → 281 | Condensed the "Pin Budget Audit (Historical)" section (deliberation tables: capacity math, verdict, recommendation, alternative, implementation order) into a 5-sentence rationale paragraph. The section is explicitly marked historical and says "Final architecture documented above" — the outcome is already stated as current fact earlier in the same file (the info box at line 42). | All going forward — nobody wiring today needs the superseded deliberation. |
| `01-power-systems/01-power-generation/04-solar.md` | 166 → 162 | Consolidated four separate restatements of the same battery-side solar contribution figure (~5.8A, derived from 78W ÷ 13.4V) into one derivation + a summary bullet list. | Owner/Troubleshooter — the number was correct each time, just repeated with different framing. |
| `05-control-interfaces/03-command-touch-ct4.md` | 228 → 204 | Replaced a full duplicate of the PMU DRL auto-off pseudocode + install notes with a link to the authoritative copy in `03-lighting-systems/05-drl-parking.md` (which also has the Operation States table and full wiring). | Mechanic/Troubleshooter — two copies of the same logic can drift; one authoritative source is safer. |
| `05-control-interfaces/02-switchpros-sp1200.md` | 228 → 213 | Trimmed the TRIGGER-3 section's restatement of the ARB automatic-pressure-control logic and pressure-switch spec (cut-in/cut-out, model detail) down to the SP1200-specific wiring pin and programming action, linking to `08-exterior-systems/02-air-compressor.md` (which owns the ARB hardware) for the rest. | Mechanic — kept the wiring fact (Pin 17, PINK) and the programming step; cut the restated ARB behavior explanation. |

**Verification:**
- `python3 -m mkdocs build --strict` — exit 0, no new broken links/anchors (confirmed by diffing against a build of unmodified `main`; the one pre-existing `#wiring` anchor notice on the CT4 page is unrelated to this change).
- `npx markdownlint-cli2 "docs/jeep_lj/**/*.md"` — pre-existing failures only (all in the generated `tbd-tracker.md`, which this pass doesn't touch, plus pre-existing table-formatting/anchor issues in the edited files themselves — confirmed identical rule set before/after, and total error count dropped 163 → 128 since trimmed sections removed some of the flagged tables).

## Left for human judgment

- **`01-power-systems/08-load-analysis/03-aux-battery.md`** — Scenarios 4 ("Airing Up Tires") and 5 ("Extended Airing Up") have byte-for-byte identical load tables, differing only in duration math. Merging them would require removing a row from the Summary comparison table, which the routine's guardrails treat as off-limits without a human call.
- **`01-power-systems/04-pmu/05-pmu-arb-load-shedding.md`** — while checking this file for the same kind of AUX-battery math duplication, I found its ARB compressor load figures (90A draw, 45A net AUX drain, ~144 min to 20% SOC) don't match the figures in `03-aux-battery.md` Scenario 4 (105A draw, 60A net drain, 108 min to 20% SOC) for what appears to be the same physical scenario. This looks like a genuine spec discrepancy, not verbosity — flagging for the owner rather than guessing which number is current.
- **`01-power-systems/STANDARDS-EXCEPTIONS.md`** — has real repetition (the same "don't flag this" verdict stated 3-4x per component across "Standards Comparison," "Review Guidance," and closing checklist sections). Left untouched: the file's stated purpose is "prevent future reviews (AI or human) from flagging intentional design decisions as oversights," so the redundancy may be a deliberate defense against exactly this kind of trimming — didn't want to guess wrong on a document engineered to resist automated editing.

---
_Generated by [Claude Code](https://claude.ai/code/session_01LcCXYACUj8NLX7bq7BJjzK)_