### PR TITLE
docs: nightly tidiness — trim verbosity (2026-08-20)

### DIFF
--- a/docs/jeep_lj/01-power-systems/01-power-generation/04-solar.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/04-solar.md
@@ -60,8 +60,6 @@ tags:
 - **Routing:** Hood → Firewall → BCDC location in passenger rear wheel well
 - **Maximum Current:** 2.23A (Isc) - well within BCDC solar input capacity
 
-**VSS System Note:** VSS kit includes standalone MPPT controller - **not used**. BCDC has built-in MPPT on solar input, providing Green Power Priority and unified charge control.
-
 **Important:** Solar negative connects to chassis ground per REDARC specifications. The BCDC requires a common ground system where all batteries and components share the same ground reference (vehicle chassis).
 
 ## Function
@@ -77,8 +75,6 @@ tags:
 - **Full sun:** ~5.8A to AUX battery (78W ÷ ~13.4V; reduces alternator load from 50A to ~44A)
 - **Partial sun:** Variable, proportional to available irradiance
 - **Overcast/Night:** 0A (BCDC uses alternator only)
-
-**Alternator Load Relief:** Minimal but measurable — reduces worst-case alternator load by ~5.8A during sunny daytime operation
 
 See [BCDC Alpha 50][bcdc] for complete charging system details.
 
@@ -134,8 +130,6 @@ Voltage Module Power: Self-powered from solar panel voltage
 
 - Mount module in weatherproof location (near BCDC in passenger rear wheel well, or sealed enclosure)
 - Use MC4 inline connectors for easy solar disconnect during installation
-- Consider conformal coating on PCB for moisture protection
-- Test threshold settings before final installation
 
 ### Alternative: Series Diode Voltage Drop
 

--- a/docs/jeep_lj/01-power-systems/07-wire-routing/04-harness-power-distribution.md
+++ b/docs/jeep_lj/01-power-systems/07-wire-routing/04-harness-power-distribution.md
@@ -26,8 +26,6 @@ Workbench specs for the high-current power harnesses: **H1** Passenger Rear Powe
 
 **Route:** Passenger rear wheel well (AUX battery) → up inside passenger rear quarter sill → forward along **inside floor board / side wall** (passenger side) → A-pillar area → **single sealed 2-piece grommet through firewall** (continuous cables, no firewall break) → engine bay → forward along passenger inner fender → through grille area → front bumper (winch portion only)
 
-**Length:** ~13 ft to firewall (all 3 cables); ~13 ft additional for winch cables continuing to bumper
-
 **Contains:**
 
 | Wire | Gauge | Color | Function | Termination at battery | Termination at firewall | Continues to |
@@ -36,13 +34,13 @@ Workbench specs for the high-current power harnesses: **H1** Passenger Rear Powe
 | Winch power (+) | 1/0 AWG | Red | AUX battery+ → winch contactor B+ | Ring lug to AUX battery+ stud | Continuous through grommet — no firewall break | Lug to winch contactor B+ |
 | Winch ground (−) | 1/0 AWG | Black | AUX battery- → winch contactor B− | Ring lug to AUX battery- stud | Continuous through grommet — no firewall break | Lug to winch motor / chassis at front |
 
-**Firewall pass-through:** **Single sealed 2-piece rubber grommet** sized for the ~1.5" OD bundle (~1.75" firewall hole). Cables run continuously from rear wheel well to their respective destinations — no service break at the firewall. The grommet seals the firewall penetration only; the cables themselves are uninterrupted.
+**Firewall pass-through:** **Single sealed 2-piece rubber grommet** sized for the ~1.5" OD bundle (~1.75" firewall hole).
 
 **Why continuous cables + grommet (not inline connectors or bulkhead studs):**
 
 - WARN install documentation references this approach as standard for winch firewall pass-through
 - No amperage limit at the pass-through (the cable is the conductor; grommet just seals the hole)
-- Common feed-through marine bulkhead studs (Blue Sea 2203/2204, Cole Hersee 46211) max at 250A continuous and were underrated for the winch leg (409A peak); continuous cable + grommet sidesteps any pass-through current limit (the cable is the conductor; the grommet only seals the hole)
+- Common feed-through marine bulkhead studs (Blue Sea 2203/2204, Cole Hersee 46211) max at 250A continuous and were underrated for the winch leg (409A peak); continuous cable + grommet sidesteps any pass-through current limit
 - Anderson SB175 is undersized for the winch leg (175A continuous); SBE320/SB350 would work but adds complexity
 - Service is rare in practice — when needed, pulling the entire cable end-to-end is acceptable
 - Steele Rubber or similar 2-piece grommet, ~$5–15
@@ -51,7 +49,6 @@ Workbench specs for the high-current power harnesses: **H1** Passenger Rear Powe
 
 **Notes:**
 
-- 3-cable bundle: ~1.5" OD final wrapped harness
 - Path is fully inside the body until firewall transition (no exposed frame rail)
 - Cables terminate as ring lugs at destinations (lug-to-stud at battery / CB / bus / contactor on each end). If a service break is ever desired, do it as a lug-to-lug junction inside the rear wheel well, not at the firewall.
 
@@ -65,8 +62,6 @@ Workbench specs for the high-current power harnesses: **H1** Passenger Rear Powe
 
 **Route:** Driver rear wheel well (START battery) → up inside driver rear quarter sill → forward along **inside floor board / side wall** (driver side) → A-pillar area → driver firewall penetration → engine bay
 
-**Length:** 6–8 ft per cable
-
 **Contains:**
 
 | Wire | Gauge | Color | Function | Termination at battery | Termination at engine bay |
@@ -78,7 +73,7 @@ Workbench specs for the high-current power harnesses: **H1** Passenger Rear Powe
 
 (BCDC input feed (4 AWG via 80A CB) takes the H3 cross-cab path instead — see [H3](#h3).)
 
-**Connectors:** Lug terminations at both ends. Heat sleeve required where bundle enters engine bay (>12" from exhaust). Bundle 4 cables with looms; expect ~1.6" OD final bundle. The 2 AWG forward-bus feed terminates at the engine-bay busbar, not at a load; the busbar's three short local feeds (fan, iBooster, TCU) are engine-bay-side and are **not** part of this harness — see [START+ Forward Distribution Bus][start-fwd-bus].
+**Connectors:** Lug terminations at both ends. Heat sleeve required where bundle enters engine bay (>12" from exhaust). Bundle 4 cables with looms; expect ~1.6" OD final bundle.
 
 **Protection:** Black braided expandable sleeve (yellow tracer) over the cabin / sill run, sized to the ~1.6" OD bundle. Heat sleeve in engine bay. P-clamps every 12–18".
 
@@ -99,8 +94,6 @@ Workbench specs for the high-current power harnesses: **H1** Passenger Rear Powe
 
 **Route:** Driver rear wheel well (START battery) → **under the rear bench seat cushion** → passenger rear wheel well (BCDC + AUX battery)
 
-**Length:** ~5–6 ft (straight cross-cab run under bench)
-
 **Contains:**
 
 | Wire | Gauge | Color | Function | Termination at driver well | Termination at passenger well |
@@ -108,13 +101,10 @@ Workbench specs for the high-current power harnesses: **H1** Passenger Rear Powe
 | BCDC input | 4 AWG | Red | START battery+ via 80A CB → BCDC input terminal | Lug to 80A CB output | Lug to BCDC input red terminal (M8) |
 | Cross-ground reference | 1/0 AWG | Black | START battery- → AUX battery- (critical for BCDC operation) | Lug to START battery- | Lug to AUX battery- |
 
-**Connectors:** Lug terminations both ends. No inline connectors needed for short run.
-
 **Protection:** Black braided expandable sleeve (green tracer) along the run. Bench cushion provides physical shielding from above; floor pan shields from below. P-clamps to body cross-member at 1–2 points.
 
 **Notes:**
 
-- Under-bench routing is short, dry, accessible, and physically protected (bench cushion above, floor pan below)
 - No frame rail exposure; no need to share the longer floor / side wall paths used by H1 / H2
 - BCDC sensor cable (~6 ft, 2-pin) is included with BCDC unit, runs to AUX battery+ terminal at the same wheel well — short, stays passenger-side, not part of this harness
 - Path is independent of cabin trunk runs (H1 passenger side, H2 driver side), so no cabin trunk congestion impact

--- a/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
+++ b/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
@@ -251,8 +251,6 @@ It is intentional adherence to:
 
 **Do NOT flag as critical safety issue** - cable sizing provides adequate protection for normal operation per SAE J1128.
 
-**Consider implementing timer relay as build enhancement** - provides additional fault protection beyond baseline automotive practice.
-
 **Documentation References:**
 
 - [Starter System][starter-system] - Complete starter specifications and wiring (line 1-125)
@@ -353,14 +351,9 @@ Grid heater brief, high-current load characteristics make circuit breaker unnece
 
 4. **Factory Practice**
    - No OEM vehicles use alternator output circuit breakers
-   - Proven safe over millions of vehicles
    - Industry standard approach
 
 ### Alternator Review Guidance
-
-**This is standard automotive practice.**
-
-Alternators NEVER use circuit breakers on output circuits in factory or aftermarket applications.
 
 **Do NOT flag as missing protection.**
 
@@ -542,15 +535,6 @@ The apparent CB > wire mismatch is intentional:
 ---
 
 ## Summary of Intentional Design Decisions
-
-**All decisions documented above are intentional and based on:**
-
-1. **Manufacturer Specifications** - Following OEM installation requirements
-2. **Automotive Standards (SAE J1128)** - Primary standard for automotive electrical systems
-3. **Industry Practice** - Factory vehicle precedents and proven approaches
-4. **Engineering Analysis** - Load characteristics, wire sizing, fault scenarios
-
-**These are NOT oversights, errors, or safety issues.**
 
 **Marine standards (ABYC E-11) are referenced selectively:**
 

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/03-bim-j1939.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/03-bim-j1939.md
@@ -73,9 +73,6 @@ Interfaces Cummins R2.8 ECM J1939 CAN bus data with HDX instrument system. Provi
 - Boost/MAP
 - Air/fuel ratio
 
-!!! info "ECM Data Availability"
-Specific J1939 parameters vary by ECM configuration and vehicle application. Cummins R2.8 ECM should provide tachometer, coolant temp, oil pressure, and check engine light at minimum. Additional parameters depend on ECM programming and connected sensors.
-
 ## Wiring
 
 | Connection   | Source                            | Destination    | Wire Gauge  | Notes                            |
@@ -101,12 +98,6 @@ Specific J1939 parameters vary by ECM configuration and vehicle application. Cum
 - Oil pressure (SPN 100) → Oil pressure gauge
 - Engine oil temp (SPN 175) → Available for display or logic (PMU oil cooler fan, OUT7)
 - Check engine light / MIL → Dashboard warning indicator
-
-**Firewall Routing:**
-
-- Cummins body harness routes through firewall (engine bay → cabin)
-- Tap J1939 CAN wires on cabin side of firewall
-- See [Firewall Ingress][firewall-ingress] for Cummins harness routing details
 
 ## Outstanding Items
 

--- a/docs/jeep_lj/08-exterior-systems/02-air-compressor.md
+++ b/docs/jeep_lj/08-exterior-systems/02-air-compressor.md
@@ -60,8 +60,6 @@ ARB Twin Compressor system with air tank and automatic pressure management for l
 - **Control:** SwitchPros OUTPUT-11 (15A output, Button 11)
   - OUTPUT-11 provides switched 12V control signal to compressor
   - Compressor has internal relay/control that handles high-current motor switching
-  - 14 AWG wire from OUTPUT-11 to compressor control terminal
-- **Ground:** 6 AWG black wire from compressor to AUX battery negative (direct connection for 90A return current)
 
 ## Wiring
 
@@ -148,8 +146,6 @@ ARB Twin Compressor system with air tank and automatic pressure management for l
 
 - **TRIGGER-3 Input:** Pressure switch signal (tank < 135 PSI activates trigger)
 - **OUTPUT-11 Logic:** Button 11 OR TRIGGER-3 → OUTPUT-11 (compressor)
-- **Manual Override:** Press Button 11 anytime to force compressor on (e.g., for tire inflation)
-- **Automatic Mode:** TRIGGER-3 maintains tank pressure 135-150 PSI without user intervention
 
 **Operational Modes:**
 

--- a/docs/jeep_lj/08-exterior-systems/03-air-lockers.md
+++ b/docs/jeep_lj/08-exterior-systems/03-air-lockers.md
@@ -54,16 +54,11 @@ ARB RD116 air-operated locking differentials for front and rear Dana 44 axles.
 ### Wire Routing
 
 - **Front Locker (OUTPUT-17):** SwitchPros (passenger rear wheel well) → along driver frame rail → to front axle solenoid (~12 ft)
-  - Wire: 18 AWG (2A load, low-side driver output)
   - Protection: Split loom, P-clamps every 18", secure to frame rail
 - **Rear Locker (OUTPUT-10):** SwitchPros (passenger rear wheel well) → to rear axle solenoid (~6 ft)
-  - Wire: 18 AWG (2A load)
   - Protection: Split loom where exposed, secure to axle housing
 
 ## Air Line Routing
-
-!!! info "Air Line Installation"
-    Air lines from manifold must be routed to both axles with proper protection from heat, abrasion, and road debris.
 
 | Line         | Route                                                          | Length |
 | ------------ | -------------------------------------------------------------- | ------ |


### PR DESCRIPTION
Nightly verbosity sweep. Prose and structure only — **no number, value, or identifier was changed**, and no TBD item, Outstanding Items checkbox, table row, frontmatter block, `div.product-info` block, or `[ref]:` definition was removed.

Six prior sweeps (2026-06-01 … 06-06) had already flattened the pages they touched, so this run targeted the ~56 docs that changed *after* the last sweep and have never been swept.

## Changes

| File | Lines | What was cut | Persona it failed |
| :--- | :--- | :--- | :--- |
| `01-power-systems/07-wire-routing/04-harness-power-distribution.md` | 145 → 135 | Three `**Length:**` lines whose figures are already in each harness's `**Build:**` line; the bundle-OD note (4th statement of `~1.5" OD`); H3's `**Connectors:**` line (verbatim in its `Build:`); the under-bench "short, dry, accessible" bullet (protection detail retained one line up); trailing sentences on the H1 pass-through and H2 connector lines restating the table's "continuous through grommet" and the busbar fan-out bullet | Mechanic — no gauge, source→destination, or caution not already on the same screen |
| `01-power-systems/STANDARDS-EXCEPTIONS.md` | 592 → 576 | The "Summary of Intentional Design Decisions" preamble (near-verbatim copy of the winch review guidance at L126–133, restated per-section five more times); the 3rd and 4th statements of the alternator no-CB conclusion; the unsourced "Proven safe over millions of vehicles"; the 4th statement of "timer relay is an optional enhancement" | Owner/Designer — same rationale, same file, 5th telling. The ABYC selective-application statement and the review checklist are untouched |
| `02-engine-systems/09-gauge-cluster/03-bim-j1939.md` | 136 → 127 | The `**Firewall Routing:**` block — a strictly weaker restatement of the `**J1939 Connection:**` bullets 14 lines above (those name the tap-connector type), with its cross-link already present under Related Documentation; the `ECM Data Availability` admonition, which paraphrases the three parameter lists directly above it **and was rendering broken** (unindented body) | Installer / Troubleshooter — nothing the bullets above don't give |
| `01-power-systems/01-power-generation/04-solar.md` | 165 → 159 | The `**VSS System Note:**` duplicating the `product-info` MPPT note (Green Power Priority survives at L73); `**Alternator Load Relief:** Minimal but measurable` (the quantified version with `~5.8A` is two lines up); "Consider conformal coating…"; "Test threshold settings…" (the Build Task carries the same step *with* the 47V/44V values) | Designer — hedged and unquantified where a quantified copy already exists |
| `08-exterior-systems/02-air-compressor.md` | 191 → 187 | Control-wire and ground bullets restating the Wiring table rows nine lines below; the Manual Override / Automatic Mode bullets restating the Operational Modes table four lines below | Mechanic / Troubleshooter — identical source→destination, gauge and reason in the adjacent table |
| `08-exterior-systems/03-air-lockers.md` | 132 → 127 | Two `Wire: 18 AWG (2A load)` sub-bullets (both figures in the Solenoid Control and spec tables on the same screen); the `Air Line Installation` admonition ("proper protection from heat, abrasion, and road debris") superseded 15 lines later by a Protection list naming split loom, P-clamp spacing, silicone sleeve, and the 6" exhaust clearance | Installer — generic practice with no build-specific content |

**Net: 3 insertions, 53 deletions across 6 files.**

## Verification

- `python3 -m mkdocs build --strict` — **passes** (exit 0). The one `INFO` anchor warning (`03-command-touch-ct4.md` → `#wiring`) is pre-existing and in a file this PR does not touch.
- `npx markdownlint-cli2 "docs/jeep_lj/**/*.md"` — **does not pass, and does not pass on `main` either.** Error counts per file were captured before and after: all six edited files are **identical** to `main` (8 / 38 / 1 / 4 / 9 / 2). This PR adds zero lint errors. Worth noting separately that lint is red repo-wide (~1,000 errors, mostly `MD060` table alignment, incl. the generated `tbd-tracker.md`) and is not enforced by any workflow in `.github/workflows/`.

## Left for human judgment

Found and deliberately **not** acted on:

1. **`08-load-analysis/index.md` L33–59 — "Why Not Sum All Loads?" (27 lines).** Reproduced verbatim from the "Load Analysis Guidelines" section of `docs/jeep_lj/CLAUDE.md`, and its `Example - CORRECT` block carries figures (`70A`, `102 minutes`) that disagree with the current `03-aux-battery.md`. It reads as analyst guidance rather than build documentation, but it is also arguably rationale — and it is a 27-line deletion. Your call.
2. **`08-load-analysis/index.md` AUX summary table vs `03-aux-battery.md`.** They disagree on nearly every row: Night Highway `38A/+12A` vs `35A/+15A`; Night Offroad `70A/−20A/102 min` vs `45A/+5A/charging`; Air Up Extended `34 min` vs `108 min`; Winch `265A/−215A` vs `255A/−205A`; Camp Mode `76 min` vs `4 hours`. Numbers — untouchable here, but one side is stale.
3. **`03-command-touch-ct4.md` L139 contradicts L67, L104 and checkbox L185.** L139 says the DRL auto-off needs "no external relay"; the others all specify a physical DRL cutoff relay with SW3 tapped to its coil. A design contradiction, not a wording problem.
4. **`09-installation/03-purchase-tracker.md` L150** still lists a center-off momentary **rocker** for winch control, which `05-dashboard-controls.md` L88 explicitly rejected in favour of `CH4X4-TOY-D-WINIO` (dual-momentary push). Stale buy-list row pointing at a rejected part — it's a table row, so untouched.
5. **HDP24-24-29 pin count disagrees across three files:** `02-firewall-ingress.md` L192 and `07-wire-routing/index.md` L131 say `17 used / 12 spare`; `03-harness-inventory.md` L211 says `18 used / 11 spare`.
6. **`02-firewall-ingress.md` L275–284** ("Alternative: Split into two connectors" + "Implementation order"). Sits inside a section marked *Historical*, and both are superseded — the build *did* split into two connectors, and the step-1 quantities conflict with the BOM table below. Cutting requires deciding which is authoritative.
7. **`10-drivetrain/01-transmission.md` L173** hedges "Exact pinout depends on controller selection (Compushift vs US Shift)", but the page elsewhere records Turbolamik TCU 2.0 as selected. Left alone because deleting it might erase a genuinely open pinout question that should become a TBD issue instead.
8. **`03-air-lockers.md` L96–101** — the Rear Locker engagement sequence is word-for-word the Front sequence with the button/output numbers swapped. Merging them is a real ~6-line win but needs a rewrite of the Front block, which is more than a trim.
9. **`03-harness-inventory.md` L17–23** ("Use these docs to:") — meta-content about how to read the page. Defensible cut, but it shades into style preference.
10. **`09-installation/01-power-systems-checklist.md`** — L56 duplicates L141 verbatim, and L54 duplicates L112. Checkbox items, so untouched by rule.

## Note on the branch

The routine specifies branch `tidy/2026-08-20`, but this session is pinned by its environment to the designated branch `claude/clever-ptolemy-0svcdz`, so the work landed there instead. Nothing was pushed to `main`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XRNSJsRZUNA8FdgHyTnQUc)_