### PR TITLE
docs: nightly tidiness — trim verbosity (2026-08-05)

### DIFF
--- a/docs/jeep_lj/01-power-systems/01-power-generation/04-solar.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/04-solar.md
@@ -70,15 +70,13 @@ tags:
 
 **Panel-side vs battery-side current:** The 1.95A figure is the panel-side current at the panel's ~40V operating voltage (40V × 1.95A ≈ 78W). The BCDC's MPPT steps that down to the battery charge voltage, so the battery-side contribution is higher: 78W ÷ ~13.4V ≈ **~5.8A to the AUX battery**.
 
-**BCDC Green Power Priority:** Solar input used first when available, alternator supplements to reach 50A total charging current. In full sun, solar contributes ~5.8A battery-side, reducing alternator load by the same amount.
+**BCDC Green Power Priority:** Solar input used first when available, alternator supplements to reach 50A total charging current.
 
 **Charging Contribution (battery-side):**
 
 - **Full sun:** ~5.8A to AUX battery (78W ÷ ~13.4V; reduces alternator load from 50A to ~44A)
 - **Partial sun:** Variable, proportional to available irradiance
 - **Overcast/Night:** 0A (BCDC uses alternator only)
-
-**Alternator Load Relief:** Minimal but measurable — reduces worst-case alternator load by ~5.8A during sunny daytime operation
 
 See [BCDC Alpha 50][bcdc] for complete charging system details.
 

--- a/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
+++ b/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
@@ -53,7 +53,7 @@ The radiator fan, iBooster, and TCU were relocated off the PMU onto START-direct
 The master feed carries the combined load (~68A continuous, ~108A brief peak); voltage drop and breaker sizing are set on that single cable.[^fwd-bus-vdrop] The iBooster's separate ignition **enable** (~5A) is sourced from the [Ignition Signal bus][ignition-signal], not this bus. Fan speed is set by a dedicated fan controller ({{ tbd(134) }}) with its own coolant sensor, independent of the PMU and J1939.
 
 !!! info "Shared forward feed — intentional tradeoff"
-    The three loads share one master feed + busbar (a passive cable, breaker, and bus bar — no active electronics), versus three independent runs from the battery. This is the same tradeoff the [AUX side][constant-bus] accepts, and is far more robust than their former shared dependency on the PMU module. Each load keeps its own breaker. See [Standards Exceptions][standards-exceptions].
+    A single master feed + passive busbar, not three independent battery runs — the same tradeoff the [AUX side][constant-bus] accepts. Each load keeps its own breaker. See [Standards Exceptions][standards-exceptions] for the rationale.
 
 [^fwd-bus-vdrop]: Master feed 2 AWG @ ~108A brief peak (~68A continuous), ~8 ft, 60°C-derated (×1.2) ≈ 1.3% — sized on the combined load. Load feeds are short from the engine-bay bus, so per-load drop is negligible: fan 4 AWG @ 53A, iBooster 8 AWG @ 40A brief, TCU 12 AWG @ 15A. Final master-feed length and breaker selective-coordination pending {{ tbd(136) }} and {{ tbd(135) }}.
 

--- a/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/04-safetyhub.md
+++ b/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/04-safetyhub.md
@@ -61,8 +61,6 @@ Wire and CB sized for full 150A SafetyHub capacity (current load 90A). Provides 
 
 **Utilization:** 90A / 150A = 60%
 
-**Future Capacity:** 60A additional capacity available (150A max - 90A current = 60A headroom)
-
 !!! info "Winch Main Power"
 Winch motor power (409A peak) connects directly to AUX battery positive terminal with no external circuit breaker per WARN manufacturer specifications. See [STANDARDS-EXCEPTIONS.md][standards-exceptions] and [Recovery Systems][recovery-systems] for complete protection strategy.
 

--- a/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/index.md
+++ b/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/index.md
@@ -16,9 +16,7 @@ The AUX battery ([Dakota Lithium 135Ah LiFePO4][batteries]) in the passenger rea
 5. **Inline 100A CB** → 4 AWG short feed → [JL Audio MV800/8i Amp][audio] (mounted under rear seat)
 
 !!! info "Two-Stage Distribution Architecture"
-The AUX battery has **no local CONSTANT bus** — protected feeds run from inline CBs at the battery to two distribution points: the firewall CONSTANT bus (most loads) and SafetyHub (local). This places distribution near the loads, minimizes the cabin trunk to a single heavy cable, and keeps the rear wheel well compartment uncluttered.
-
-See [Firewall CONSTANT Bus][constant-bus] for downstream distribution, [SafetyHub][aux-safetyhub] for fused recovery circuits, and [Circuit Breakers][circuit-breakers] for full CB list.
+The AUX battery has **no local CONSTANT bus** — protected feeds run from inline CBs at the battery to two distribution points: the firewall CONSTANT bus (most loads) and SafetyHub (local). See [Firewall CONSTANT Bus][constant-bus] for the distribution rationale, [SafetyHub][aux-safetyhub] for fused recovery circuits, and [Circuit Breakers][circuit-breakers] for full CB list.
 
 !!! info "Single Source of Truth"
 This page is the authoritative source for all AUX battery wire specs (gauge, distance, voltage drop). Component pages reference here. For battery specs see [Section 1.1][batteries]. For ground bus bars see [Section 1.5][grounding].

--- a/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
@@ -15,7 +15,7 @@ Automatic load management during ARB compressor operation to preserve AUX batter
 - **BCDC Charging (50A max):** Replenishes AUX battery from alternator
 - **Net AUX battery drain:** 90A - 50A = 40A during compressor operation
 
-The alternator is NOT overloaded during ARB operation. The 50A BCDC significantly reduces net discharge rate, making extended air-up practical. Load shedding provides additional margin and maintains optimal voltage.
+The alternator is NOT overloaded during ARB operation. The 50A BCDC significantly reduces net discharge rate, making extended air-up practical.
 
 ## Problem Statement
 

--- a/docs/jeep_lj/01-power-systems/08-load-analysis/index.md
+++ b/docs/jeep_lj/01-power-systems/08-load-analysis/index.md
@@ -106,8 +106,6 @@ These loads are **NOT** included in running alternator calculations:
 | Winch Recovery    | 265A       | 50A  | -215A      | 30-sec pulls   | Brief OK  |
 | Camp Mode         | 27A        | 0A   | -27A       | 76 min         | Limited   |
 
-**Key Insight:** 50A BCDC enables night highway charging and 102-minute night offroad runtime.
-
 ## Related Documentation
 
 - [Combined Scenarios][scenarios] - Multi-battery load analysis


### PR DESCRIPTION
Nightly tidiness pass per `docs/jeep_lj/CLAUDE.md` "BE SUCCINCT". Prose-only edits — no specs, values, identifiers, TBD items, checkboxes, table rows, or links were changed.

| File | Lines before → after | What was cut | Which persona it failed |
|---|---|---|---|
| `01-power-systems/04-pmu/05-pmu-arb-load-shedding.md` | 326 → 326 | Duplicate "load shedding provides additional margin and maintains optimal voltage" sentence — the same claim was restated word-for-word two paragraphs apart around the same numbers. Kept the copy tied to the actual capacity math, cut the earlier premature one. | Owner (rationale said twice before the reader even reaches the numbers) |
| `01-power-systems/03-aux-battery-distribution/04-safetyhub.md` | 90 → 88 | Removed a "Future Capacity: 60A additional... (150A - 90A = 60A headroom)" line that just re-did arithmetic already given one line above (`90A / 150A = 60%`) and in the "Future-Proof Capacity" admonition above that. | Mechanic/Buyer (redundant arithmetic, no new info) |
| `01-power-systems/03-aux-battery-distribution/index.md` | 66 → 64 | Trimmed the "Two-Stage Distribution Architecture" info box to a pointer instead of re-explaining the full rationale, which already lives in `02-constant-bus.md`'s own box (same argument: near the loads, single heavy cable). | Owner (same design rationale stated in two files) |
| `01-power-systems/02-starter-battery-distribution/index.md` | 103 → 103 | Trimmed the "Shared forward feed" info box, which re-explained the same tradeoff already covered in `STANDARDS-EXCEPTIONS.md`'s "START+ Forward Distribution Bus" section (mirrors AUX two-stage architecture, single master feed vs. three independent runs). Also dropped the unsupported "far more robust" marketing claim. | Owner (rationale duplicated across files); Mechanic (marketing adjective) |
| `01-power-systems/01-power-generation/04-solar.md` | 165 → 163 | The ~5.8A battery-side solar contribution was derived once, then restated as fact three more times (Green Power Priority paragraph, Charging Contribution bullet, and a separate "Alternator Load Relief" line). Kept the derivation and the bulleted summary, cut the two flat restatements. | Owner/Troubleshooter (same number stated 4x, no new context added) |
| `01-power-systems/08-load-analysis/index.md` | 125 → 123 | Removed a "Key Insight" line restating the Night Highway/Night Offroad rows of the Summary table directly above it. | Owner (adds nothing beyond the table it sits under) |

## Left for human judgment

- `01-power-systems/STANDARDS-EXCEPTIONS.md` has a repeated rhetorical structure across its 7 sub-sections (Manufacturer Spec → Engineering Analysis → Standards Comparison → Review Guidance), each ending in a near-identical "Do NOT flag..." conclusion that's then echoed a third time in the bottom "Review Checklist." This looks like a real win but the file is 592 lines and restructuring it would exceed tonight's scope/diff budget — left for a dedicated pass.
- `01-power-systems/08-load-analysis/{01-scenarios.md,02-start-battery.md,03-aux-battery.md}` have the same "Key Insight restates the table above it" pattern as `index.md` in this PR. Left untouched tonight to keep the diff small; worth a follow-up sweep across all four files together.
- `docs/jeep_lj/index.md` has one stray marketing adjective ("advanced" describing the SafetyHub controller) — flagged but not touched, single-word change felt too trivial to spend one of tonight's 6 file slots on.
- `markdownlint-cli2` (run via `npx --yes`, i.e. latest published version) reports ~1100 pre-existing `MD060` table-alignment findings across ~70 files repo-wide, none in lines this PR touches — appears to be a rule newly enabled by a markdownlint-cli2 version bump rather than anything introduced here. Verified none of the 6 edited files have new findings beyond what already existed on `main`. Left as-is; a repo-wide table-reformat is out of scope for a verbosity pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ar9bUCA7c46X4ofcNpdqhJ)_