### PR TITLE
docs: nightly tidiness — trim verbosity (2026-08-19)

### DIFF
--- a/docs/jeep_lj/02-engine-systems/05-horn.md
+++ b/docs/jeep_lj/02-engine-systems/05-horn.md
@@ -52,18 +52,6 @@ START battery CONSTANT → PMU → Out 18 → PIAA Horns (5.4A) → Chassis Grou
                       Horn Button → In 1 (trigger)  [column path undefined — {{ tbd(152) }}]
 ```
 
-**Power Flow:**
-
-1. START battery+ → 250A inline CB → PMU
-2. Horn button (steering wheel) → PMU In 1 (trigger signal)
-3. PMU Out 18 activated when In 1 closes
-4. PMU Out 18 → PIAA horns (5.4A) → chassis ground (engine bay)
-
-**Notes:**
-
-- PMU Out 18 switches directly (no external relay needed)
-- Works with ignition off (CONSTANT power for safety)
-
 ## Outstanding Items
 
 {{ tbds() }}

--- a/docs/jeep_lj/02-engine-systems/07-grid-heater.md
+++ b/docs/jeep_lj/02-engine-systems/07-grid-heater.md
@@ -41,25 +41,6 @@ tags:
 | Duty cycle        | 3–5 s during cold start (ECM-controlled)           |
 | Protection        | Integrated fusible link                            |
 
-## System Architecture
-
-1. **ECM Control (Direct):**
-   - ECM triggers grid heater relay directly via pins 46/21 (~0.5-1A)
-   - ECM manages timing, temperature thresholds, and duty cycle
-   - No PMU involvement - ECM knows engine temperature better than external controller
-
-2. **Grid Heater Relay (Cummins 5467024):**
-   - Coil Power: ECM pins 46/21 (~1A) - direct connection
-   - Main Power: Direct from START battery+ via fusible link (bypasses all bus bars and PMU)
-   - Main Ground: START battery- or NEGATIVE bus
-   - Output: 80A to grid heater element (design value - verify via resistance measurement during installation)
-   - Protection: Integrated fusible link
-
-3. **Grid Heater Element:**
-   - Location: Intake manifold
-   - Power: 80A from relay (design value)
-   - Duty Cycle: 3-5 seconds during cold start (ECM controlled)
-
 ## Wiring Summary
 
 **Two-Stage Design:** ECM pins 46/21 (1A) → relay coil → relay switches high current (40-80A) directly from battery to element.
@@ -84,22 +65,11 @@ flowchart LR
     style ELEMENT fill:#d1d5db,color:#000
 ```
 
-## Why Direct ECM Control
+## Design Rationale
 
-- ECM has accurate engine temperature data
-- ECM knows optimal grid heater timing for cold starts
-- Eliminates unnecessary complexity of PMU passthrough
-- Frees PMU output slots for other critical systems
+**ECM control, not PMU:** the ECM already has engine-temperature data and manages timing/duty cycle directly — a PMU passthrough would add a hop and consume an output slot for no benefit.
 
-## Power Distribution
-
-**Bypasses all distribution systems:**
-
-- Does NOT use CONSTANT bus bar
-- Does NOT use PMU outputs
-- Direct battery connection with fusible link protection
-
-**Reason:** High current draw (40-80A) for very short duration (3-5 seconds). Direct connection minimizes voltage drop and connection complexity.
+**Direct battery connection, not bus/PMU switching:** bypasses the CONSTANT bus bar and PMU outputs entirely, protected by the integrated fusible link. The 40-80A/3-5s duty cycle is brief and high-current — a poor fit for bus/PMU switching, and direct connection minimizes voltage drop.
 
 ## Outstanding Items
 

--- a/docs/jeep_lj/02-engine-systems/08-fuel-system.md
+++ b/docs/jeep_lj/02-engine-systems/08-fuel-system.md
@@ -45,12 +45,6 @@ Return line → Fuel Tank
 
 The factory Jeep LJ in-tank electric fuel pump is **not used** in this configuration.
 
-## Installation Summary
-
-1. **Inlet:** Route fuel line from tank pickup → fuel filter/separator inlet
-2. **Filter to Pump:** Route from filter outlet → gear-driven pump inlet (back of block)
-3. **Return:** Route from engine return fitting → tank return
-
 ## Priming
 
 Use the manual hand pump on the fuel filter/water separator to prime the system before initial startup or after filter changes.

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/02-dashboard-cluster.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/02-dashboard-cluster.md
@@ -70,7 +70,7 @@ Drop-in replacement for factory TJ gauge cluster. Combines analog gauges with di
 See [HDX Control Module wiring table][hdx-control] for complete signal routing.
 
 !!! warning "Speedometer Required for Legal Operation"
-Speedometer is legally required for on-road vehicle operation. GPS-50-2 module provides speed data - ensure GPS antenna has clear sky view for reliable operation.
+Speed is GPS-derived via the GPS-50-2 module — see [GPS-50-2][bim-gps] for antenna placement and sky-view requirements.
 
 ## Outstanding Items
 

--- a/docs/jeep_lj/04-offroad-lighting/10-reverse-lights.md
+++ b/docs/jeep_lj/04-offroad-lighting/10-reverse-lights.md
@@ -50,14 +50,7 @@ High-output reverse lights that activate automatically via PMU reverse circuit.
 
 Wired in parallel with Maxbilt Round Trail Tail WHITE (reverse) and WolfBox camera trigger.
 
-See [Tail/Brake/Reverse Lights][tail-brake-reverse] for PMU reverse circuit details.
-
-**Load Verification:**
-
-- Squadron Sport pair: 2.8A
-- Maxbilt WHITE: ~2A
-- WolfBox trigger: negligible
-- **Total: ~5A** (PMU Out 22 capacity: 7A, 71% utilization)
+See [Tail/Brake/Reverse Lights][tail-brake-reverse] for PMU reverse circuit details and load breakdown.
 
 ## Related Documentation
 

--- a/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
+++ b/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
@@ -134,24 +134,7 @@ Recommended configuration for this build:
 
 ### PMU DRL Auto-Off Logic
 
-**Purpose:** Automatically turns off DRL when headlights are activated via CT4 SW3
-
-**Implementation:** PMU programming logic (no external relay needed)
-
-**PMU Configuration:**
-
-```text
-PMU Input 7 (In 7): CT4 SW3 headlight status signal (tapped from low beam circuit)
-PMU Pin 7: Ignition RUN signal (12V switched input)
-PMU Output 23 (Out 23): DRL/Parking lights circuit
-
-Programming Logic:
-IF (Pin7_IgnitionRUN == ON) AND (In7_CT4_Headlights == OFF)
-  THEN Out23_DRL = ON
-ELSE
-  Out23_DRL = OFF
-END
-```
+PMU programming logic disables DRL when CT4 SW3 (headlights) activates — no external relay needed. Full input/output config and operation-state table: [DRL & Parking][drl-parking].
 
 **Installation Notes:**
 


### PR DESCRIPTION
Prose and structure only. No number, part number, wire gauge, pin name, table row, TBD item, checkbox, frontmatter block, or `[ref]:` definition was changed. All reference-style links preserved.

| File | Lines before → after | What was cut | Which persona it failed |
| :--- | :--- | :--- | :--- |
| `02-engine-systems/07-grid-heater.md` | 115 → 85 | `System Architecture` section (re-listed the pins, currents, and duty cycle already in the Specifications table). Merged `Why Direct ECM Control` + `Power Distribution` into one `Design Rationale` section — both stated the same two decisions (ECM controls this, not the PMU; it feeds direct from the battery) that the removed section had also stated a first time. | Mechanic/Troubleshooter — three passes over the same spec table added no routing or signal-path information. Rationale itself is kept, stated once. |
| `05-control-interfaces/03-command-touch-ct4.md` | 228 → 211 | The `PMU DRL Auto-Off Logic` pseudocode block, duplicated near-verbatim from `03-lighting-systems/05-drl-parking.md`, which is authoritative (it also carries the Operation States walkthrough this page lacks). Replaced with a one-line cross-link. | Owner/Designer — same logic maintained in two places, so an edit to one silently drifts from the other. |
| `02-engine-systems/05-horn.md` | 82 → 70 | `Power Flow` (restated the ASCII wiring diagram directly above it, step for step) and `Notes` (restated two bullets verbatim from the PMU Configuration list above: "no external relay needed", "CONSTANT for safety"). | Mechanic/Troubleshooter — the diagram and config list already carry the full signal path. |
| `04-offroad-lighting/10-reverse-lights.md` | 71 → 64 | `Load Verification` block, identical to the `Load Breakdown` in `03-lighting-systems/04-tail-brake-reverse.md` (authoritative — it owns the PMU Out 22 circuit and the wiring steps this data supports). The page already linked there one line above; folded the load reference into that link. | Troubleshooter — two copies of one load budget is a drift risk, not extra help. |
| `02-engine-systems/08-fuel-system.md` | 66 → 60 | `Installation Summary` — three numbered steps that restated the `Fuel Flow Path` diagram above with no added detail. | Mechanic/Installer — routing already fully given by the diagram. |
| `02-engine-systems/09-gauge-cluster/02-dashboard-cluster.md` | 98 → 98 | Repeated GPS sky-view caution; `04-bim-gps.md` carries the fuller version (with obstruction examples). Warning now points there. | Mechanic/Installer — same caution in two files, the shorter copy being the less useful one. |

Net: 6 files, 84 changed lines.

## Verification

- `python3 -m mkdocs build --strict` — passes (exit 0). The one reported anchor warning (`03-command-touch-ct4.md` → `#wiring`) is pre-existing on `main` and untouched by this PR.
- `npx markdownlint-cli2 "docs/jeep_lj/**/*.md"` — the tree carries ~1161 pre-existing issues. Compared each edited file against its `main` version: same 6 findings before and after, identical rules and contexts, only line numbers shifted. **No new lint issues introduced.**

## Left for human judgment

Deliberately not changed — each is a real call, but not one an unattended pass should make:

- **`01-power-systems/STANDARDS-EXCEPTIONS.md` (592 lines)** — the largest and most repetitive file in the tree. It repeats "Do NOT flag …" six times, "This is NOT a marine application" twice, and a marine-vs-automotive standards comparison three times, then re-lists all seven decisions in two back-to-back closing sections. But the file's stated purpose is precisely to stop reviewers flagging these designs, so the per-section repetition is arguably functional rather than filler. Consolidating it (plausibly ~590 → ~200 lines with no fact lost) is a real win but needs an owner's call on whether the redundancy is load-bearing.
- **`07-wire-routing/02-firewall-ingress.md` — `Pin Budget Audit (Historical)` (~75 lines)** — the section opens by declaring itself superseded ("Final architecture documented above"), then re-derives the whole decision. It looks safe to reduce to two sentences, but doing so means deleting several tables, which this pass treats as untouchable.
- **`08-load-analysis/index.md` vs `03-aux-battery.md`** — both carry an AUX scenario summary table, and **the numbers disagree**: Night Offroad reads `70A / −20A / 102 min` in one and `45A / +5A / N/A (charging)` in the other; Winch Recovery `265A` vs `255A`; Camp Mode `76 min` vs `4 hours`. This is a data conflict, not verbosity — flagging it rather than picking a winner.
- **`04-pmu/05-pmu-arb-load-shedding.md`** — a conclusion about BCDC/battery capacity appears twice (lines ~18 and ~36), and a prose "Impact Without Load Shedding" list is superseded by a worked calculation later in the same file. Cutting either means deciding which framing the owner wants to keep.
- **Cross-file:** the "Current Draw: Negligible — bus-powered…" sentence is verbatim in all four BIM module pages; `01-hdx-control.md` owns the OUT9 power budget and is the natural single home. Left alone because the fix touches four files at once.
- **Not a verbosity issue, but surfaced during the survey:** `03-lighting-systems/06-dome-lights.md` and `05-control-interfaces/05-dashboard-controls.md` describe *different* physical switches (KC bracket switch vs. Blue Sea 4160) doing the same rear-dome-override job on OUTPUT-4. Possible spec conflict worth a look.

---
_Generated by [Claude Code](https://claude.ai/code/session_01FgfJeJ7NThSN3HHxwvQYeG)_