### PR TITLE
docs: nightly tidiness — trim verbosity (2026-08-26)

### DIFF
--- a/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
+++ b/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
@@ -53,7 +53,7 @@ The radiator fan, iBooster, and TCU were relocated off the PMU onto START-direct
 The master feed carries the combined load (~68A continuous, ~108A brief peak); voltage drop and breaker sizing are set on that single cable.[^fwd-bus-vdrop] The iBooster's separate ignition **enable** (~5A) is sourced from the [Ignition Signal bus][ignition-signal], not this bus. Fan speed is set by a dedicated fan controller ({{ tbd(134) }}) with its own coolant sensor, independent of the PMU and J1939.
 
 !!! info "Shared forward feed — intentional tradeoff"
-    The three loads share one master feed + busbar (a passive cable, breaker, and bus bar — no active electronics), versus three independent runs from the battery. This is the same tradeoff the [AUX side][constant-bus] accepts, and is far more robust than their former shared dependency on the PMU module. Each load keeps its own breaker. See [Standards Exceptions][standards-exceptions].
+    The three loads share one master feed + busbar (a passive cable, breaker, and bus bar — no active electronics), versus three independent runs from the battery. This is the same tradeoff the [AUX side][constant-bus] accepts, and removes their former shared dependency on the PMU module. Each load keeps its own breaker. See [Standards Exceptions][standards-exceptions].
 
 [^fwd-bus-vdrop]: Master feed 2 AWG @ ~108A brief peak (~68A continuous), ~8 ft, 60°C-derated (×1.2) ≈ 1.3% — sized on the combined load. Load feeds are short from the engine-bay bus, so per-load drop is negligible: fan 4 AWG @ 53A, iBooster 8 AWG @ 40A brief, TCU 12 AWG @ 15A. Final master-feed length and breaker selective-coordination pending {{ tbd(136) }} and {{ tbd(135) }}.
 

--- a/docs/jeep_lj/01-power-systems/04-pmu/03-pmu-outputs.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/03-pmu-outputs.md
@@ -62,7 +62,6 @@ _The radiator fan (formerly OUT2+3+4) and iBooster main (formerly OUT1+10) were 
 - **Non-adjacent terminals:** Each rated 23A @ 40°C individually = 46A combined capacity (much better thermal performance)
 - **Brief peak loads:** Thermal derating less critical for loads <5 seconds (e.g., brake booster)
 - **Load balancing:** Avoid placing heavily loaded outputs adjacent to each other - use non-adjacent combining for high-current loads
-- Use proper terminal crimping and wire gauge to maximize current capacity
 
 ## Thermal Analysis
 

--- a/docs/jeep_lj/05-control-interfaces/index.md
+++ b/docs/jeep_lj/05-control-interfaces/index.md
@@ -15,18 +15,6 @@ Driver control interfaces: switches, controllers, and input devices for vehicle 
 - **[Dakota Digital Gauge Cluster][dakota-digital-gauge-cluster]** - See Section 2.9
 - **[5.4 Dashboard Controls][dashboard-physical-controls]** - Physical dash-mounted switches (winch control, rear seat switch)
 
-## System Overview
-
-**Primary Controllers:**
-
-- **SwitchPros SP-1200:** Auxiliary lighting and accessories (AUX battery CONSTANT bus, 150A capacity)
-- **Command Touch CT4:** Turn signals and headlights (START battery, PMU integration)
-
-**Physical Controls:**
-
-- **Dashboard switches:** Winch 3-position switch, other dash controls
-- **Rear seat switch:** Dome light control for rear passengers
-
 [control-interfaces-overview]: 01-overview.md
 [switchpros-sp-1200-rcr-force-12]: 02-switchpros-sp1200.md
 [command-touch-ct4]: 03-command-touch-ct4.md

--- a/docs/jeep_lj/08-exterior-systems/index.md
+++ b/docs/jeep_lj/08-exterior-systems/index.md
@@ -16,21 +16,6 @@ Recovery equipment and air systems for offroad capability.
 | [8.3][air-lockers] | ARB Air Lockers | RD116 front/rear Dana 44 lockers |
 | [8.4][rear-air-chuck] | Rear Air Chuck | External air access in tailgate area |
 
-## System Overview
-
-**Recovery:**
-
-- Warn Zeon 10-S winch (10,000 lb capacity, 409A peak)
-- Direct AUX battery connection (1/0 AWG, no external breaker)
-- Dash rocker switch + factory wired remote
-
-**Air System:**
-
-- ARB Twin Compressor (brushless, 90A draw)
-- 1-gallon air tank (135-150 PSI automatic pressure)
-- ARB front/rear air lockers (RD116)
-- Rear air chuck plate for tire inflation
-
 ## Power Distribution
 
 | Component      | Power Source            | Protection      | Control            |

--- a/docs/jeep_lj/09-installation/index.md
+++ b/docs/jeep_lj/09-installation/index.md
@@ -24,16 +24,6 @@ Physical installation planning, tracking, and validation procedures.
 
 - [Section 1.7.2 - Firewall Ingress][firewall-ingress] - Deutsch HDP24-24-29 connector pinout and specifications
 
-## System Overview
-
-Installation planning and tracking includes:
-
-- Outstanding items tracking (TBD Tracker)
-- Installation checklists organized by section
-- Wire routing and bundling specifications
-- Firewall penetration planning
-- Testing and validation procedures
-
 [tbd-tracker]: ../tbd-tracker.md
 [power-checklist]: 01-power-systems-checklist.md
 [engine-checklist]: 02-engine-systems-checklist.md

--- a/docs/jeep_lj/10-drivetrain/index.md
+++ b/docs/jeep_lj/10-drivetrain/index.md
@@ -19,30 +19,6 @@ Complete drivetrain system documentation for the Jeep LJ build.
 | [10.6][suspension] | Suspension | ORI struts - 14" front, 16" rear |
 | [10.7][steering] | Steering | PSC full hydraulic steering |
 
-## System Overview
-
-**Axles:**
-
-- Front: TJ Rubicon Dana 44 with ARB RD116 air locker, RCV Performance axle shafts
-- Rear: TJ Rubicon Dana 44 with ARB RD116 air locker
-
-**Drivetrain:**
-
-- Transmission: ZF 8HP70 (845RE) - 8-speed automatic from 2015-2019 RAM 1500 EcoDiesel 4x4
-- Transfer Case: NV241 GenII Command-Trac (2012 JK Sport) - 2.72:1 low range
-- Front Driveshaft: Custom (Tom Woods) - measure at final ride height
-- Rear Driveshaft: Custom (Tom Woods) - measure at final ride height
-
-**Suspension:**
-
-- Wheelbase: 110.5" (stretched ~7" from stock 103.4")
-- Front: ORI 14" bypass struts
-- Rear: ORI 16" bypass struts
-
-**Steering:**
-
-- PSC Motorsports full hydraulic steering
-
 ## Outstanding Items
 
 {{ tbds() }}


### PR DESCRIPTION
Nightly tidiness pass per `docs/jeep_lj/CLAUDE.md` — trims prose that failed the persona test, per the Core Imperative **BE SUCCINCT**. No specs, part numbers, TBD items, checkboxes, table rows, or link targets were touched; edits are prose/structure only.

| File | Lines before → after | What was cut | Which persona it failed |
| :--- | :--- | :--- | :--- |
| `05-control-interfaces/index.md` | 35 → 23 | "System Overview" section restating the same controllers already listed, per-item, in "Contents" above | All — pure restatement of an adjacent list |
| `08-exterior-systems/index.md` | 61 → 46 | "System Overview" section restating the winch/compressor facts already in the "Contents" table and the "Power Distribution" table | All — pure restatement of adjacent tables |
| `09-installation/index.md` | 43 → 33 | "System Overview" section restating the four items already named in "Contents" | All — pure restatement of an adjacent list |
| `10-drivetrain/index.md` | 65 → 41 | "System Overview" section walking back through every row of the "Contents" table (axles, transmission, transfer case, suspension, steering) | All — pure restatement of an adjacent table (wheelbase figure confirmed still present in `06-suspension.md`) |
| `01-power-systems/04-pmu/03-pmu-outputs.md` | 172 → 171 | Generic bullet "Use proper terminal crimping and wire gauge to maximize current capacity" | Mechanic/Installer — obvious standard practice, not build-specific |
| `01-power-systems/02-starter-battery-distribution/index.md` | 104 → 104 | Unsupported "far more robust" claim tightened to the factual "removes their former shared dependency on the PMU module" | Owner/Designer — rationale kept, marketing adjective cut |

## Left for human judgment

- `01-power-systems/STANDARDS-EXCEPTIONS.md` has real internal repetition (e.g. the "This is NOT a marine application" line appears near-verbatim in both the Winch and Starter sections, and every component's "Review Guidance" block restates a conclusion also covered by the file's closing "Review Checklist"). Left alone: this file's whole purpose is defensive redundancy aimed at a different audience (future AI/human reviewers, per its own stated Purpose) rather than the four documented reader personas, so the repetition may be intentional rather than accidental verbosity.
- `01-power-systems/04-pmu/05-pmu-arb-load-shedding.md` restates AUX-battery drain scenarios also covered in `01-power-systems/08-load-analysis/03-aux-battery.md`, but the two pages use slightly different load assumptions (one nets 45A/144min, the other 60A/108min for a similar scenario). Collapsing this to a cross-link risks papering over what may be a real numeric inconsistency rather than pure duplication — left for a human to reconcile the underlying figures first.

## Verification

- `python3 -m mkdocs build --strict` — passes (exit 0); only pre-existing INFO notices (unrelated pages), no errors.
- `npx markdownlint-cli2 "docs/jeep_lj/**/*.md"` — reports pre-existing `MD060` table-alignment errors (1161, all in files this PR doesn't touch, e.g. the generated `tbd-tracker.md`); confirmed identical count on `main` before this branch's changes, so nothing here is newly introduced.

---
_Generated by [Claude Code](https://claude.ai/code/session_01KkwQL3CuUJ8z8D2wbyRdHz)_