### PR TITLE
docs: nightly tidiness — trim verbosity (2026-08-06)

### DIFF
--- a/docs/jeep_lj/01-power-systems/01-power-generation/03-bcdc.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/03-bcdc.md
@@ -97,12 +97,7 @@ The BCDC includes a battery temperature sensor (2-pin, polarity reversible) that
 - **Attachment:** Ring terminal under battery terminal bolt
 - **Why Positive Terminal:** Measures both voltage and temperature at the battery for accurate charge control
 
-**Why Required:**
-
-- AGM batteries are temperature-sensitive during charging
-- Overcharging at high temps causes thermal runaway risk
-- Undercharging at low temps leads to sulfation
-- BCDC adjusts charge voltage based on sensor reading (temperature compensation)
+**Why Required:** BCDC adjusts charge voltage based on sensor reading (temperature compensation) to avoid overcharge/undercharge damage.
 
 **Installation Notes:**
 

--- a/docs/jeep_lj/02-engine-systems/05-horn.md
+++ b/docs/jeep_lj/02-engine-systems/05-horn.md
@@ -52,18 +52,6 @@ START battery CONSTANT → PMU → Out 18 → PIAA Horns (5.4A) → Chassis Grou
                       Horn Button → In 1 (trigger)  [column path undefined — {{ tbd(152) }}]
 ```
 
-**Power Flow:**
-
-1. START battery+ → 250A inline CB → PMU
-2. Horn button (steering wheel) → PMU In 1 (trigger signal)
-3. PMU Out 18 activated when In 1 closes
-4. PMU Out 18 → PIAA horns (5.4A) → chassis ground (engine bay)
-
-**Notes:**
-
-- PMU Out 18 switches directly (no external relay needed)
-- Works with ignition off (CONSTANT power for safety)
-
 ## Outstanding Items
 
 {{ tbds() }}

--- a/docs/jeep_lj/02-engine-systems/07-grid-heater.md
+++ b/docs/jeep_lj/02-engine-systems/07-grid-heater.md
@@ -41,25 +41,6 @@ tags:
 | Duty cycle        | 3–5 s during cold start (ECM-controlled)           |
 | Protection        | Integrated fusible link                            |
 
-## System Architecture
-
-1. **ECM Control (Direct):**
-   - ECM triggers grid heater relay directly via pins 46/21 (~0.5-1A)
-   - ECM manages timing, temperature thresholds, and duty cycle
-   - No PMU involvement - ECM knows engine temperature better than external controller
-
-2. **Grid Heater Relay (Cummins 5467024):**
-   - Coil Power: ECM pins 46/21 (~1A) - direct connection
-   - Main Power: Direct from START battery+ via fusible link (bypasses all bus bars and PMU)
-   - Main Ground: START battery- or NEGATIVE bus
-   - Output: 80A to grid heater element (design value - verify via resistance measurement during installation)
-   - Protection: Integrated fusible link
-
-3. **Grid Heater Element:**
-   - Location: Intake manifold
-   - Power: 80A from relay (design value)
-   - Duty Cycle: 3-5 seconds during cold start (ECM controlled)
-
 ## Wiring Summary
 
 **Two-Stage Design:** ECM pins 46/21 (1A) → relay coil → relay switches high current (40-80A) directly from battery to element.
@@ -84,20 +65,9 @@ flowchart LR
     style ELEMENT fill:#d1d5db,color:#000
 ```
 
-## Why Direct ECM Control
-
-- ECM has accurate engine temperature data
-- ECM knows optimal grid heater timing for cold starts
-- Eliminates unnecessary complexity of PMU passthrough
-- Frees PMU output slots for other critical systems
-
 ## Power Distribution
 
-**Bypasses all distribution systems:**
-
-- Does NOT use CONSTANT bus bar
-- Does NOT use PMU outputs
-- Direct battery connection with fusible link protection
+**Bypasses all distribution systems** (no CONSTANT bus bar, no PMU outputs) — direct battery connection with fusible link protection.
 
 **Reason:** High current draw (40-80A) for very short duration (3-5 seconds). Direct connection minimizes voltage drop and connection complexity.
 

--- a/docs/jeep_lj/03-lighting-systems/05-drl-parking.md
+++ b/docs/jeep_lj/03-lighting-systems/05-drl-parking.md
@@ -49,25 +49,11 @@ END
 
 ## Operation States
 
-**1. Ignition ON, Headlights OFF:**
-
-- PMU Pin 7 = ON (ignition RUN)
-- PMU In 7 = OFF (CT4 SW3 not active)
-- PMU Out 23 = ON
-- **Result:** All DRL/parking lights illuminated
-
-**2. Ignition ON, Headlights ON:**
-
-- PMU Pin 7 = ON (ignition RUN)
-- PMU In 7 = ON (CT4 SW3 active)
-- PMU Out 23 = OFF
-- **Result:** Headlights active, DRL off
-
-**3. Ignition OFF:**
-
-- PMU Pin 7 = OFF
-- PMU Out 23 = OFF (regardless of headlight status)
-- **Result:** All DRL/parking lights off
+| Pin 7 (ignition) | In 7 (CT4 SW3) | Out 23 (DRL) | Result |
+| :---------------- | :-------------- | :------------ | :----- |
+| ON | OFF | ON | DRL/parking lights illuminated |
+| ON | ON | OFF | Headlights active, DRL off |
+| OFF | any | OFF | All DRL/parking lights off |
 
 ## Wiring
 

--- a/docs/jeep_lj/06-audio-systems/03-speakers.md
+++ b/docs/jeep_lj/06-audio-systems/03-speakers.md
@@ -48,9 +48,7 @@ Marine-grade coaxial speakers with integrated RGB LED lighting for front dash an
 - Integrated 0.8" pure silk dome tweeter (no separate install)
 - Multi-order 2-way passive crossover (built-in)
 - Automatic solid-state tweeter protection
-- Transflective RGB LED lighting
-- Mica-filled polypropylene woofer
-- Gunmetal trim ring with titanium sport grille
+- RGB LED lighting (see [LED Controller][led-controller])
 
 ---
 
@@ -88,11 +86,10 @@ Marine-grade coaxial speakers with integrated RGB LED lighting for front dash an
 
 ### Rear Speaker Features
 
-- Built-in RGB LED lights
 - 3/4" silk dome tweeters
-- Mica-filled polypropylene woofers
 - Enclosed weather-resistant design
 - Roll bar clamp mounting
+- RGB LED lighting (see [LED Controller][led-controller])
 
 ## Wiring
 

--- a/docs/jeep_lj/06-audio-systems/04-subwoofer.md
+++ b/docs/jeep_lj/06-audio-systems/04-subwoofer.md
@@ -57,7 +57,7 @@ Amp Ch 1+2 (+/−) bridged → Sub A (+/−)
 Amp Ch 3+4 (+/−) bridged → Sub B (+/−)
 ```
 
-Total amp output 400W into the pair (200W per sub) — exact RMS match, no headroom waste from series resistance, independent gain trim per side if the L/R quarter-panel locations end up acoustically asymmetric.
+Total amp output: 400W into the pair (200W per sub), with independent gain trim per side if the L/R quarter-panel locations end up acoustically asymmetric.
 
 ## Infinite Baffle Requirements
 
@@ -65,14 +65,6 @@ Total amp output 400W into the pair (200W per sub) — exact RMS match, no headr
 - **Installation type:** No dedicated enclosure required
 - **Ideal location:** Rear quarter panels above wheel wells, firing inward into cabin
 - **IB chamber:** Rear cargo area / behind quarter trim (effectively unlimited volume in an LJ)
-
-## Features
-
-- Transflective RGB LED lighting (via MLC-RW)
-- Gunmetal trim ring with titanium sport grille
-- Marine-grade construction
-- Mica-filled polypropylene cone
-- Synthetic rubber surround
 
 ## Wiring
 


### PR DESCRIPTION
Nightly tidiness pass per `docs/jeep_lj/CLAUDE.md`'s **BE SUCCINCT** rule. Trimmed prose that failed the reader-persona test (restated an adjacent table/diagram, marketing catalog copy, or generic non-build-specific explanation) on the 6 highest-confidence pages found this run. No specs, part numbers, wire gauges, TBD items, table rows, or reference-link definitions were changed.

| File | Lines before → after | What was cut | Persona it failed |
| :--- | :-------------------- | :------------ | :----------------- |
| `01-power-systems/01-power-generation/03-bcdc.md` | 119 → 114 | Generic AGM battery-chemistry explanation ("temperature-sensitive during charging", "thermal runaway", "sulfation") under **Why Required** — collapsed to the one operational fact (BCDC does temp-compensated charging) | Mechanic/Parts Buyer — textbook explanation, not a build fact |
| `02-engine-systems/05-horn.md` | 82 → 70 | **Power Flow** numbered list and **Notes** — both fully restated the signal path already shown in the **Wiring Configuration** diagram and the **Control** section above it | Mechanic/Installer — restates adjacent diagram |
| `02-engine-systems/07-grid-heater.md` | 115 → 85 | **System Architecture** (3-part breakdown) and **Why Direct ECM Control** bullets — restated the Specifications table + wiring diagram three separate ways; tightened **Power Distribution** to one line | Mechanic/Troubleshooter — same fact (direct battery, ECM-controlled, no PMU) stated 4 times |
| `03-lighting-systems/05-drl-parking.md` | 105 → 91 | **Operation States** prose (3 verbose state blocks) — replaced with a 3-row truth table restating the same states from the `IF/THEN/ELSE` PMU logic block directly above it | Mechanic/Troubleshooter — prose restating adjacent pseudocode |
| `06-audio-systems/03-speakers.md` | 124 → 121 | Cosmetic catalog-copy bullets ("Gunmetal trim ring with titanium sport grille", "Mica-filled polypropylene woofer(s)") in both Front and Rear **Features** lists; consolidated the RGB LED bullet into a cross-link to the LED Controller page | Parts Buyer — cosmetic marketing copy, not a spec |
| `06-audio-systems/04-subwoofer.md` | 116 → 108 | Whole **Features** section (RGB lighting, trim ring, "marine-grade construction", cone material, surround material) — all catalog copy already covered by the Specifications/Wiring tables; also cut a sentence that restated itself two paragraphs up | Parts Buyer / Mechanic — catalog copy + self-restatement |

**Verification performed:**
- `python3 -m mkdocs build --strict` — clean (exit 0), no broken links/anchors introduced
- `npx markdownlint-cli2 "docs/jeep_lj/**/*.md"` — the newly-added/edited lines are clean; the tool still reports pre-existing `MD060`/`MD053` findings on tables and reference definitions this diff does not touch (confirmed identical against `main` before this change, e.g. in `tbd-tracker.md`, `03-bcdc.md`'s untouched spec table, and `04-subwoofer.md`'s untouched spec table)

## Left for human judgment

Candidates surveyed but deliberately **not** touched this run — flagged for a future pass or explicit sign-off rather than an unattended edit:

- **`01-power-systems/STANDARDS-EXCEPTIONS.md`** (578 lines) — each of the 7 exception write-ups repeats the same 4-part scaffolding (Engineering Analysis / Standards Comparison / Review Guidance / Do-NOT-flag). Real win, but too large to fit this run's diff cap safely.
- **`01-power-systems/07-wire-routing/02-firewall-ingress.md`** — the "Pin Budget Audit (Historical)" section (~75 lines) is explicitly marked superseded by the page's own header, but cutting it means removing several full tables; left alone per the "unsure → leave it, don't delete tables" guardrail.
- **`02-engine-systems/02-brake-booster.md`** — the 60×80mm firewall-pattern citation is repeated 3× (product-info block, warning box, Installation Notes). This is the exact class of critical, previously-mis-sourced fact `CLAUDE.md` cites as the reason for the citation rule — too high-stakes to trim unattended even though the repetition is real.
- **Gauge-cluster BIM files** (`02-engine-systems/09-gauge-cluster/03-bim-j1939.md`, `04-bim-gps.md`, `05-bim-tpms.md`, `06-bim-compass.md`) — identical "Current Draw: Negligible — bus-powered..." sentence copy-pasted verbatim across all 4 files. Safe, mechanical dedupe candidate, but touching 4 files for one fix didn't fit this run's 6-page slate; a good pick for tomorrow night.
- **`04-pmu/05-pmu-arb-load-shedding.md`** — AUX-battery depletion math duplicates `08-load-analysis/03-aux-battery.md`'s scenario analysis.
- Minor Wiring-table restatements in `07-communication-systems/{01-gmrs-radio,02-intercom,04-dash-camera}.md`, `05-control-interfaces/05-dashboard-controls.md`, and `08-exterior-systems/03-air-lockers.md`.
- Duplicated citation footnotes between `10-drivetrain/04-front-axle.md` and `05-rear-axle.md`.
- **Not a tidiness item, flagged as-is:** `01-power-generation/03-bcdc.md`'s Wiring table calls the temp sensor "REQUIRED — LiFePO4 temperature-compensated charging" while the Temperature Sensor Installation section (now tightened but not reworded) still says "REQUIRED for proper AGM charging." Pre-existing AGM/LiFePO4 terminology inconsistency in the source content, not something this pass should silently resolve.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WvPDd7dWLmSj8uLR2gmDfD)_