### PR TITLE
docs: nightly tidiness — trim verbosity (2026-08-10)

### DIFF
--- a/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
@@ -15,7 +15,7 @@ Automatic load management during ARB compressor operation to preserve AUX batter
 - **BCDC Charging (50A max):** Replenishes AUX battery from alternator
 - **Net AUX battery drain:** 90A - 50A = 40A during compressor operation
 
-The alternator is NOT overloaded during ARB operation. The 50A BCDC significantly reduces net discharge rate, making extended air-up practical. Load shedding provides additional margin and maintains optimal voltage.
+The alternator is NOT overloaded during ARB operation. The 50A BCDC significantly reduces net discharge rate, making extended air-up practical.
 
 ## Problem Statement
 
@@ -34,12 +34,6 @@ Time to 20% SOC:           ~144 minutes continuous (2.4 hours)
 ```
 
 The Dakota Lithium 135Ah combined with 50A BCDC makes extended air-up a non-issue. Load shedding provides additional margin and maintains optimal voltage for electronics.
-
-**Impact Without Load Shedding:**
-
-- Minor: AUX battery still has comfortable margin at 50A BCDC
-- START battery loads reduce BCDC charging efficiency slightly
-- Load shedding maximizes available margin for extended sessions
 
 ## Solution Overview
 
@@ -219,10 +213,7 @@ ELSE:
 
 **Best Practices for ARB Use:**
 
-1. **Increase Engine RPM:** Run engine at 1500+ RPM during tire inflation
-   - Alternator output increases with RPM
-   - Better voltage regulation at higher speeds
-   - Faster tire inflation
+1. **Increase Engine RPM:** Run engine at 1500+ RPM during tire inflation for better alternator output and faster inflation
 
 2. **Monitor Voltage:** Watch Dakota Digital voltage gauge during ARB use
    - Normal: 14.0-14.4V (load shedding working)

--- a/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
+++ b/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
@@ -68,8 +68,7 @@ This document tracks intentional deviations from general electrical standards wh
 
 **Marine (ABYC E-11):**
 
-- Would require 400A circuit breaker for all loads
-- **This is NOT a marine application** - automotive standards apply
+- Would require 400A circuit breaker for all loads (not applicable — automotive standards apply; see Summary below)
 
 **Automotive (SAE J1128):**
 
@@ -82,17 +81,6 @@ This document tracks intentional deviations from general electrical standards wh
 - No external protection required ✓
 - Direct battery connection specified ✓
 - Internal protection designed for fault scenarios ✓
-
-### Factory Vehicle Precedent
-
-**OEM winch installations do NOT use external circuit breakers:**
-
-- **Ford Super Duty** with factory winch prep: No CB on winch circuit
-- **RAM Power Wagon** factory winch: No external CB, direct battery connection
-- **Toyota TRD Pro** winch ready: No CB specified in prep package
-- **Jeep Rubicon** winch-capable: Power runs via relay, no CB
-
-**Industry Standard Practice:** Winch manufacturers design internal protection for automotive fault scenarios, making external CBs redundant.
 
 ### Winch Fault Scenarios Covered
 
@@ -236,8 +224,7 @@ It is intentional adherence to:
 
 **Marine (ABYC E-11):**
 
-- Would require circuit breaker or fuse
-- **This is NOT a marine application** - automotive standards apply
+- Would require circuit breaker or fuse (not applicable — automotive standards apply; see Summary below)
 
 ### Starter Review Guidance
 
@@ -360,8 +347,6 @@ Grid heater brief, high-current load characteristics make circuit breaker unnece
 
 **This is standard automotive practice.**
 
-Alternators NEVER use circuit breakers on output circuits in factory or aftermarket applications.
-
 **Do NOT flag as missing protection.**
 
 **Documentation References:**
@@ -426,7 +411,7 @@ No additional CB required at BCDC - entire circuit protected from battery termin
 - A single master feed + forward busbar mirrors the proven AUX-side two-stage architecture (300A master → firewall CONSTANT bus), placing each load's breaker near its load.
 - The intermediate bus is a passive bar; the feed is protected by a 150A master breaker within 7" of the battery (the cable is never unprotected), with selective coordination to the downstream load breakers.
 
-### Review Guidance
+### START+ Forward Bus Review Guidance
 
 **This is intentional.** Do NOT flag the START+ Forward Distribution Bus as violating the "no bus bar between battery and loads" rule — it is the same accepted tradeoff as the AUX CONSTANT bus, chosen to relocate three critical loads off the PMU. See {{ tbd(135) }} for final busbar/breaker selection.
 
@@ -519,7 +504,7 @@ The CB is sized for _device capacity_, not actual load. Actual loads are well wi
 - CB sizing considers duty cycle and thermal time constants
 - Brief overloads acceptable if within wire thermal limits
 
-### Review Guidance
+### SwitchPros/SafetyHub Review Guidance
 
 **This is NOT a safety issue.**
 

--- a/docs/jeep_lj/02-engine-systems/05-horn.md
+++ b/docs/jeep_lj/02-engine-systems/05-horn.md
@@ -52,18 +52,6 @@ START battery CONSTANT → PMU → Out 18 → PIAA Horns (5.4A) → Chassis Grou
                       Horn Button → In 1 (trigger)  [column path undefined — {{ tbd(152) }}]
 ```
 
-**Power Flow:**
-
-1. START battery+ → 250A inline CB → PMU
-2. Horn button (steering wheel) → PMU In 1 (trigger signal)
-3. PMU Out 18 activated when In 1 closes
-4. PMU Out 18 → PIAA horns (5.4A) → chassis ground (engine bay)
-
-**Notes:**
-
-- PMU Out 18 switches directly (no external relay needed)
-- Works with ignition off (CONSTANT power for safety)
-
 ## Outstanding Items
 
 {{ tbds() }}

--- a/docs/jeep_lj/02-engine-systems/07-grid-heater.md
+++ b/docs/jeep_lj/02-engine-systems/07-grid-heater.md
@@ -93,13 +93,7 @@ flowchart LR
 
 ## Power Distribution
 
-**Bypasses all distribution systems:**
-
-- Does NOT use CONSTANT bus bar
-- Does NOT use PMU outputs
-- Direct battery connection with fusible link protection
-
-**Reason:** High current draw (40-80A) for very short duration (3-5 seconds). Direct connection minimizes voltage drop and connection complexity.
+Bypasses the CONSTANT bus bar and PMU outputs (see Main Power above) — the 40-80A draw for 3-5 seconds is too brief to justify the added voltage drop and connection complexity of routing through them.
 
 ## Outstanding Items
 

--- a/docs/jeep_lj/02-engine-systems/08-fuel-system.md
+++ b/docs/jeep_lj/02-engine-systems/08-fuel-system.md
@@ -45,12 +45,6 @@ Return line → Fuel Tank
 
 The factory Jeep LJ in-tank electric fuel pump is **not used** in this configuration.
 
-## Installation Summary
-
-1. **Inlet:** Route fuel line from tank pickup → fuel filter/separator inlet
-2. **Filter to Pump:** Route from filter outlet → gear-driven pump inlet (back of block)
-3. **Return:** Route from engine return fitting → tank return
-
 ## Priming
 
 Use the manual hand pump on the fuel filter/water separator to prime the system before initial startup or after filter changes.

--- a/docs/jeep_lj/03-lighting-systems/05-drl-parking.md
+++ b/docs/jeep_lj/03-lighting-systems/05-drl-parking.md
@@ -47,28 +47,6 @@ ELSE
 END
 ```
 
-## Operation States
-
-**1. Ignition ON, Headlights OFF:**
-
-- PMU Pin 7 = ON (ignition RUN)
-- PMU In 7 = OFF (CT4 SW3 not active)
-- PMU Out 23 = ON
-- **Result:** All DRL/parking lights illuminated
-
-**2. Ignition ON, Headlights ON:**
-
-- PMU Pin 7 = ON (ignition RUN)
-- PMU In 7 = ON (CT4 SW3 active)
-- PMU Out 23 = OFF
-- **Result:** Headlights active, DRL off
-
-**3. Ignition OFF:**
-
-- PMU Pin 7 = OFF
-- PMU Out 23 = OFF (regardless of headlight status)
-- **Result:** All DRL/parking lights off
-
 ## Wiring
 
 **PMU Input Wiring:**


### PR DESCRIPTION
Automated nightly tidiness pass per `docs/jeep_lj/CLAUDE.md` §1 (BE SUCCINCT). Six pages had prose that either restated an adjacent table/diagram/pseudocode block verbatim in sentence form, or repeated the same sentence/rationale within the same file. No specs, part numbers, wire gauges, TBDs, checkbox items, table rows, or `[ref]:` link definitions were touched — prose and structure only.

| File | Lines before → after | What was cut | Persona it failed |
| :--- | :--- | :--- | :--- |
| `02-engine-systems/05-horn.md` | 82 → 70 | "Power Flow" numbered list and "Notes" bullets that restated the ASCII wiring diagram and PMU Configuration bullets above them | Mechanic/Troubleshooter (same fact stated 3x) |
| `02-engine-systems/07-grid-heater.md` | 115 → 109 | "Power Distribution" section's bullet list, which restated the "Main Power" line in System Architecture item 2; kept the one new fact (voltage-drop rationale) as a single sentence | Mechanic (restated spec already given) |
| `02-engine-systems/08-fuel-system.md` | 66 → 60 | "Installation Summary" numbered list that re-narrated the Fuel Flow Path diagram directly above it | Mechanic (diagram already covers this) |
| `03-lighting-systems/05-drl-parking.md` | 105 → 83 | "Operation States" section that walked through all 3 states in prose, duplicating the IF/THEN pseudocode block above it | Mechanic/Troubleshooter (logic table already covers this) |
| `01-power-systems/04-pmu/05-pmu-arb-load-shedding.md` | 326 → 317 | A sentence ("Load shedding provides additional margin...") repeated twice near-verbatim; a vague "Impact Without Load Shedding" filler bullet list with no numbers; generic RPM/alternator sub-bullets tightened to one line | Owner (redundant, unsourced filler) |
| `01-power-systems/STANDARDS-EXCEPTIONS.md` | 592 → 577 | "Factory Vehicle Precedent" appeal-to-authority list (redundant with the manufacturer spec + engineering analysis already given); the "This is NOT a marine application" disclaimer duplicated verbatim in the Winch and Starter sections (tightened to one line each, since the doc-wide Summary already states it); a redundant "Alternators NEVER use..." absolute claim; renamed two duplicate bare "### Review Guidance" headings (pre-existing `MD024` lint failure) to disambiguate | Owner (same disclaimer/precedent repeated) |

## Left for human judgment

- **`docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md` — "Winch Fault Scenarios Covered" vs "Protection Mechanisms."** These two sections cover the same four protection mechanisms from different angles (by-mechanism vs. by-fault-scenario), and the fault-scenario version adds a specific "60-90 seconds" thermal-cutoff timing not stated elsewhere. Left both in place rather than risk losing that figure without being certain it's not the only place it's recorded.
- **`docs/jeep_lj/02-engine-systems/09-gauge-cluster/{03,04,05,06}-*.md`** — an identical "Current Draw: Negligible..." paragraph appears verbatim in all four files. This is a clean case for consolidating into one authoritative file with cross-links from the other three, but it wasn't included in this run's six picks (kept the diff scope tighter). Good candidate for a future run.
- **Pre-existing `MD053` lint failures (`[install-checklist]` unused reference)** in `05-horn.md` and `07-grid-heater.md` were left as-is — the same unused reference exists repo-wide in `01-starter.md`, `02-brake-booster.md`, `04-wipers.md`, and `06-radiator-fan.md` (none touched this run), and the hard guardrail for this routine explicitly forbids deleting `[ref]:` link definitions. Fixing this properly (by using the reference or removing it repo-wide) is a separate, deliberate cleanup, not a one-file verbosity trim.

## Verification

- `python3 -m mkdocs build --strict` — passes (exit 0), no new broken links/anchors.
- `npx markdownlint-cli2 "docs/jeep_lj/**/*.md"` — no new failures introduced; the two `MD053` hits above are pre-existing and unrelated to this change (confirmed via `git stash` diff against `main`).

---
_Generated by [Claude Code](https://claude.ai/code/session_019opV6Wmq8QB31AQbpoxhhg)_