### PR TITLE
docs: nightly tidiness — trim verbosity (2026-08-08)

### DIFF
--- a/docs/jeep_lj/01-power-systems/05-grounding/03-switchpros-ground-bus.md
+++ b/docs/jeep_lj/01-power-systems/05-grounding/03-switchpros-ground-bus.md
@@ -56,8 +56,6 @@ tags:
 
 **Ground Path:** Bus → chassis ground (1/0 AWG, handles ~100A total lighting load) at firewall chassis point → main grounding network
 
-**Critical:** Clean metal-to-metal connection to chassis at firewall, accessible for lighting ground wires
-
 ## Related Documentation
 
 - [Grounding Architecture Overview][grounding-architecture]

--- a/docs/jeep_lj/02-engine-systems/08-fuel-system.md
+++ b/docs/jeep_lj/02-engine-systems/08-fuel-system.md
@@ -45,12 +45,6 @@ Return line → Fuel Tank
 
 The factory Jeep LJ in-tank electric fuel pump is **not used** in this configuration.
 
-## Installation Summary
-
-1. **Inlet:** Route fuel line from tank pickup → fuel filter/separator inlet
-2. **Filter to Pump:** Route from filter outlet → gear-driven pump inlet (back of block)
-3. **Return:** Route from engine return fitting → tank return
-
 ## Priming
 
 Use the manual hand pump on the fuel filter/water separator to prime the system before initial startup or after filter changes.

--- a/docs/jeep_lj/07-communication-systems/01-gmrs-radio.md
+++ b/docs/jeep_lj/07-communication-systems/01-gmrs-radio.md
@@ -73,8 +73,6 @@ tags:
 
 ## Installation Notes
 
-- Direct battery ground required for best RF performance
-- Route antenna coax away from power leads
 - Keep coax length <25 ft for minimal signal loss
 
 ## Outstanding Items

--- a/docs/jeep_lj/07-communication-systems/02-intercom.md
+++ b/docs/jeep_lj/07-communication-systems/02-intercom.md
@@ -77,7 +77,6 @@ tags:
 
 ## Installation Notes
 
-- Direct battery ground recommended for best audio quality
 - PMU output has integrated 5A protection - no inline fuse needed
 
 ## Outstanding Items

--- a/docs/jeep_lj/08-exterior-systems/03-air-lockers.md
+++ b/docs/jeep_lj/08-exterior-systems/03-air-lockers.md
@@ -86,25 +86,14 @@ ARB RD116 air-operated locking differentials for front and rear Dana 44 axles.
 
 ### Engagement Sequence
 
-**Front Locker:**
+Press and hold the button to open the solenoid; pressurized air locks the differential **instantly** (no waiting for compressor). Release to disengage.
 
-1. Press Button 9 (OUTPUT-17)
-2. Solenoid opens, pressurized air from tank → front locker
-3. Front differential locks **instantly** (no waiting for compressor)
-4. Release Button 9 to disengage
+| Locker | Button    | SwitchPros Output |
+| ------ | --------- | ----------------- |
+| Front  | Button 9  | OUTPUT-17         |
+| Rear   | Button 10 | OUTPUT-10         |
 
-**Rear Locker:**
-
-1. Press Button 10 (OUTPUT-10)
-2. Solenoid opens, pressurized air from tank → rear locker
-3. Rear differential locks **instantly**
-4. Release Button 10 to disengage
-
-**Automatic Refill:**
-
-- After multiple locker uses, tank pressure drops below 135 PSI
-- Pressure switch automatically activates compressor to refill tank
-- No user action required
+Tank refill after locker use is automatic — see [Air Compressor: Automatic Pressure Control][air-compressor-auto] for the pressure switch logic.
 
 ## Safety Considerations
 
@@ -129,4 +118,5 @@ ARB RD116 air-operated locking differentials for front and rear Dana 44 axles.
 - [SwitchPros][switchpros] - Locker control (OUTPUT-10, OUTPUT-17)
 
 [air-compressor]: 02-air-compressor.md
+[air-compressor-auto]: 02-air-compressor.md#automatic-pressure-control
 [switchpros]: ../05-control-interfaces/02-switchpros-sp1200.md

--- a/docs/jeep_lj/08-exterior-systems/04-rear-air-chuck.md
+++ b/docs/jeep_lj/08-exterior-systems/04-rear-air-chuck.md
@@ -9,7 +9,7 @@ tags:
 
 # 8.4 Rear Air Chuck {#rear-air-chuck}
 
-External air access plate mounted in the tailgate area for tire inflation and air tool use.
+External air access plate mounted in the tailgate area for tire inflation, air tool use, and trail-side air sharing with other vehicles.
 
 /// html | div.product-info
 
@@ -20,13 +20,6 @@ External air access plate mounted in the tailgate area for tire inflation and ai
 **Air Source:** [Air Compressor][air-compressor] via manifold (1/4" air line)
 
 ///
-
-## Purpose
-
-- External access to compressed air without opening the vehicle
-- Convenient tire inflation at each wheel
-- Air tool connection point
-- Trail-side air sharing with other vehicles
 
 ## Specifications
 


### PR DESCRIPTION
Nightly tidiness pass per `docs/jeep_lj/CLAUDE.md`'s **BE SUCCINCT** rule. Cuts prose that restated an adjacent table, generic shop-practice advice already covered by the manufacturer, and a cross-file duplicate of pressure-switch logic already documented authoritatively elsewhere. No specs, values, identifiers, TBD items, checkbox items, table rows, frontmatter, or `div.product-info` blocks were touched — prose and structure only.

| File | Lines before → after | What was cut | Which persona it failed |
| :--- | :-------------------- | :------------ | :----------------------- |
| `08-exterior-systems/03-air-lockers.md` | 133 → 122 | Front/Rear "Engagement Sequence" repeated the identical 4-step press/release pattern twice, differing only by button number — collapsed into one instruction + a table. "Automatic Refill" fully restated the 135/150 PSI pressure-switch cut-in/cut-out logic already documented in `02-air-compressor.md`'s "Automatic Pressure Control" section — replaced with a cross-link to the authoritative source. | Mechanic (redundant steps for the same action), Troubleshooter (duplicate pressure logic across files instead of one source) |
| `07-communication-systems/01-gmrs-radio.md` | 97 → 95 | Two "Installation Notes" bullets ("Direct battery ground required...", "Route antenna coax away from power leads") verbatim-restated the Ground and Antenna rows of the Wiring table directly above. | Mechanic (table already had it) |
| `07-communication-systems/02-intercom.md` | 100 → 99 | One "Installation Notes" bullet ("Direct battery ground recommended...") restated the Wiring table's Ground row. | Mechanic (table already had it) |
| `02-engine-systems/08-fuel-system.md` | 67 → 61 | "Installation Summary" (3 numbered steps) purely re-narrated the "Fuel Flow Path" ASCII diagram directly above it in the same order with the same information. | Mechanic (restates adjacent diagram) |
| `01-power-systems/05-grounding/03-switchpros-ground-bus.md` | 73 → 71 | Cut "Clean metal-to-metal connection to chassis" — the literal generic-shop-practice example `CLAUDE.md` names as banned ("clean surfaces"), not build-specific. | Mechanic (generic advice, not build-specific) |
| `08-exterior-systems/04-rear-air-chuck.md` | 66 → 59 | "## Purpose" bullet list mostly re-explained the one-line page intro ("tire inflation and air tool use") in slightly marketing-flavored phrasing. Folded the one genuinely new fact (trail-side air sharing) into the intro sentence and cut the section. | Mechanic/Parts Buyer (pure scaffolding, no new info) |

## Left for human judgment

- **`01-power-systems/04-pmu/02-pmu-inputs.md`** — "## 12V Switched Input (Pin 7)" and "## Ignition Signal Distribution" describe the identical routing (PMU Pin 7, 18 AWG from the ignition signal bus bar) twice in the same file, which is exactly the kind of same-file duplication this pass targets. However the two descriptions disagree on a routing detail — one says the wire enters via "firewall Grommet 2," the other says it's tapped from "HDP24 Pin 12." Since collapsing the duplicate would mean picking one of two conflicting facts, and I can't verify which is correct, I left both sections untouched rather than risk silently resolving (or hiding) a real inconsistency. Worth a manual check against the harness build.
- **`01-power-systems/01-power-generation/01-batteries.md`** (not edited this run) — "System Configuration" and "Mounting" both state the START/AUX battery→wheel-well pairing; flagged by survey as medium-confidence, left out to keep tonight's pass to the clearest wins.

## Context on the open PR backlog

There are currently ~40 open, unmerged `tidy/*` PRs stacked up since early July — this pass avoided touching any file already modified by one of those branches to prevent future merge conflicts, but the backlog itself may be worth a look (either batch-merging the safe ones or reconsidering the cadence).

---
🤖 Generated with [Claude Code](https://claude.ai/code)

https://claude.ai/code/session_01YbbvL9NDUrcEkvezEc5RFs

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbbvL9NDUrcEkvezEc5RFs)_