### PR TITLE
docs: nightly tidiness — trim verbosity (2026-08-25)

### DIFF
--- a/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
@@ -15,7 +15,7 @@ Automatic load management during ARB compressor operation to preserve AUX batter
 - **BCDC Charging (50A max):** Replenishes AUX battery from alternator
 - **Net AUX battery drain:** 90A - 50A = 40A during compressor operation
 
-The alternator is NOT overloaded during ARB operation. The 50A BCDC significantly reduces net discharge rate, making extended air-up practical. Load shedding provides additional margin and maintains optimal voltage.
+The alternator is NOT overloaded during ARB operation — the compressor draws from AUX, not the alternator directly.
 
 ## Problem Statement
 
@@ -39,7 +39,6 @@ The Dakota Lithium 135Ah combined with 50A BCDC makes extended air-up a non-issu
 
 - Minor: AUX battery still has comfortable margin at 50A BCDC
 - START battery loads reduce BCDC charging efficiency slightly
-- Load shedding maximizes available margin for extended sessions
 
 ## Solution Overview
 

--- a/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
+++ b/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
@@ -123,16 +123,7 @@ This document tracks intentional deviations from general electrical standards wh
 
 ### Winch Review Guidance
 
-**This is NOT an oversight or safety issue.**
-
-It is intentional adherence to:
-
-1. Manufacturer specifications (WARN)
-2. Automotive standards (SAE J1128)
-3. Industry standard practice (factory winch installations)
-4. Engineering analysis (load, wire sizing, fault scenarios)
-
-**Do NOT flag as requiring correction in future reviews.**
+**Do NOT flag as requiring correction in future reviews** - intentional per WARN spec, SAE J1128, factory precedent, and the engineering analysis above.
 
 **Documentation References:**
 
@@ -306,11 +297,7 @@ It is intentional adherence to:
 
 ### Grid Heater Review Guidance
 
-**This is intentional per manufacturer specifications.**
-
-Grid heater brief, high-current load characteristics make circuit breaker unnecessary - fusible link and ECM control provide adequate protection.
-
-**Do NOT flag as requiring circuit breaker.**
+**Do NOT flag as requiring circuit breaker** - intentional per manufacturer spec; the brief load is covered by the fusible link and ECM control above.
 
 **Documentation References:**
 
@@ -358,11 +345,7 @@ Grid heater brief, high-current load characteristics make circuit breaker unnece
 
 ### Alternator Review Guidance
 
-**This is standard automotive practice.**
-
-Alternators NEVER use circuit breakers on output circuits in factory or aftermarket applications.
-
-**Do NOT flag as missing protection.**
+**Do NOT flag as missing protection** - standard automotive practice; see the self-limiting/cable/buffer/factory-precedent analysis above.
 
 **Documentation References:**
 
@@ -400,11 +383,7 @@ Alternators NEVER use circuit breakers on output circuits in factory or aftermar
 
 ### BCDC Review Guidance
 
-**Circuit breaker AT BATTERY TERMINAL is correct protection point.**
-
-No additional CB required at BCDC - entire circuit protected from battery terminal CB.
-
-**Do NOT flag as missing protection at BCDC.**
+**Do NOT flag as missing protection at BCDC** - the battery-terminal CB protects the entire run (see Protection Location above).
 
 **Documentation References:**
 
@@ -521,16 +500,7 @@ The CB is sized for _device capacity_, not actual load. Actual loads are well wi
 
 ### Review Guidance
 
-**This is NOT a safety issue.**
-
-The apparent CB > wire mismatch is intentional:
-
-1. Actual loads (82-100A) well within wire rating (130A)
-2. CB sized for device capacity and inrush tolerance
-3. Fault protection adequate (CB trips before wire damage)
-4. Intermittent duty cycle (not continuous operation)
-
-**Do NOT flag as requiring wire upgrade or CB downgrade.**
+**Do NOT flag as requiring wire upgrade or CB downgrade** - the CB > wire mismatch is intentional; actual loads stay well within wire rating and fault protection is adequate (see analysis above).
 
 **Documentation References:**
 

--- a/docs/jeep_lj/02-engine-systems/05-horn.md
+++ b/docs/jeep_lj/02-engine-systems/05-horn.md
@@ -59,11 +59,6 @@ START battery CONSTANT → PMU → Out 18 → PIAA Horns (5.4A) → Chassis Grou
 3. PMU Out 18 activated when In 1 closes
 4. PMU Out 18 → PIAA horns (5.4A) → chassis ground (engine bay)
 
-**Notes:**
-
-- PMU Out 18 switches directly (no external relay needed)
-- Works with ignition off (CONSTANT power for safety)
-
 ## Outstanding Items
 
 {{ tbds() }}


### PR DESCRIPTION
Nightly tidiness pass per `docs/jeep_lj/CLAUDE.md` "BE SUCCINCT". Prose and structure only — no spec, number, part number, wire gauge, or rationale was changed; every table row, TBD item, checkbox, and `[ref]:` link definition is untouched.

| File | Lines before → after | What was cut | Which persona it failed |
| :--- | :--- | :--- | :--- |
| `01-power-systems/STANDARDS-EXCEPTIONS.md` | 592 → 562 | 5 "Review Guidance" subsections (Winch, Grid Heater, Alternator, BCDC, SwitchPros/SafetyHub) each restated the engineering rationale already given earlier in the same section, ending in a "Do NOT flag..." instruction. Condensed each to a single line: the "Do NOT flag" instruction plus a pointer back to the analysis above. The distinct Starter and START+ Forward Bus guidance blocks were left as-is since they add reasoning beyond restatement. | Owner/Designer — the rationale itself is preserved verbatim above each guidance block; only the second (and sometimes third) restatement of the same conclusion was cut. |
| `01-power-systems/04-pmu/05-pmu-arb-load-shedding.md` | 326 → 325 | The claim "Load shedding provides additional margin and maintains optimal voltage" appeared three times (once before the numbers, once restating the same figures right after them, once more under a bullet list). Trimmed to one canonical statement and tightened the lead-in sentence, which was re-deriving math already shown in the adjacent code block. | Owner/Designer and Troubleshooter — the repeated sentence added no new signal path or rationale beyond what the numbers already showed. |
| `02-engine-systems/05-horn.md` | 82 → 77 | Removed the "Notes:" section — both of its bullets ("switches directly, no external relay needed" and "works with ignition off, CONSTANT power") were verbatim restatements of the "Logic:" and "Power:" lines already in the PMU Configuration list directly above. | Mechanic/Installer — a Notes block that repeats the connection table above it serves nothing extra. |

## Left for human judgment

- `STANDARDS-EXCEPTIONS.md`'s Starter Review Guidance section has some restatement too, but also contains a distinct enhancement recommendation (timer relay) — left untouched rather than risk losing that distinction.
- Whether the file's whole "restate rationale → Review Guidance → then a final Review Checklist" structure is more redundancy than the doc's stated anti-re-flagging purpose actually needs. I only condensed the clearest, most duplicative subsections; a larger restructuring of this file felt like a design call beyond a nightly trim.
- The rest of the ~90-page corpus surveyed came back clean — no other high-confidence verbosity was found this run.

## Verification

- `python3 -m mkdocs build --strict` — passes (exit 0), no new broken links/anchors.
- `npx markdownlint-cli2 "docs/jeep_lj/**/*.md"` — no new lint errors introduced (pre-existing failures in the generated `tbd-tracker.md` and two pre-existing issues in `STANDARDS-EXCEPTIONS.md`/`horn.md` are unchanged by this diff and are out of scope for a prose-only pass).

---
_Generated by [Claude Code](https://claude.ai/code/session_01CjJfZDhaz5pfQJ3aS19fxc)_