### PR TITLE
docs: nightly tidiness — trim verbosity (2026-08-27)

### DIFF
--- a/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/index.md
+++ b/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/index.md
@@ -16,9 +16,9 @@ The AUX battery ([Dakota Lithium 135Ah LiFePO4][batteries]) in the passenger rea
 5. **Inline 100A CB** → 4 AWG short feed → [JL Audio MV800/8i Amp][audio] (mounted under rear seat)
 
 !!! info "Two-Stage Distribution Architecture"
-The AUX battery has **no local CONSTANT bus** — protected feeds run from inline CBs at the battery to two distribution points: the firewall CONSTANT bus (most loads) and SafetyHub (local). This places distribution near the loads, minimizes the cabin trunk to a single heavy cable, and keeps the rear wheel well compartment uncluttered.
+The AUX battery has **no local CONSTANT bus** — protected feeds run from inline CBs at the battery to two distribution points: the firewall CONSTANT bus (most loads) and SafetyHub (local). See [Firewall CONSTANT Bus][constant-bus] for the full two-stage rationale.
 
-See [Firewall CONSTANT Bus][constant-bus] for downstream distribution, [SafetyHub][aux-safetyhub] for fused recovery circuits, and [Circuit Breakers][circuit-breakers] for full CB list.
+See [SafetyHub][aux-safetyhub] for fused recovery circuits and [Circuit Breakers][circuit-breakers] for full CB list.
 
 !!! info "Single Source of Truth"
 This page is the authoritative source for all AUX battery wire specs (gauge, distance, voltage drop). Component pages reference here. For battery specs see [Section 1.1][batteries]. For ground bus bars see [Section 1.5][grounding].

--- a/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
@@ -33,13 +33,7 @@ Usable capacity (80% DOD):  108Ah
 Time to 20% SOC:           ~144 minutes continuous (2.4 hours)
 ```
 
-The Dakota Lithium 135Ah combined with 50A BCDC makes extended air-up a non-issue. Load shedding provides additional margin and maintains optimal voltage for electronics.
-
-**Impact Without Load Shedding:**
-
-- Minor: AUX battery still has comfortable margin at 50A BCDC
-- START battery loads reduce BCDC charging efficiency slightly
-- Load shedding maximizes available margin for extended sessions
+**Impact Without Load Shedding:** Minor — the 135Ah/50A BCDC combination already leaves comfortable margin; load shedding maximizes it further for extended sessions.
 
 ## Solution Overview
 

--- a/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
+++ b/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
@@ -64,25 +64,6 @@ This document tracks intentional deviations from general electrical standards wh
    - Emergency shutoff capability
    - Maintenance safety
 
-### Winch Standards Comparison
-
-**Marine (ABYC E-11):**
-
-- Would require 400A circuit breaker for all loads
-- **This is NOT a marine application** - automotive standards apply
-
-**Automotive (SAE J1128):**
-
-- Cable sizing acceptable for brief peak loads ✓
-- Manufacturer specifications take precedence ✓
-- Internal protection acceptable for factory-designed components ✓
-
-**Manufacturer (WARN):**
-
-- No external protection required ✓
-- Direct battery connection specified ✓
-- Internal protection designed for fault scenarios ✓
-
 ### Factory Vehicle Precedent
 
 **OEM winch installations do NOT use external circuit breakers:**
@@ -123,16 +104,7 @@ This document tracks intentional deviations from general electrical standards wh
 
 ### Winch Review Guidance
 
-**This is NOT an oversight or safety issue.**
-
-It is intentional adherence to:
-
-1. Manufacturer specifications (WARN)
-2. Automotive standards (SAE J1128)
-3. Industry standard practice (factory winch installations)
-4. Engineering analysis (load, wire sizing, fault scenarios)
-
-**Do NOT flag as requiring correction in future reviews.**
+**Not an oversight.** Intentional per WARN manufacturer spec, SAE J1128 (automotive, not marine ABYC E-11), factory winch precedent, and the fault-scenario analysis above. Do NOT flag as requiring correction.
 
 **Documentation References:**
 
@@ -226,32 +198,11 @@ It is intentional adherence to:
 - Manual battery disconnect available
 - **Status:** Acceptable per automotive practice, enhancement recommended
 
-### Starter Standards Comparison
-
-**Automotive (SAE J1128):**
-
-- Cable sizing acceptable for brief peak loads ✓
-- No CB required for starter circuits in factory vehicles ✓
-- Timer relay or slow-blow CB optional enhancement ✓
-
-**Marine (ABYC E-11):**
-
-- Would require circuit breaker or fuse
-- **This is NOT a marine application** - automotive standards apply
-
 ### Starter Review Guidance
 
-**Current design (no CB) is acceptable per automotive standards.**
+**Current design (no CB) is acceptable per SAE J1128** - cable sizing provides adequate protection for normal operation. This is not a marine (ABYC E-11) application. Do NOT flag as a critical safety issue.
 
-**Enhancement (timer relay) is recommended but not critical:**
-
-- Adds protection for stuck solenoid scenario
-- Low cost, simple implementation
-- Common in heavy-duty truck applications
-
-**Do NOT flag as critical safety issue** - cable sizing provides adequate protection for normal operation per SAE J1128.
-
-**Consider implementing timer relay as build enhancement** - provides additional fault protection beyond baseline automotive practice.
+**Timer relay remains a recommended (not critical) enhancement** for the stuck-solenoid scenario - low cost, common in heavy-duty truck applications.
 
 **Documentation References:**
 
@@ -421,12 +372,9 @@ No additional CB required at BCDC - entire circuit protected from battery termin
 
 ### Engineering Rationale
 
-- The radiator fan, iBooster, and TCU were moved off the PMU and all sit forward (engine bay / transmission), while the START battery is in the rear wheel well.
-- Three independent feeds would mean three long rear-to-front cables and ~9 stacked lugs on the battery post (impractical, hard to service).
-- A single master feed + forward busbar mirrors the proven AUX-side two-stage architecture (300A master → firewall CONSTANT bus), placing each load's breaker near its load.
-- The intermediate bus is a passive bar; the feed is protected by a 150A master breaker within 7" of the battery (the cable is never unprotected), with selective coordination to the downstream load breakers.
+See [START+ Forward Distribution Bus][start-forward-bus] for the full rationale (relocated loads, cable-count tradeoff, AUX-side precedent). The intermediate bus is a passive bar; the feed is protected by a 150A master breaker within 7" of the battery (the cable is never unprotected), with selective coordination to the downstream load breakers.
 
-### Review Guidance
+### Forward Bus Review Guidance
 
 **This is intentional.** Do NOT flag the START+ Forward Distribution Bus as violating the "no bus bar between battery and loads" rule — it is the same accepted tradeoff as the AUX CONSTANT bus, chosen to relocate three critical loads off the PMU. See {{ tbd(135) }} for final busbar/breaker selection.
 
@@ -471,12 +419,6 @@ The CB is sized for _device capacity_, not actual load. Actual loads are well wi
 
 ### Protection Strategy
 
-**Normal Operation:**
-
-- Wire operates at 37-77% of its ampacity
-- No thermal stress, adequate safety margin
-- Wire temperature remains well below insulation rating
-
 **Fault Condition (Short Circuit):**
 
 - Fault current exceeds CB rating → CB trips
@@ -519,18 +461,9 @@ The CB is sized for _device capacity_, not actual load. Actual loads are well wi
 - CB sizing considers duty cycle and thermal time constants
 - Brief overloads acceptable if within wire thermal limits
 
-### Review Guidance
+### SwitchPros/SafetyHub Review Guidance
 
-**This is NOT a safety issue.**
-
-The apparent CB > wire mismatch is intentional:
-
-1. Actual loads (82-100A) well within wire rating (130A)
-2. CB sized for device capacity and inrush tolerance
-3. Fault protection adequate (CB trips before wire damage)
-4. Intermittent duty cycle (not continuous operation)
-
-**Do NOT flag as requiring wire upgrade or CB downgrade.**
+**Not a safety issue.** The CB > wire mismatch above is intentional - actual loads (82-100A) are well within wire rating (130A), CB is sized for device capacity, and fault protection is adequate (CB trips before wire damage). Do NOT flag as requiring wire upgrade or CB downgrade.
 
 **Documentation References:**
 
@@ -582,6 +515,7 @@ Before flagging as issues, verify these intentional design choices:
 [wire-distance]: 01-power-generation/05-wire-distance-reference.md
 [starter-system]: ../02-engine-systems/01-starter.md
 [starter-battery-distribution]: 02-starter-battery-distribution/index.md
+[start-forward-bus]: 02-starter-battery-distribution/index.md#start-forward-bus
 [grid-heater]: ../02-engine-systems/07-grid-heater.md
 [alternator]: 01-power-generation/02-alternator.md
 [bcdc]: 01-power-generation/03-bcdc.md


### PR DESCRIPTION
Nightly tidiness pass per `docs/jeep_lj/CLAUDE.md`'s **BE SUCCINCT** rule. Cut prose that restated an adjacent table/list or repeated the same conclusion multiple times within a section. No specs, numbers, part numbers, wire gauges, or identifiers were changed — prose and structure only.

| File | Lines before → after | What was cut | Which persona it failed |
| :--- | :--- | :--- | :--- |
| `01-power-systems/STANDARDS-EXCEPTIONS.md` | 592 → 526 | Winch and Starter sections each restated their "no CB needed" conclusion 3×: a `Standards Comparison` subsection that just re-listed the manufacturer spec + marine/automotive standards already stated above, plus a `Review Guidance` block that re-listed the same four bullets again. Collapsed each to a single sentence. Also de-duplicated the SwitchPros/SafetyHub `Protection Strategy` section's "Normal Operation" bullets (a pure restatement of the load table above it) and its `Review Guidance` (restated the whole section as a numbered list). Also de-duplicated the START+ Forward Bus rationale against its authoritative page (see next row) and fixed a pre-existing `MD024` duplicate-heading lint error (two identically-named "Review Guidance" headings) by making both section-specific. | Mechanic/Troubleshooter — none of them need the same "don't flag this" conclusion stated 3 times; the unique load data, wire sizing, and fault-scenario analysis in each section is preserved. |
| `01-power-systems/03-aux-battery-distribution/index.md` | 66 → 66 | The "Two-Stage Distribution Architecture" admonition repeated the same rationale (no local CONSTANT bus, two-stage feed, "near the loads") already fully explained on `02-constant-bus.md`, the authoritative page for that bus bar. Trimmed to a one-line summary + cross-link. | Owner/Designer — rationale kept in its one authoritative file; this page now links instead of duplicating it. |
| `01-power-systems/04-pmu/05-pmu-arb-load-shedding.md` | 326 → 320 | The claim "ARB draw is fine without load shedding; shedding just adds margin" was stated 3 times in ~25 lines (after the dual-battery-architecture intro, again after the depletion-time table, and a third time in the "Impact Without Load Shedding" bullets). Collapsed to one line. | Owner/Designer and Troubleshooter — the numeric depletion-time analysis and the rationale are preserved once, not three times. |

Verified: `mkdocs build --strict` passes; `markdownlint-cli2 "docs/jeep_lj/**/*.md"` passes on all three touched files (pre-existing `MD060` table-alignment errors elsewhere in the tree — e.g. `tbd-tracker.md`, and one pre-existing table in `03-aux-battery-distribution/index.md` — are unrelated, present on `main` before this change, and untouched here).

## Left for human judgment

- `03-aux-battery-distribution/index.md` has a pre-existing `MD060` table-column-style lint error (table pipe alignment) at lines 31/34/44, present on `main` before this PR. Left alone since it's a table (guardrail: don't touch table content/structure) and out of scope for a prose-only pass — flagging in case it's worth a dedicated formatting pass.
- The other `STANDARDS-EXCEPTIONS.md` sections (Grid Heater, Alternator, BCDC) follow a similar Spec→Analysis→Guidance structure but were already concise (single "do not flag" statement, no restatement) — left as-is.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WUkRTQGdruW4Q8oYtKcHVM)_