### PR TITLE
docs: nightly tidiness — trim verbosity (2026-08-21)

### DIFF
--- a/docs/jeep_lj/02-engine-systems/05-horn.md
+++ b/docs/jeep_lj/02-engine-systems/05-horn.md
@@ -59,11 +59,6 @@ START battery CONSTANT → PMU → Out 18 → PIAA Horns (5.4A) → Chassis Grou
 3. PMU Out 18 activated when In 1 closes
 4. PMU Out 18 → PIAA horns (5.4A) → chassis ground (engine bay)
 
-**Notes:**
-
-- PMU Out 18 switches directly (no external relay needed)
-- Works with ignition off (CONSTANT power for safety)
-
 ## Outstanding Items
 
 {{ tbds() }}

--- a/docs/jeep_lj/02-engine-systems/07-grid-heater.md
+++ b/docs/jeep_lj/02-engine-systems/07-grid-heater.md
@@ -50,7 +50,7 @@ tags:
 
 2. **Grid Heater Relay (Cummins 5467024):**
    - Coil Power: ECM pins 46/21 (~1A) - direct connection
-   - Main Power: Direct from START battery+ via fusible link (bypasses all bus bars and PMU)
+   - Main Power: Direct from START battery+ via fusible link (bypasses all bus bars and PMU) — the brief 40-80A pulse doesn't warrant routing through distribution; direct connection minimizes voltage drop
    - Main Ground: START battery- or NEGATIVE bus
    - Output: 80A to grid heater element (design value - verify via resistance measurement during installation)
    - Protection: Integrated fusible link
@@ -90,16 +90,6 @@ flowchart LR
 - ECM knows optimal grid heater timing for cold starts
 - Eliminates unnecessary complexity of PMU passthrough
 - Frees PMU output slots for other critical systems
-
-## Power Distribution
-
-**Bypasses all distribution systems:**
-
-- Does NOT use CONSTANT bus bar
-- Does NOT use PMU outputs
-- Direct battery connection with fusible link protection
-
-**Reason:** High current draw (40-80A) for very short duration (3-5 seconds). Direct connection minimizes voltage drop and connection complexity.
 
 ## Outstanding Items
 

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/03-bim-j1939.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/03-bim-j1939.md
@@ -39,7 +39,7 @@ Interfaces Cummins R2.8 ECM J1939 CAN bus data with HDX instrument system. Provi
 - **Compatible ECUs:** Cummins R2.8, Mercury Racing SBF, BIGStuff EFI
 - **Wiring:** CAN High, CAN Low (twisted pair)
 - **Power:** Via BIM harness from HDX control
-- **Current Draw:** Negligible — bus-powered via the HDX BIM/IO cable (no separate feed); draw is included in the HDX system budget on PMU OUT9 (25A cap, ~12A typ). Dakota Digital publishes no per-module current for these data modules (only power modules like the BIM-RGB, 7.4A, list a figure).
+- **Current Draw:** Negligible — bus-powered via the HDX BIM/IO cable; included in the [system power budget][gauge-system].
 
 ## J1939 Data Available
 

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/04-bim-gps.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/04-bim-gps.md
@@ -41,7 +41,7 @@ GPS-based speedometer, compass, altimeter, and clock sync module. Eliminates nee
 - **Accuracy:** ±0.1 MPH (GPS-dependent)
 - **Output Signals:** 4k, 8k, 16k PPM (selectable)
 - **Signal Types:** Sine wave or square wave (configurable)
-- **Current Draw:** Negligible — bus-powered via the HDX BIM/IO cable (no separate feed); draw is included in the HDX system budget on PMU OUT9 (25A cap, ~12A typ). Dakota Digital publishes no per-module current for these data modules (only power modules like the BIM-RGB, 7.4A, list a figure).
+- **Current Draw:** Negligible — bus-powered via the HDX BIM/IO cable; included in the [system power budget][gauge-system].
 - **Antenna:** Integrated omni-directional (optional external antenna available)
 - **Warranty:** 2 years
 

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/05-bim-tpms.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/05-bim-tpms.md
@@ -41,7 +41,7 @@ Wireless TPMS module displaying real-time tire pressure for all four wheels on H
 - **Communication:** Wireless RF (sensors → BIM-22-3 receiver)
 - **Display:** Dashboard message center shows all 4 tire pressures
 - **Programming:** Sensors easily reprogrammed via Bluetooth app
-- **Current Draw:** Negligible — bus-powered via the HDX BIM/IO cable (no separate feed); draw is included in the HDX system budget on PMU OUT9 (25A cap, ~12A typ). Dakota Digital publishes no per-module current for these data modules (only power modules like the BIM-RGB, 7.4A, list a figure).
+- **Current Draw:** Negligible — bus-powered via the HDX BIM/IO cable; included in the [system power budget][gauge-system].
 - **Compatibility:** HDX, RTX, GRFX systems (limited VFD3/VHX compatibility)
 
 ## Display Integration

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/06-bim-compass.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/06-bim-compass.md
@@ -39,7 +39,7 @@ tags:
 - Directions: 8-point (N, NE, E, SE, S, SW, W, NW)
 - Internal Resolution: 1° (displayed as 8 directions)
 - Calibration: Automatic via internal accelerometers
-- Current Draw: Negligible — bus-powered via the HDX BIM/IO cable (no separate feed); draw is included in the HDX system budget on PMU OUT9 (25A cap, ~12A typ). Dakota Digital publishes no per-module current for these data modules (only power modules like the BIM-RGB, 7.4A, list a figure).
+- Current Draw: Negligible — bus-powered via the HDX BIM/IO cable; included in the [system power budget][gauge-system].
 
 **Temperature (SEN-15-1 Sender Included):**
 

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/index.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/index.md
@@ -9,7 +9,7 @@ hide:
 
 Complete digital instrumentation system replacing factory TJ gauge cluster. HDX control module processes sensor inputs and BIM module data to drive analog/digital hybrid dashboard display.
 
-**Power:** [PMU OUT9][pmu-outputs] (25A capacity, ~25A worst-case, ~12A typical)
+**Power:** [PMU OUT9][pmu-outputs] (25A capacity, ~25A worst-case, ~12A typical). Expansion modules are bus-powered via the BIM/IO daisy-chain (no separate feed) and their draw is included in this budget — Dakota Digital publishes no per-module current for these data modules (only power modules like the BIM-RGB, 7.4A, list a figure).
 
 **Mounting:** Dashboard cluster in factory location, HDX control + BIM modules on HDPE firewall panel
 

--- a/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
+++ b/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
@@ -57,41 +57,27 @@ tags:
 ### Headlight Control
 
 - **Headlights (SW3 - PULL):** Baja Designs LP6 headlights (low beam)
-  - **Pull lever** → Activates headlights (low beam)
-  - Power: PMU Out 13 (CONSTANT) → CT4 internal switching → SW3 output
-  - CT4 SW3 output → LP6 Pin 1 (low beam, both lights in parallel)
-  - CT4 handles switching internally (10A output capacity, 3.6A actual load)
-  - Disabled when ignition off (via ignition signal from ignition switch RUN)
-  - Latching on/off control (pull once to turn on, pull again to turn off)
+  - **Pull lever** → Activates headlights (low beam); pull again to turn off (latching)
   - Wire gauge: 14 AWG from CT4 SW3 output to LP6 headlights
   - When active: Also triggers DRL cutoff relay to disable DRL circuit (SW3 output tapped to relay coil)
 
 - **High Beams (SW4 - PUSH):** Switches to high beams
-  - **Push lever** (while headlights on) → Activates high beams
-  - Power: PMU Out 13 (CONSTANT) → CT4 internal switching → SW4 output
-  - CT4 SW4 output → LP6 Pin 4 (high beam, both lights in parallel)
-  - CT4 handles switching internally (10A output capacity, 5.6A actual load)
-  - Disabled when ignition off (via ignition signal from ignition switch RUN)
-  - CT4 provides mutual exclusivity (high beam disables low beam automatically)
+  - **Push lever** (while headlights on) → Activates high beams; mutual exclusivity disables low beam automatically
   - Momentary or latching toggle (programmable)
   - Wire gauge: 14 AWG from CT4 SW4 output to LP6 headlights
 
 ### DRL/Parking Lights
 
-Automatic ignition-controlled circuit that powers:
+Automatic ignition-controlled circuit (PMU Out 23) that powers:
 
 - License plate lights
 - LP6 Headlight DRL function (Pin 3) - **via cutoff relay**
 - Front 2" LED side markers (parking function)
 - Maxbilt tail light RED wire (marker/parking function)
 
-**Power Source:** PMU Out 23 (7A capacity, ~2.6A load, auto with ignition)
-
-**DRL Auto-Off:** PMU programming logic disables when CT4 SW3 activates (headlights on = DRL off)
-
 Wire gauge: 14 AWG from PMU to junction, 16 AWG to each light
 
-See [PMU DRL Auto-Off Logic](#pmu-drl-auto-off-logic) section below for complete wiring.
+See [DRL & Parking][drl-parking] for power source, auto-off logic, and the full load breakdown.
 
 ## Wiring Pinout
 
@@ -134,31 +120,7 @@ Recommended configuration for this build:
 
 ### PMU DRL Auto-Off Logic
 
-**Purpose:** Automatically turns off DRL when headlights are activated via CT4 SW3
-
-**Implementation:** PMU programming logic (no external relay needed)
-
-**PMU Configuration:**
-
-```text
-PMU Input 7 (In 7): CT4 SW3 headlight status signal (tapped from low beam circuit)
-PMU Pin 7: Ignition RUN signal (12V switched input)
-PMU Output 23 (Out 23): DRL/Parking lights circuit
-
-Programming Logic:
-IF (Pin7_IgnitionRUN == ON) AND (In7_CT4_Headlights == OFF)
-  THEN Out23_DRL = ON
-ELSE
-  Out23_DRL = OFF
-END
-```
-
-**Installation Notes:**
-
-- Tap CT4 SW3 output (low beam circuit) to PMU In 7 for headlight status monitoring
-- Run wire from PMU Out 23 to DRL junction
-- Total DRL/parking circuit load: ~2.6A — see [DRL & Parking][drl-parking] for the itemized load breakdown and wiring
-- PMU Out 23 capacity: 7A (sufficient for the ~2.6A load)
+Automatically turns off DRL when headlights are activated via CT4 SW3, via PMU programming logic (no external relay needed). Tap CT4 SW3 output (low beam circuit) to PMU In 7 for headlight status monitoring. Full programming logic, wiring, and load breakdown: see [DRL & Parking][drl-parking].
 
 ## Installation Checklist
 

--- a/docs/jeep_lj/08-exterior-systems/index.md
+++ b/docs/jeep_lj/08-exterior-systems/index.md
@@ -16,21 +16,6 @@ Recovery equipment and air systems for offroad capability.
 | [8.3][air-lockers] | ARB Air Lockers | RD116 front/rear Dana 44 lockers |
 | [8.4][rear-air-chuck] | Rear Air Chuck | External air access in tailgate area |
 
-## System Overview
-
-**Recovery:**
-
-- Warn Zeon 10-S winch (10,000 lb capacity, 409A peak)
-- Direct AUX battery connection (1/0 AWG, no external breaker)
-- Dash rocker switch + factory wired remote
-
-**Air System:**
-
-- ARB Twin Compressor (brushless, 90A draw)
-- 1-gallon air tank (135-150 PSI automatic pressure)
-- ARB front/rear air lockers (RD116)
-- Rear air chuck plate for tire inflation
-
 ## Power Distribution
 
 | Component      | Power Source            | Protection      | Control            |


### PR DESCRIPTION
Nightly tidiness pass per `docs/jeep_lj/CLAUDE.md`'s **BE SUCCINCT** rule. Read all 108 non-CLAUDE.md pages under `docs/jeep_lj/`; edited the 6 pages (9 files — a couple of fixes needed a matching edit in a linked page) with the clearest, highest-confidence wins. No specs, numbers, wire gauges, part numbers, or link targets were touched — only redundant prose.

Total diff: 9 files, 11 insertions / 79 deletions.

| File | Lines before → after | What was cut | Persona it failed |
| :--- | :--- | :--- | :--- |
| `02-engine-systems/05-horn.md` | 83 → 78 | "Notes" section restating facts already given in "PMU Configuration" two paragraphs up | Mechanic/Installer |
| `02-engine-systems/07-grid-heater.md` | 116 → 106 | "Power Distribution" section duplicating "System Architecture" item 2; folded its one new fact (brief pulse → minimizes voltage drop) into that bullet | Mechanic/Installer |
| `02-engine-systems/09-gauge-cluster/03-bim-j1939.md` | 137 → 137 | Verbatim "Current Draw" paragraph (identical across 4 BIM pages) trimmed to a cross-link | Owner/Designer |
| `02-engine-systems/09-gauge-cluster/04-bim-gps.md` | 102 → 102 | Same verbatim paragraph, same fix | Owner/Designer |
| `02-engine-systems/09-gauge-cluster/05-bim-tpms.md` | 95 → 95 | Same verbatim paragraph, same fix | Owner/Designer |
| `02-engine-systems/09-gauge-cluster/06-bim-compass.md` | 110 → 110 | Same verbatim paragraph, same fix | Owner/Designer |
| `02-engine-systems/09-gauge-cluster/index.md` | 47 → 47 | Added the one caveat sentence (moved from the 4 BIM pages) to the system overview so it stays the single source | — (receiving page for the fix above) |
| `05-control-interfaces/03-command-touch-ct4.md` | 229 → 205 | SW3/SW4 bullets restating the adjacent Wiring Pinout table; DRL/Parking section restating `05-drl-parking.md`'s power source/auto-off facts; a full PMU-programming code block duplicated verbatim from `05-drl-parking.md` | Mechanic/Installer, Owner/Designer |
| `08-exterior-systems/index.md` | 61 → 46 | "System Overview" section restating the Contents table two sections above | Mechanic/Installer |

## Left for human judgment

- **`docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md`** — has real internal redundancy (e.g. winch "Protection Mechanisms" vs. "Winch Fault Scenarios Covered" restate the same facts; "NOT a marine application" appears 3×). Didn't touch it: this file's stated purpose is to stand up to a future reviewer reading *any single subsection* in isolation ("prevent future reviews from flagging intentional design decisions as oversights"), so some of its repetition may be deliberate robustness rather than verbosity. Flagging for a human call on whether to consolidate.
- **`01-power-systems/04-pmu/05-pmu-arb-load-shedding.md`** — the "load shedding provides additional margin" conclusion is stated three times across ~25 lines, and there's a generic "increase engine RPM" tip with sub-bullets that are true of any alternator, not build-specific. Left for a future night — didn't want to touch PMU load-shedding logic in the same pass as the ARB findings without more scrutiny.
- **Several other cross-file rationale duplications surfaced by the survey** (XL Sport pod-current correction repeated in `08-load-analysis/01-scenarios.md` and `03-aux-battery.md`; reverse-light load calc repeated in `04-offroad-lighting/10-reverse-lights.md` and `03-lighting-systems/04-tail-brake-reverse.md`; footwell LED pin mapping repeated in `06-audio-systems/05-led-controller.md` and `04-offroad-lighting/09-footwell-lights.md`; front/rear axle footnotes duplicated verbatim) — all legitimate candidates, deferred to keep tonight's diff small and reviewable per the routine's own scope guardrail.

## Verification

- `python3 -m mkdocs build --strict` — passes (exit 0), no broken links/anchors introduced.
- `npx markdownlint-cli2 "docs/jeep_lj/**/*.md"` — pre-existing errors only (confirmed via before/after diff on the 9 edited files: identical error sets, only line numbers shifted). The repo currently has ~1,160 pre-existing lint issues across 71 files unrelated to this change (`.markdownlint.json`'s rule overrides don't appear to be picked up by `.markdownlint-cli2.jsonc`, and no CI workflow runs markdownlint) — out of scope for a verbosity-trim pass.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RGM4SpxZe3XYgCCvJaQfjB)_