### PR TITLE
docs: nightly tidiness — trim verbosity (2026-09-01)

### DIFF
--- a/docs/jeep_lj/01-power-systems/08-load-analysis/01-scenarios.md
+++ b/docs/jeep_lj/01-power-systems/08-load-analysis/01-scenarios.md
@@ -42,7 +42,7 @@ Both batteries under significant load simultaneously:
 - START: 198A / 270A = **73% alternator utilization**
 - AUX: 44A - 50A BCDC = **+6A net charge**
 
-**Verdict:** With corrected XL Sport specs (2.2A/pod), full night offroad lighting is now fully covered by BCDC. Battery maintains charge even in worst realistic case.
+**Verdict:** Full night offroad lighting is fully covered by BCDC. Battery maintains charge even in worst realistic case.
 
 ---
 
@@ -155,7 +155,7 @@ ARB compressor running with engine idling:
 | Extended Camp | —          | —       | -27A    | 76 min       | Limited   |
 | Airing Up     | 115A       | 43%     | -59A    | 10 min       | Excellent |
 
-**Key Insight:** With corrected XL Sport specs (2.2A/pod), the dual battery architecture now provides net positive charging even during full night offroad lighting. The 50A BCDC fully covers all lighting loads with margin to spare.
+**Key Insight:** The dual battery architecture provides net positive charging even during full night offroad lighting. The 50A BCDC fully covers all lighting loads with margin to spare.
 
 ## Related Documentation
 

--- a/docs/jeep_lj/01-power-systems/08-load-analysis/03-aux-battery.md
+++ b/docs/jeep_lj/01-power-systems/08-load-analysis/03-aux-battery.md
@@ -125,7 +125,7 @@ All circuits powered by AUX battery (charged by BCDC at 50A max):
 
 **Net Battery Effect:** +5A (battery charging!)
 
-**Assessment:** Excellent - with corrected XL Sport specs (2.2A/pod), full night offroad lighting is now fully covered by BCDC charging. Battery maintains charge even with all lights on.
+**Assessment:** Excellent - full night offroad lighting is fully covered by BCDC charging. Battery maintains charge even with all lights on.
 
 ---
 

--- a/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
+++ b/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
@@ -57,24 +57,16 @@ tags:
 ### Headlight Control
 
 - **Headlights (SW3 - PULL):** Baja Designs LP6 headlights (low beam)
-  - **Pull lever** → Activates headlights (low beam)
-  - Power: PMU Out 13 (CONSTANT) → CT4 internal switching → SW3 output
-  - CT4 SW3 output → LP6 Pin 1 (low beam, both lights in parallel)
-  - CT4 handles switching internally (10A output capacity, 3.6A actual load)
-  - Disabled when ignition off (via ignition signal from ignition switch RUN)
-  - Latching on/off control (pull once to turn on, pull again to turn off)
+  - **Pull lever** → Activates headlights (low beam), latching (pull again to turn off)
   - Wire gauge: 14 AWG from CT4 SW3 output to LP6 headlights
   - When active: Also triggers DRL cutoff relay to disable DRL circuit (SW3 output tapped to relay coil)
 
 - **High Beams (SW4 - PUSH):** Switches to high beams
-  - **Push lever** (while headlights on) → Activates high beams
-  - Power: PMU Out 13 (CONSTANT) → CT4 internal switching → SW4 output
-  - CT4 SW4 output → LP6 Pin 4 (high beam, both lights in parallel)
-  - CT4 handles switching internally (10A output capacity, 5.6A actual load)
-  - Disabled when ignition off (via ignition signal from ignition switch RUN)
-  - CT4 provides mutual exclusivity (high beam disables low beam automatically)
+  - **Push lever** (while headlights on) → Activates high beams; mutual exclusivity disables low beam automatically
   - Momentary or latching toggle (programmable)
   - Wire gauge: 14 AWG from CT4 SW4 output to LP6 headlights
+
+See [Wiring Pinout](#wiring-pinout) below for power source, pin mapping, and current ratings.
 
 ### DRL/Parking Lights
 

--- a/docs/jeep_lj/08-exterior-systems/01-winch.md
+++ b/docs/jeep_lj/08-exterior-systems/01-winch.md
@@ -81,12 +81,9 @@ See [AUX Battery Distribution][aux-battery] for wire specs (gauge, length, routi
 
 **Control Wiring:**
 
-- **Power Source:** BODY PDU CB43 (10A fuse) - sourced from Firewall CONSTANT Bus (AUX battery)
-- **Dash Switch:** [CH4X4-TOY-D-WINIO][ch4x4-winch] dual-momentary push, Toyota-style (1.54" × 0.83" cutout) - see [Dashboard Controls][dashboard-controls]
-- **Signal Path:** BODY PDU CB43 → CH4X4 switch (push IN or OUT) → HDP24 pins 16/17 → winch contactor IN/OUT triggers
-- **Remote:** Wired in parallel with dash switch at contactor IN/OUT trigger terminals
-- **Wire Gauge:** 18 AWG (low-current trigger signals, ~2A max each direction)
-- **Routing:** BODY PDU (firewall cabin side) → ~3 ft to dash switch → out through HDP24 → engine bay → winch contactor (front bumper)
+Trigger signals are 18 AWG, ~2A max each direction, via the [CH4X4-TOY-D-WINIO][ch4x4-winch]
+dash switch. See [Dashboard Controls][dashboard-controls] for full signal path and routing.
+Circuit-level connections below.
 
 | Circuit         | Source             | Protection            | Wire Gauge                                                 | Destination             | Function            |
 | --------------- | ------------------ | --------------------- | ---------------------------------------------------------- | ----------------------- | ------------------- |

--- a/docs/jeep_lj/08-exterior-systems/02-air-compressor.md
+++ b/docs/jeep_lj/08-exterior-systems/02-air-compressor.md
@@ -144,20 +144,9 @@ ARB Twin Compressor system with air tank and automatic pressure management for l
 
 ### SwitchPros Integration
 
-**SwitchPros Programming:**
-
-- **TRIGGER-3 Input:** Pressure switch signal (tank < 135 PSI activates trigger)
-- **OUTPUT-11 Logic:** Button 11 OR TRIGGER-3 → OUTPUT-11 (compressor)
-- **Manual Override:** Press Button 11 anytime to force compressor on (e.g., for tire inflation)
-- **Automatic Mode:** TRIGGER-3 maintains tank pressure 135-150 PSI without user intervention
-
-**Operational Modes:**
-
-| Mode                | Control Method                | Use Case                                                   |
-| ------------------- | ----------------------------- | ---------------------------------------------------------- |
-| **Automatic**       | Pressure switch via TRIGGER-3 | Normal operation - system maintains pressure automatically |
-| **Manual Override** | Button 11 (latching mode)     | Tire inflation - keep compressor running continuously      |
-| **Off**             | Button 11 off + tank > 135 PSI | Compressor idle, tank maintains pressure for locker use   |
+Button 11 OR TRIGGER-3 → OUTPUT-11 (compressor). Full control logic, cut-in/cut-out
+thresholds, and manual override behavior are documented once at
+[SwitchPros TRIGGER-3][switchpros].
 
 ### Pressure Switch Wiring
 


### PR DESCRIPTION
Nightly tidiness pass per `docs/jeep_lj/CLAUDE.md`'s **BE SUCCINCT** imperative. Obvious grep-level fluff (marketing adjectives, hedging phrases) was already gone from a prior pass, so this run did a deeper read-based survey for prose that restates an adjacent table or repeats the same explanation across files. No specs, part numbers, wire gauges, or identifiers were changed — prose and structure only.

| File | Lines before → after | What was cut | Persona it failed |
|---|---|---|---|
| `08-exterior-systems/02-air-compressor.md` | 191 → 180 | "SwitchPros Programming" bullets + "Operational Modes" table duplicated the TRIGGER-3 control logic already fully documented on the SwitchPros page; replaced with a one-line summary + link | Mechanic/Troubleshooter (duplicate control logic across files) |
| `01-power-systems/08-load-analysis/01-scenarios.md` | 170 → 170 | "With corrected XL Sport specs (2.2A/pod)" preamble repeated in two scenario verdicts, restating a per-pod spec already in the load tables | Mechanic (prose restating adjacent table) |
| `01-power-systems/08-load-analysis/03-aux-battery.md` | 269 → 269 | Same "with corrected XL Sport specs (2.2A/pod)" preamble in one scenario assessment (the more informative "2.2A/pod vs 6A" occurrence elsewhere in this file was kept intact) | Mechanic (prose restating adjacent table) |
| `05-control-interfaces/03-command-touch-ct4.md` | 228 → 220 | Headlight/high-beam bullets re-stated power source, pin mapping, and current ratings that are already in the Wiring Pinout table below; kept the lever-action/latching/mutual-exclusivity behavior that isn't in the table, added a pointer to the table | Mechanic (prose restating adjacent table) |
| `08-exterior-systems/01-winch.md` | 126 → 123 | "Control Wiring" bullet list re-stated power source, signal path, and routing that are also in the table immediately below and, verbatim, on the Dashboard Controls page | Mechanic (duplicate rationale/wiring across files) |

Verification:
- `python3 -m mkdocs build --strict` — exits 0. The only anchor warning it logs (`#wiring` on the CT4 page) pre-dates this PR and isn't touched by it.
- `npx markdownlint-cli2 "docs/jeep_lj/**/*.md"` — no new issues introduced. The repo already has pre-existing `MD060` table-alignment findings (including in the generated `tbd-tracker.md`) on `main`; none of the touched lines are among them.

## Left for human judgment

- **`01-power-systems/STANDARDS-EXCEPTIONS.md`** — flagged for a generic "Factory Vehicle Precedent" list, an overbroad "alternators NEVER use circuit breakers" sentence, and repeated "no external CB needed" framing. Left untouched: this file's stated purpose is to pre-empt automated reviewers (including AI ones) from flagging these design decisions as missing protection, so trimming its persuasive repetition risks weakening the guardrail it exists to provide.
- **`01-power-systems/07-wire-routing/02-firewall-ingress.md`** — the "Pin Budget Audit (Historical)" section (~75 lines) is a full decision trail (capacity analysis, alternatives considered, cost comparison) behind upsizing the firewall connector. It's already labeled historical with a one-line summary linking to the current architecture above it. This reads as exactly the kind of owner-facing design rationale the style guide says to keep, even though it's long, so it wasn't touched.
- **Possible stale content, not a verbosity issue:** while reading `01-winch.md` and `01-power-systems/07-wire-routing/02-firewall-ingress.md`, both describe the winch dash control as a "center-off momentary rocker switch," but `05-control-interfaces/05-dashboard-controls.md` shows this was superseded by a CH4X4 dual-momentary push-button switch (resolved 2026-05-30). This looks like a real cross-file inconsistency, not verbosity — left alone since it needs a correctness judgment call, not a trim.

---
_Generated by [Claude Code](https://claude.ai/code/session_01WUjff7AdTkwEALtX9UFgNa)_