### PR TITLE
docs: nightly tidiness — trim verbosity (2026-08-07)

### DIFF
--- a/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
+++ b/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
@@ -18,7 +18,7 @@ The START battery (driver rear wheel well) provides power for critical engine an
 3. **[START+ Forward Distribution Bus](#start-forward-bus)** (150A master CB → single feed → engine-bay busbar) → radiator fan (60A), iBooster main (50A), TCU (25A) — relocated off the PMU
 4. **Direct low-current** → ECM, grid heater (fusible link protection)
 
-See [Circuit Breakers][circuit-breakers] for complete CB specifications. All CBs mounted in rear wheel well within 7" of battery (code compliant).
+See [Circuit Breakers][circuit-breakers] for complete CB specifications.
 
 !!! info "Single Source of Truth"
 This page is the authoritative source for all START battery wire specs (gauge, distance, voltage drop). Component pages reference here. For battery specs see [Section 1.1][batteries]. For ground bus bars see [Section 1.5][grounding].
@@ -53,7 +53,7 @@ The radiator fan, iBooster, and TCU were relocated off the PMU onto START-direct
 The master feed carries the combined load (~68A continuous, ~108A brief peak); voltage drop and breaker sizing are set on that single cable.[^fwd-bus-vdrop] The iBooster's separate ignition **enable** (~5A) is sourced from the [Ignition Signal bus][ignition-signal], not this bus. Fan speed is set by a dedicated fan controller ({{ tbd(134) }}) with its own coolant sensor, independent of the PMU and J1939.
 
 !!! info "Shared forward feed — intentional tradeoff"
-    The three loads share one master feed + busbar (a passive cable, breaker, and bus bar — no active electronics), versus three independent runs from the battery. This is the same tradeoff the [AUX side][constant-bus] accepts, and is far more robust than their former shared dependency on the PMU module. Each load keeps its own breaker. See [Standards Exceptions][standards-exceptions].
+    The three loads share one master feed + busbar (a passive cable, breaker, and bus bar — no active electronics), versus three independent runs from the battery. This is the same tradeoff the [AUX side][constant-bus] accepts, and removes the prior shared dependency on the PMU module (a single point of failure for all three loads). Each load keeps its own breaker. See [Standards Exceptions][standards-exceptions].
 
 [^fwd-bus-vdrop]: Master feed 2 AWG @ ~108A brief peak (~68A continuous), ~8 ft, 60°C-derated (×1.2) ≈ 1.3% — sized on the combined load. Load feeds are short from the engine-bay bus, so per-load drop is negligible: fan 4 AWG @ 53A, iBooster 8 AWG @ 40A brief, TCU 12 AWG @ 15A. Final master-feed length and breaker selective-coordination pending {{ tbd(136) }} and {{ tbd(135) }}.
 

--- a/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
@@ -15,7 +15,7 @@ Automatic load management during ARB compressor operation to preserve AUX batter
 - **BCDC Charging (50A max):** Replenishes AUX battery from alternator
 - **Net AUX battery drain:** 90A - 50A = 40A during compressor operation
 
-The alternator is NOT overloaded during ARB operation. The 50A BCDC significantly reduces net discharge rate, making extended air-up practical. Load shedding provides additional margin and maintains optimal voltage.
+The alternator is NOT overloaded during ARB operation. The 50A BCDC significantly reduces net discharge rate, making extended air-up practical.
 
 ## Problem Statement
 
@@ -39,7 +39,6 @@ The Dakota Lithium 135Ah combined with 50A BCDC makes extended air-up a non-issu
 
 - Minor: AUX battery still has comfortable margin at 50A BCDC
 - START battery loads reduce BCDC charging efficiency slightly
-- Load shedding maximizes available margin for extended sessions
 
 ## Solution Overview
 
@@ -219,19 +218,14 @@ ELSE:
 
 **Best Practices for ARB Use:**
 
-1. **Increase Engine RPM:** Run engine at 1500+ RPM during tire inflation
-   - Alternator output increases with RPM
-   - Better voltage regulation at higher speeds
-   - Faster tire inflation
+1. **Increase Engine RPM:** Run engine at 1500+ RPM during tire inflation for stronger alternator output and voltage regulation
 
 2. **Monitor Voltage:** Watch Dakota Digital voltage gauge during ARB use
    - Normal: 14.0-14.4V (load shedding working)
    - Marginal: 13.5-14.0V (acceptable, brief periods)
    - Low: <13.5V (increase RPM or reduce loads)
 
-3. **Hot Weather:** Avoid prolonged ARB use at idle when ambient temp >95°F
-   - Radiator fan + ARB + heat soak = high total load
-   - Let engine cool between inflation cycles
+3. **Hot Weather:** Avoid prolonged ARB use at idle when ambient temp >95°F — radiator fan + ARB + heat soak stacks load; let engine cool between inflation cycles
 
 4. **Avoid Simultaneous High Loads:**
    - ❌ ARB + winch (both 90A+ loads)

--- a/docs/jeep_lj/01-power-systems/08-load-analysis/03-aux-battery.md
+++ b/docs/jeep_lj/01-power-systems/08-load-analysis/03-aux-battery.md
@@ -125,7 +125,7 @@ All circuits powered by AUX battery (charged by BCDC at 50A max):
 
 **Net Battery Effect:** +5A (battery charging!)
 
-**Assessment:** Excellent - with corrected XL Sport specs (2.2A/pod), full night offroad lighting is now fully covered by BCDC charging. Battery maintains charge even with all lights on.
+**Assessment:** Excellent - full night offroad lighting stays within 50A BCDC charging; battery maintains charge even with all lights on.
 
 ---
 
@@ -177,7 +177,7 @@ All circuits powered by AUX battery (charged by BCDC at 50A max):
 
 **Time to 20% SOC:** 108Ah / 60A = **108 minutes** of continuous compressor operation
 
-**Assessment:** Extended air-up no longer a concern. Can run compressor for nearly 2 hours before reaching 20% SOC.
+**Assessment:** Minimal battery impact - can run compressor for nearly 2 hours before reaching 20% SOC.
 
 ---
 
@@ -229,7 +229,7 @@ All circuits powered by AUX battery (charged by BCDC at 50A max):
 
 **Time to 20% SOC (with solar):** 108Ah / 21A = **5+ hours** (daytime only)
 
-**Assessment:** Camp mode now practical. 4+ hours of music, lights, and charging without engine. For extended camping:
+**Assessment:** 4+ hours of music, lights, and charging without engine. For extended camping:
 
 - Solar extends daytime runtime significantly
 - Idle engine 30 min to recover ~25Ah

--- a/docs/jeep_lj/02-engine-systems/02-brake-booster.md
+++ b/docs/jeep_lj/02-engine-systems/02-brake-booster.md
@@ -202,7 +202,7 @@ See [tail/brake][tail-brake] (PMU lighting flow), [starter][starter] (crank chai
 
 ## Installation Notes
 
-- **Firewall mounting strategy:** Factory LJ vacuum booster holes are abandoned. The Honda Gen 2 iBooster bolts directly to the firewall via its own integral 4-stud flange (60×80mm M8 pattern, **80mm dimension vertical** per Back Bay Customs; 62mm body neck through the firewall) — no separate steel bracket. Drill matching holes in the LJ firewall, then sandwich a SendCutSend 3/16" steel backing plate on the cabin side to distribute the cantilevered load and prevent fatigue cracking at the new holes. If an 80mm-horizontal orientation is ever required, Back Bay sells a re-orientation adapter (currently out of stock).
+- **Firewall mounting strategy:** Factory LJ vacuum booster holes are abandoned. The Honda Gen 2 iBooster bolts directly to the firewall via its own integral 4-stud flange — no separate steel bracket. Drill matching holes in the LJ firewall; see [Firewall Backing Plate](#firewall-backing-plate) for the cabin-side plate and pattern geometry.
 - **Fallback paths:** If integral flange has engine-bay packaging conflicts, fall back to (a) SendCutSend custom one-off firewall plate that re-patterns mounting holes, or (b) Back Bay Customs one-off commission — *only worthwhile if they have access to an LJ for trial fit; without one, customer-measurement-blind design carries the same risk as SendCutSend at higher cost.*
 - **Reservoir height:** Mount reservoirs 4-6" above MC flange on firewall standoff for proper gravity feed. More than 6" risks hood clearance issues.
 - **Bench test before fab:** Apply 12V ignition signal to the iBooster and verify motor cycles + pedal rod assists. Used iBoosters fail frequently.

--- a/docs/jeep_lj/05-control-interfaces/02-switchpros-sp1200.md
+++ b/docs/jeep_lj/05-control-interfaces/02-switchpros-sp1200.md
@@ -114,8 +114,7 @@ tags:
 See [AUX Battery Distribution][aux-battery] for source battery and [Firewall CONSTANT Bus][firewall-bus] for downstream distribution.
 
 - **Power:** AUX battery+ → 300A master CB → 2/0 AWG forward (~13 ft) → Firewall CONSTANT Bus → 150A CB → SwitchPros power module
-- **Ground (logic reference):** 4 AWG wire from SwitchPros power module → chassis ground at firewall (short run, per manufacturer spec)
-- **Load returns:** Each output's ground wire returns to the [SwitchPros Ground Bus][switchpros-ground-bus] (Blue Sea 2105 MaxiBus), co-located with the power module at the firewall
+- **Ground:** see callout above (logic reference only); load returns go to the [SwitchPros Ground Bus][switchpros-ground-bus] (Blue Sea 2105 MaxiBus), co-located with the power module at the firewall
 
 ## Trigger Input Assignments
 
@@ -158,7 +157,7 @@ Rear Cargo Rocker Switch (SPST) → TRIGGER-2 (Pin 8, PINK)
 
 ### TRIGGER-3: Air Pressure Switch → Auto Compressor Control
 
-ARB air tank pressure switch automatically activates compressor to maintain tank pressure between 135-150 PSI.
+ARB air tank pressure switch automatically activates the compressor to maintain tank pressure — see setpoints below.
 
 **Wiring:**
 
@@ -168,7 +167,7 @@ ARB Pressure Switch (180901) → TRIGGER-3 (Pin 17, PINK)
 
 **Configuration:**
 
-Program TRIGGER-3 to activate compressor when tank pressure drops below 135 PSI:
+Program TRIGGER-3 to activate the compressor on pressure switch closure:
 
 **SwitchPros Logic:**
 

--- a/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
+++ b/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
@@ -60,8 +60,7 @@ tags:
   - **Pull lever** → Activates headlights (low beam)
   - Power: PMU Out 13 (CONSTANT) → CT4 internal switching → SW3 output
   - CT4 SW3 output → LP6 Pin 1 (low beam, both lights in parallel)
-  - CT4 handles switching internally (10A output capacity, 3.6A actual load)
-  - Disabled when ignition off (via ignition signal from ignition switch RUN)
+  - CT4 handles switching internally
   - Latching on/off control (pull once to turn on, pull again to turn off)
   - Wire gauge: 14 AWG from CT4 SW3 output to LP6 headlights
   - When active: Also triggers DRL cutoff relay to disable DRL circuit (SW3 output tapped to relay coil)
@@ -70,8 +69,7 @@ tags:
   - **Push lever** (while headlights on) → Activates high beams
   - Power: PMU Out 13 (CONSTANT) → CT4 internal switching → SW4 output
   - CT4 SW4 output → LP6 Pin 4 (high beam, both lights in parallel)
-  - CT4 handles switching internally (10A output capacity, 5.6A actual load)
-  - Disabled when ignition off (via ignition signal from ignition switch RUN)
+  - CT4 handles switching internally
   - CT4 provides mutual exclusivity (high beam disables low beam automatically)
   - Momentary or latching toggle (programmable)
   - Wire gauge: 14 AWG from CT4 SW4 output to LP6 headlights
@@ -86,8 +84,6 @@ Automatic ignition-controlled circuit that powers:
 - Maxbilt tail light RED wire (marker/parking function)
 
 **Power Source:** PMU Out 23 (7A capacity, ~2.6A load, auto with ignition)
-
-**DRL Auto-Off:** PMU programming logic disables when CT4 SW3 activates (headlights on = DRL off)
 
 Wire gauge: 14 AWG from PMU to junction, 16 AWG to each light
 
@@ -155,10 +151,8 @@ END
 
 **Installation Notes:**
 
-- Tap CT4 SW3 output (low beam circuit) to PMU In 7 for headlight status monitoring
 - Run wire from PMU Out 23 to DRL junction
 - Total DRL/parking circuit load: ~2.6A — see [DRL & Parking][drl-parking] for the itemized load breakdown and wiring
-- PMU Out 23 capacity: 7A (sufficient for the ~2.6A load)
 
 ## Installation Checklist
 


### PR DESCRIPTION
Nightly tidiness pass per `docs/jeep_lj/CLAUDE.md`'s **BE SUCCINCT** rule. Cuts prose that restated an adjacent table/code block, or repeated the same fact/rationale multiple times in one page. No specs, values, identifiers, TBD items, checkbox items, table rows, frontmatter, or `div.product-info` blocks were touched — prose and structure only.

| File | Lines before → after | What was cut | Which persona it failed |
| :--- | :-------------------- | :------------ | :----------------------- |
| `05-control-interfaces/03-command-touch-ct4.md` | 229 → 221 | Headlight/high-beam output capacity + "disabled when ignition off" restated the Wiring Pinout table; DRL auto-off summary restated the PMU logic code block below it; an installation-note bullet restated both the code block and the checklist; PMU Out 23 capacity restated the product-info line above it | Mechanic (table already had it), Troubleshooter (logic already in the authoritative code block) |
| `05-control-interfaces/02-switchpros-sp1200.md` | 229 → 227 | Ground path restated the `!!! note` callout in the product-info block; ARB pressure-switch cut-in/cut-out PSI restated across the intro line and the Configuration lead-in (kept once in the Logic table and once in Signal Source, which carries the part number) | Mechanic (setpoints stated 4x for the same fact) |
| `02-engine-systems/02-brake-booster.md` | 249 → 248 | Installation Notes restated the firewall pattern, cantilever/fatigue-cracking rationale, and the "80mm-horizontal adapter out of stock" fact — all already stated in the Overview and Firewall Backing Plate sections | Mechanic (same mounting geometry repeated) |
| `01-power-systems/02-starter-battery-distribution/index.md` | 104 → 103 | Duplicate "CBs mounted within 7\" of battery" statement (Overview restated the table footnote below); "far more robust" adjective layered on a claim the sentence already made — tightened to the concrete tradeoff (removed PMU single point of failure) instead | Mechanic (redundant lookup), Owner (adjective added nothing beyond the tradeoff already stated) |
| `01-power-systems/04-pmu/05-pmu-arb-load-shedding.md` | 327 → 322 | "Load shedding provides additional margin" rationale stated 3x within 25 lines; RPM/heat "best practices" sub-bullets restated obvious alternator/thermal physics | Owner (same tradeoff re-explained instead of stated once) |
| `01-power-systems/08-load-analysis/03-aux-battery.md` | 270 → 269 | Two scenario "Assessment" lines duplicated the Summary's "Key Insight" fact, with stale "now/no longer a concern" revision-history framing that doesn't help a reader returning months later | Owner (redundant with the single Key Insight; framing was about a past correction, not current state) |

## Left for human judgment

- **`01-power-systems/STANDARDS-EXCEPTIONS.md`** — each of the 7 component sections repeats its own conclusion ~3x (Analysis → Standards Comparison → "Do NOT flag" Review Guidance), plus a closing Summary that recaps the whole file. Some repetition here is the file's *stated purpose* (pre-empting future reviewers from re-flagging intentional deviations), so trimming it is a judgment call about how much redundancy that purpose actually requires — left alone this run.
- **`01-power-systems/07-wire-routing/02-firewall-ingress.md`** — the "Pin Budget Audit (Historical)" section (~75 lines) re-derives a connector-sizing decision that's already implemented and stated concisely in an admonition earlier in the file. It reads as a preserved audit trail/changelog rather than pure filler, and cutting ~75 lines is bigger than a "minimal edit" — left for you to decide whether the history is worth keeping at that length.
- **`01-power-systems/07-wire-routing/03-harness-inventory.md`** — a Cabin Trunk Bundle table is followed by prose repeating harness/cable-count/gauge already in the table, mixed with genuinely new info (bundle OD, grommet/termination type). Could go either way: fold the new facts into the table and cut the prose, or leave as a compact caption — small enough that either call is fine.
- **`01-power-systems/08-load-analysis/02-start-battery.md`** — the "Architecture" line under one scenario closely tracks the Dual Battery Architecture rationale in `CLAUDE.md`'s Load Analysis Guidelines and possibly a battery-overview page; didn't cross-check every other file closely enough to call it a confirmed duplicate.

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01AqgV45R83hhKBwmLxKr1cx

---
_Generated by [Claude Code](https://claude.ai/code/session_01AqgV45R83hhKBwmLxKr1cx)_