### PR TITLE
docs: nightly tidiness — trim verbosity (2026-08-09)

### DIFF
--- a/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
+++ b/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
@@ -53,7 +53,7 @@ The radiator fan, iBooster, and TCU were relocated off the PMU onto START-direct
 The master feed carries the combined load (~68A continuous, ~108A brief peak); voltage drop and breaker sizing are set on that single cable.[^fwd-bus-vdrop] The iBooster's separate ignition **enable** (~5A) is sourced from the [Ignition Signal bus][ignition-signal], not this bus. Fan speed is set by a dedicated fan controller ({{ tbd(134) }}) with its own coolant sensor, independent of the PMU and J1939.
 
 !!! info "Shared forward feed — intentional tradeoff"
-    The three loads share one master feed + busbar (a passive cable, breaker, and bus bar — no active electronics), versus three independent runs from the battery. This is the same tradeoff the [AUX side][constant-bus] accepts, and is far more robust than their former shared dependency on the PMU module. Each load keeps its own breaker. See [Standards Exceptions][standards-exceptions].
+    The shared feed (a passive cable, breaker, and bus bar — no active electronics) is the same tradeoff the [AUX side][constant-bus] accepts, and is far more robust than the loads' former shared dependency on the PMU module. Each load keeps its own breaker. See [Standards Exceptions][standards-exceptions].
 
 [^fwd-bus-vdrop]: Master feed 2 AWG @ ~108A brief peak (~68A continuous), ~8 ft, 60°C-derated (×1.2) ≈ 1.3% — sized on the combined load. Load feeds are short from the engine-bay bus, so per-load drop is negligible: fan 4 AWG @ 53A, iBooster 8 AWG @ 40A brief, TCU 12 AWG @ 15A. Final master-feed length and breaker selective-coordination pending {{ tbd(136) }} and {{ tbd(135) }}.
 

--- a/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
@@ -33,7 +33,7 @@ Usable capacity (80% DOD):  108Ah
 Time to 20% SOC:           ~144 minutes continuous (2.4 hours)
 ```
 
-The Dakota Lithium 135Ah combined with 50A BCDC makes extended air-up a non-issue. Load shedding provides additional margin and maintains optimal voltage for electronics.
+The Dakota Lithium 135Ah combined with 50A BCDC makes extended air-up a non-issue.
 
 **Impact Without Load Shedding:**
 
@@ -219,10 +219,7 @@ ELSE:
 
 **Best Practices for ARB Use:**
 
-1. **Increase Engine RPM:** Run engine at 1500+ RPM during tire inflation
-   - Alternator output increases with RPM
-   - Better voltage regulation at higher speeds
-   - Faster tire inflation
+1. **Increase Engine RPM:** Run engine at 1500+ RPM during tire inflation for more alternator headroom and faster fill
 
 2. **Monitor Voltage:** Watch Dakota Digital voltage gauge during ARB use
    - Normal: 14.0-14.4V (load shedding working)

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/02-firewall-ingress.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/02-firewall-ingress.md
@@ -252,8 +252,6 @@ Each SwitchPros output normally pairs a power wire (SP → load) with a ground w
 
 ### Verdict
 
-**Current HDP24-24-21 will work but leaves zero future headroom.**
-
 - The 1 size-16 spare (pin 2) + 4 size-12 reserved cavities can accommodate all 5 new circuits *only* if size-12 cavities accept 18 AWG wires via reducer crimps or 12 AWG dummy wires
 - Any future expansion (additional sensors, accessories, telematics) will require a connector change anyway
 
@@ -269,8 +267,6 @@ Each SwitchPros output normally pairs a power wire (SP → load) with a ground w
 | Firewall hole size | 1.5" diameter | 1.5" diameter (same) |
 | Approx connector cost | ~$60 (recpt + plug) | ~$80 (recpt + plug) |
 | Crimping tool | HDT-48-00 | HDT-48-00 (same) |
-
-**Net change:** ~$20 extra, same install procedure, same hole, 8 pins of future headroom.
 
 ### Alternative: Split into two connectors
 

--- a/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
+++ b/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
@@ -44,25 +44,10 @@ This document tracks intentional deviations from general electrical standards wh
 
 **Protection Mechanisms:**
 
-1. **Internal Thermal Cutoff**
-   - Winch motor has integrated thermal protection
-   - Trips before windings reach damage temperature
-   - Automatic reset when motor cools
-
-2. **Contactor Disconnect**
-   - Isolates winch when not in use
-   - Prevents parasitic drain
-   - Manual control provides emergency stop
-
-3. **Cable Self-Protection**
-   - 1/0 AWG fuses open at ~800A+ (thermal runaway)
-   - Well above 409A operating peak
-   - Adequate for brief loads per SAE J1128
-
-4. **Manual Battery Disconnect**
-   - Master disconnect at AUX battery terminal
-   - Emergency shutoff capability
-   - Maintenance safety
+1. **Internal thermal cutoff** - trips before winding damage, auto-resets when cool
+2. **Contactor disconnect** - isolates winch when not in use, prevents parasitic drain
+3. **Cable self-protection** - 1/0 AWG fuses open at ~800A+, well above the 409A peak
+4. **Manual battery disconnect** - master disconnect at AUX battery terminal for emergency shutoff
 
 ### Winch Standards Comparison
 
@@ -336,33 +321,14 @@ Grid heater brief, high-current load characteristics make circuit breaker unnece
 
 **Why No Circuit Breaker Required:**
 
-1. **Alternator Self-Limiting**
-   - Maximum output: 270A (design limit)
-   - Cannot exceed rated output regardless of load
-   - Internal voltage regulator prevents overcharge
-
-2. **Cable Sizing**
-   - Wire: 2/0 AWG (375A continuous rating)
-   - Adequate for 270A continuous output
-   - No thermal concerns at rated load
-
-3. **Battery Acts as Buffer**
-   - Absorbs brief load spikes
-   - Prevents alternator overload
-   - Natural load smoothing
-
-4. **Factory Practice**
-   - No OEM vehicles use alternator output circuit breakers
-   - Proven safe over millions of vehicles
-   - Industry standard approach
+1. **Self-limiting output** - 270A design maximum, cannot exceed regardless of load; internal regulator prevents overcharge
+2. **Cable sizing** - 2/0 AWG (375A continuous) covers the 270A output with no thermal concern
+3. **Battery acts as buffer** - absorbs brief load spikes, smooths demand on the alternator
+4. **Factory practice** - no OEM vehicle uses an alternator output circuit breaker
 
 ### Alternator Review Guidance
 
-**This is standard automotive practice.**
-
-Alternators NEVER use circuit breakers on output circuits in factory or aftermarket applications.
-
-**Do NOT flag as missing protection.**
+**Standard automotive practice — do NOT flag as missing protection.**
 
 **Documentation References:**
 
@@ -421,10 +387,7 @@ No additional CB required at BCDC - entire circuit protected from battery termin
 
 ### Engineering Rationale
 
-- The radiator fan, iBooster, and TCU were moved off the PMU and all sit forward (engine bay / transmission), while the START battery is in the rear wheel well.
-- Three independent feeds would mean three long rear-to-front cables and ~9 stacked lugs on the battery post (impractical, hard to service).
-- A single master feed + forward busbar mirrors the proven AUX-side two-stage architecture (300A master → firewall CONSTANT bus), placing each load's breaker near its load.
-- The intermediate bus is a passive bar; the feed is protected by a 150A master breaker within 7" of the battery (the cable is never unprotected), with selective coordination to the downstream load breakers.
+Three independent feeds would need ~9 stacked lugs on the battery post — impractical to service. A single master feed + forward busbar instead mirrors the AUX-side two-stage architecture, keeping each load's breaker near its load; the bus itself is a passive bar, with the feed staying protected by a 150A master breaker within 7" of the battery. Full rationale: [START+ Forward Distribution Bus][starter-battery-distribution].
 
 ### Review Guidance
 

--- a/docs/jeep_lj/05-control-interfaces/06-keyless-ignition.md
+++ b/docs/jeep_lj/05-control-interfaces/06-keyless-ignition.md
@@ -42,7 +42,7 @@ Push-button ignition for the Cummins R2.8 + 8HP70 build. Replaces the factory ke
 | Detection Range | ~10 ft (iTag fob) |
 | Auto-arm | 60 sec after fob leaves range |
 | Module Dimensions | ~5.5" × 3" × 1.25" |
-| Wiring | Heavy-duty Molex high-current connectors, 12 GA bus wiring |
+| Wiring | Molex high-current connectors, 12 GA bus wiring |
 | Mounting | **Dakota Digital HDPE panel, under dash** — co-located with the HDX control module (panel detailed in the [HDX Control][hdx-control] plan). Vendor mandate: cabin only, never engine bay |
 | Kit Contents | ICM + 2 iTag fobs + Start Button (36" pre-wired harness) + Programming Button + Bypass Card + 4-digit PIN |
 

--- a/docs/jeep_lj/index.md
+++ b/docs/jeep_lj/index.md
@@ -96,7 +96,7 @@ The factory TIPM is replaced with discrete, serviceable modules:
 
 - **[PMU24][pmu]:** Programmable 24-channel power management unit
 - **[BODY PDU][body-pdu]:** Body relay/fuse panel for cabin accessories
-- **[SafetyHub][safetyhub]:** 12-channel advanced safety controller
+- **[SafetyHub][safetyhub]:** 150A fuse block, 12-channel
 - **[Ron Francis WS-51C][wipers]:** Wiper control module
 
 ### Brake & Ignition


### PR DESCRIPTION
Nightly tidiness pass per `docs/jeep_lj/CLAUDE.md`'s **BE SUCCINCT** rule. Six pages had the clearest, highest-confidence redundancy — collapsed multi-bullet blocks that said the same thing three ways, deduplicated a design rationale that was written out in full in two files, and dropped two leftover marketing adjectives.

No specs, part numbers, wire gauges, TBDs, checkboxes, table rows, frontmatter, or `[ref]:` link definitions were touched — prose and structure only.

| File | Lines before → after | What was cut | Persona it failed |
| :--- | :--- | :--- | :--- |
| `01-power-systems/STANDARDS-EXCEPTIONS.md` | 592 → 550 | Winch "Protection Mechanisms" and Alternator "Why No CB Required" each restated one idea across 3 sub-bullets per item; collapsed to one line each. Alternator "Review Guidance" collapsed from 3 restated sentences to 1. START+ Forward Bus "Engineering Rationale" tightened and pointed at the authoritative rationale in `02-starter-battery-distribution/index.md` instead of re-deriving it | Owner/Designer, Troubleshooter (real decisions buried under repeated justification) |
| `01-power-systems/02-starter-battery-distribution/index.md` | 104 → 104 | Tightened the "Shared forward feed" admonition, which restated the paragraph directly above it almost verbatim | Owner/Designer (duplicated rationale drifts when only one copy gets updated) |
| `01-power-systems/04-pmu/05-pmu-arb-load-shedding.md` | 326 → 323 | A concluding sentence ("Load shedding provides additional margin...") appeared twice, once per section; removed the second. Collapsed a 4-line "Increase Engine RPM" bullet (3 sub-bullets stating generic alternator behavior) to one line | Mechanic/Installer (restated common-knowledge alternator behavior instead of the actionable instruction) |
| `01-power-systems/07-wire-routing/02-firewall-ingress.md` | 353 → 351 | In the (self-flagged) "Historical" pin-budget-audit section, removed one bolded sentence and one "Net change" sentence that just restated the adjacent tables in prose | Owner/Designer, Parts Buyer (current pin assignments already documented above; this section is decision-log) |
| `05-control-interfaces/06-keyless-ignition.md` | 151 → 151 | Dropped "Heavy-duty" from a spec-table wiring cell | Mechanic/Installer (adjective, not a spec) |
| `index.md` | 164 → 164 | "12-channel advanced safety controller" → "150A fuse block, 12-channel" — SafetyHub is a Blue Sea fuse block, not a "safety controller"; states the actual rating instead of the marketing label | Parts Buyer (product type/rating is signal, "advanced" is not) |

## Left for human judgment

- `01-power-systems/STANDARDS-EXCEPTIONS.md` still has real redundancy in the Starter, Grid Heater, BCDC, and SwitchPros/SafetyHub sections (Standards Comparison + Review Guidance blocks each restate the same "not an issue" conclusion 2-3x). Left alone this run to keep the diff small and reviewable — the Winch and Alternator sections were the worst offenders and are fixed here.
- `01-power-systems/08-load-analysis/*.md` — "Excellent"/"Good" assessment labels in scenario tables read as subjective but function as a categorical status column next to hard numbers; left as-is.
- `02-engine-systems/09-gauge-cluster/0{3,4,5,6}-bim-*.md` share a near-identical sourcing-caveat sentence ("Dakota Digital publishes no per-module current..."); this looked like duplicated rationale at first glance but each is a page-specific sourcing note for a module that genuinely lacks its own published spec, so left alone.

## Verification

- `python3 -m mkdocs build --strict` — passes (exit 0).
- `npx markdownlint-cli2 "docs/jeep_lj/**/*.md"` — **pre-existing failures on `main`, unrelated to this change.** Confirmed via `git stash` that running the same lint command against unmodified `main` produces the identical error count (167) in the six files touched here — table-column-style (`MD060`), unused link references (`MD053`), and a duplicate heading (`MD024`) that all predate this PR and affect dozens of untouched files repo-wide (e.g. `tbd-tracker.md`, `10-drivetrain/01-transmission.md`, `09-installation/03-purchase-tracker.md`). This diff introduces **zero new lint errors**. Repo-wide table reformatting to satisfy `MD060` is out of scope for a prose-only tidiness pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Fin5t3czf9G3u63VXmNiSE)_