### PR TITLE
docs: nightly tidiness — trim verbosity (2026-08-22)

### DIFF
--- a/docs/jeep_lj/01-power-systems/01-power-generation/04-solar.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/04-solar.md
@@ -70,15 +70,13 @@ tags:
 
 **Panel-side vs battery-side current:** The 1.95A figure is the panel-side current at the panel's ~40V operating voltage (40V × 1.95A ≈ 78W). The BCDC's MPPT steps that down to the battery charge voltage, so the battery-side contribution is higher: 78W ÷ ~13.4V ≈ **~5.8A to the AUX battery**.
 
-**BCDC Green Power Priority:** Solar input used first when available, alternator supplements to reach 50A total charging current. In full sun, solar contributes ~5.8A battery-side, reducing alternator load by the same amount.
+**BCDC Green Power Priority:** Solar input used first when available, alternator supplements to reach 50A total charging current.
 
 **Charging Contribution (battery-side):**
 
 - **Full sun:** ~5.8A to AUX battery (78W ÷ ~13.4V; reduces alternator load from 50A to ~44A)
 - **Partial sun:** Variable, proportional to available irradiance
 - **Overcast/Night:** 0A (BCDC uses alternator only)
-
-**Alternator Load Relief:** Minimal but measurable — reduces worst-case alternator load by ~5.8A during sunny daytime operation
 
 See [BCDC Alpha 50][bcdc] for complete charging system details.
 

--- a/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
@@ -33,13 +33,7 @@ Usable capacity (80% DOD):  108Ah
 Time to 20% SOC:           ~144 minutes continuous (2.4 hours)
 ```
 
-The Dakota Lithium 135Ah combined with 50A BCDC makes extended air-up a non-issue. Load shedding provides additional margin and maintains optimal voltage for electronics.
-
-**Impact Without Load Shedding:**
-
-- Minor: AUX battery still has comfortable margin at 50A BCDC
-- START battery loads reduce BCDC charging efficiency slightly
-- Load shedding maximizes available margin for extended sessions
+The Dakota Lithium 135Ah combined with 50A BCDC makes extended air-up a non-issue on its own; load shedding below is additional margin, not a requirement.
 
 ## Solution Overview
 

--- a/docs/jeep_lj/02-engine-systems/07-grid-heater.md
+++ b/docs/jeep_lj/02-engine-systems/07-grid-heater.md
@@ -46,11 +46,11 @@ tags:
 1. **ECM Control (Direct):**
    - ECM triggers grid heater relay directly via pins 46/21 (~0.5-1A)
    - ECM manages timing, temperature thresholds, and duty cycle
-   - No PMU involvement - ECM knows engine temperature better than external controller
+   - No PMU involvement (see [Why Direct ECM Control](#why-direct-ecm-control))
 
 2. **Grid Heater Relay (Cummins 5467024):**
    - Coil Power: ECM pins 46/21 (~1A) - direct connection
-   - Main Power: Direct from START battery+ via fusible link (bypasses all bus bars and PMU)
+   - Main Power: Direct from START battery+ via fusible link (bypasses all bus bars and PMU — minimizes voltage drop for the 40-80A/3-5s draw)
    - Main Ground: START battery- or NEGATIVE bus
    - Output: 80A to grid heater element (design value - verify via resistance measurement during installation)
    - Protection: Integrated fusible link
@@ -90,16 +90,6 @@ flowchart LR
 - ECM knows optimal grid heater timing for cold starts
 - Eliminates unnecessary complexity of PMU passthrough
 - Frees PMU output slots for other critical systems
-
-## Power Distribution
-
-**Bypasses all distribution systems:**
-
-- Does NOT use CONSTANT bus bar
-- Does NOT use PMU outputs
-- Direct battery connection with fusible link protection
-
-**Reason:** High current draw (40-80A) for very short duration (3-5 seconds). Direct connection minimizes voltage drop and connection complexity.
 
 ## Outstanding Items
 

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/03-bim-j1939.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/03-bim-j1939.md
@@ -39,7 +39,7 @@ Interfaces Cummins R2.8 ECM J1939 CAN bus data with HDX instrument system. Provi
 - **Compatible ECUs:** Cummins R2.8, Mercury Racing SBF, BIGStuff EFI
 - **Wiring:** CAN High, CAN Low (twisted pair)
 - **Power:** Via BIM harness from HDX control
-- **Current Draw:** Negligible — bus-powered via the HDX BIM/IO cable (no separate feed); draw is included in the HDX system budget on PMU OUT9 (25A cap, ~12A typ). Dakota Digital publishes no per-module current for these data modules (only power modules like the BIM-RGB, 7.4A, list a figure).
+- **Current Draw:** Negligible — bus-powered via the HDX BIM/IO cable, included in the [system power budget][gauge-system] on PMU OUT9.
 
 ## J1939 Data Available
 

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/04-bim-gps.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/04-bim-gps.md
@@ -41,7 +41,7 @@ GPS-based speedometer, compass, altimeter, and clock sync module. Eliminates nee
 - **Accuracy:** ±0.1 MPH (GPS-dependent)
 - **Output Signals:** 4k, 8k, 16k PPM (selectable)
 - **Signal Types:** Sine wave or square wave (configurable)
-- **Current Draw:** Negligible — bus-powered via the HDX BIM/IO cable (no separate feed); draw is included in the HDX system budget on PMU OUT9 (25A cap, ~12A typ). Dakota Digital publishes no per-module current for these data modules (only power modules like the BIM-RGB, 7.4A, list a figure).
+- **Current Draw:** Negligible — bus-powered via the HDX BIM/IO cable, included in the [system power budget][gauge-system] on PMU OUT9.
 - **Antenna:** Integrated omni-directional (optional external antenna available)
 - **Warranty:** 2 years
 

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/05-bim-tpms.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/05-bim-tpms.md
@@ -41,7 +41,7 @@ Wireless TPMS module displaying real-time tire pressure for all four wheels on H
 - **Communication:** Wireless RF (sensors → BIM-22-3 receiver)
 - **Display:** Dashboard message center shows all 4 tire pressures
 - **Programming:** Sensors easily reprogrammed via Bluetooth app
-- **Current Draw:** Negligible — bus-powered via the HDX BIM/IO cable (no separate feed); draw is included in the HDX system budget on PMU OUT9 (25A cap, ~12A typ). Dakota Digital publishes no per-module current for these data modules (only power modules like the BIM-RGB, 7.4A, list a figure).
+- **Current Draw:** Negligible — bus-powered via the HDX BIM/IO cable, included in the [system power budget][gauge-system] on PMU OUT9.
 - **Compatibility:** HDX, RTX, GRFX systems (limited VFD3/VHX compatibility)
 
 ## Display Integration

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/06-bim-compass.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/06-bim-compass.md
@@ -39,7 +39,7 @@ tags:
 - Directions: 8-point (N, NE, E, SE, S, SW, W, NW)
 - Internal Resolution: 1° (displayed as 8 directions)
 - Calibration: Automatic via internal accelerometers
-- Current Draw: Negligible — bus-powered via the HDX BIM/IO cable (no separate feed); draw is included in the HDX system budget on PMU OUT9 (25A cap, ~12A typ). Dakota Digital publishes no per-module current for these data modules (only power modules like the BIM-RGB, 7.4A, list a figure).
+- Current Draw: Negligible — bus-powered via the HDX BIM/IO cable, included in the [system power budget][gauge-system] on PMU OUT9.
 
 **Temperature (SEN-15-1 Sender Included):**
 

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/index.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/index.md
@@ -11,6 +11,8 @@ Complete digital instrumentation system replacing factory TJ gauge cluster. HDX 
 
 **Power:** [PMU OUT9][pmu-outputs] (25A capacity, ~25A worst-case, ~12A typical)
 
+**Expansion module power:** BIM modules are bus-powered via the HDX control box's BIM/IO daisy-chain — no separate feed per module, and their draw is already included in the OUT9 budget above. Dakota Digital publishes no per-module current for these data modules (only power modules like the BIM-RGB, 7.4A, list a figure).
+
 **Mounting:** Dashboard cluster in factory location, HDX control + BIM modules on HDPE firewall panel
 
 ## System Components

--- a/docs/jeep_lj/06-audio-systems/04-subwoofer.md
+++ b/docs/jeep_lj/06-audio-systems/04-subwoofer.md
@@ -50,14 +50,7 @@ Each sub runs on its own dedicated bridged channel pair on the JL Audio MV800/8i
 | **Bridged @ 4Ω per sub**  |       4Ω       |      200W       | **200W** | ✅ 100% of RMS rating |
 | Parallel both on one pair |       2Ω       |  n/a (bridged minimum is 4Ω) |   n/a    | ❌ Below bridged minimum |
 
-**Wiring path (per sub, both pairs identical):**
-
-```
-Amp Ch 1+2 (+/−) bridged → Sub A (+/−)
-Amp Ch 3+4 (+/−) bridged → Sub B (+/−)
-```
-
-Total amp output 400W into the pair (200W per sub) — exact RMS match, no headroom waste from series resistance, independent gain trim per side if the L/R quarter-panel locations end up acoustically asymmetric.
+Total amp output 400W into the pair (200W per sub) — exact RMS match.
 
 ## Infinite Baffle Requirements
 
@@ -82,7 +75,7 @@ Total amp output 400W into the pair (200W per sub) — exact RMS match, no headr
 | Sub B (+) / (−)       | 14 AWG | From amp Ch 3+4 bridged to Sub B voice coil        |
 | LED                   | 20 AWG | RGB from MLC-RW (one tap per sub)                  |
 
-Standard speaker wire (no XM-WHTMFC needed for subwoofer audio). No series jumper between subs — each sub returns directly to its own bridged channel pair.
+Standard speaker wire (no XM-WHTMFC needed for subwoofer audio).
 
 ## Why Two 8" vs Single 12"
 


### PR DESCRIPTION
Nightly tidiness pass per `docs/jeep_lj/CLAUDE.md` ("BE SUCCINCT"). No specs, numbers, part numbers, TBD items, or reference-link definitions were touched — prose and structure only.

| File | Lines before → after | What was cut | Which persona it failed |
| :--- | :-------------------- | :----------- | :----------------------- |
| `02-engine-systems/07-grid-heater.md` | 116 → 106 | Same "why direct ECM control, bypasses PMU" rationale was stated 3x (System Architecture step 1, a dedicated "Why Direct ECM Control" section, and a redundant "Power Distribution" section). Consolidated into the dedicated section; folded the one new fact (voltage-drop reasoning) into the architecture bullet. | Owner (rationale repeated, not additive) |
| `01-power-systems/01-power-generation/04-solar.md` | 166 → 162 | The "~5.8A to AUX battery" panel-side/battery-side calculation was restated 4x in a row (Function, Green Power Priority, Charging Contribution, Alternator Load Relief). Kept the one derivation + the spec-style bullet list, cut the two pure restatements. | Owner/Troubleshooter (same number, no new info each time) |
| `06-audio-systems/04-subwoofer.md` | 117 → 110 | A "Wiring path" code block duplicated the comparison table directly above it and the connections table below it; a closing sentence restated the "no series resistance" rationale already given earlier in the same section. | Mechanic (duplicate of the actual wiring table) |
| `01-power-systems/04-pmu/05-pmu-arb-load-shedding.md` | 327 → 321 | A "Load shedding provides additional margin..." sentence appeared twice 18 lines apart, plus a vague "Impact Without Load Shedding" bullet list that just restated the margin conclusion with no new numbers. | Owner (restated conclusion, no new rationale) |
| `02-engine-systems/09-gauge-cluster/{index.md, 03-bim-j1939.md, 04-bim-gps.md, 05-bim-tpms.md, 06-bim-compass.md}` | index +2; each BIM page −1 | The exact same sentence ("Dakota Digital publishes no per-module current for these data modules...") was copy-pasted verbatim into all 4 BIM module pages. Moved it once into the section `index.md` (next to the OUT9 power budget it explains), each module page now links to it. | Owner (identical rationale copy-pasted across files — CLAUDE.md's own example of what to fix) |

Net: 9 files touched, +12/−35 lines (47 total changed lines).

## Verification

- `python3 -m mkdocs build --strict` — succeeds (exit 0), no new warnings on any touched file.
- `npx markdownlint-cli2 "docs/jeep_lj/**/*.md"` — the repo has pre-existing lint failures unrelated to this change (table-alignment/MD060 issues in `tbd-tracker.md` (generated), `CLAUDE.md`, `purchase-tracker.md`, `10-drivetrain/01-transmission.md` — none of which this PR is allowed to touch or introduced). Confirmed via before/after diff on each touched file that these edits introduce **zero new lint errors**; one pre-existing error (an unlabeled fenced code block) was incidentally removed along with the code block it belonged to.

## Left for human judgment

- **`01-power-systems/STANDARDS-EXCEPTIONS.md`** — heavily repetitive by design (each component section ends with its own "Do NOT flag as..." reminder, and repeats the same protection-mechanism list from two angles). Its stated purpose is exactly to be a standalone rebuttal per section for future reviewers, so I judged the repetition load-bearing rather than fluff and left it untouched rather than guess wrong.
- **`08-exterior-systems/01-winch.md` vs `05-control-interfaces/05-dashboard-controls.md`** — both describe the CH4X4 winch dash switch and its wiring path. `dashboard-controls.md` has the fuller spec (SKU, price, illumination colors); `winch.md`'s "Dash Rocker Switch" section describes a generic "center-off momentary rocker (SPDT/DPDT)" which reads inconsistently with the actual selected part (a dual independent momentary pushbutton, not a rocker) documented in `dashboard-controls.md`. That looks like it may be a stale correctness issue rather than pure verbosity, so I left it for a human to decide whether it needs a content fix (out of scope for a tidiness-only pass).

---
_Generated by [Claude Code](https://claude.ai/code/session_01RhkfDCEnSWgK64o6wS7d67)_