### PR TITLE
docs: nightly tidiness — trim verbosity (2026-09-03)

### DIFF
--- a/docs/jeep_lj/01-power-systems/01-power-generation/04-solar.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/04-solar.md
@@ -70,15 +70,13 @@ tags:
 
 **Panel-side vs battery-side current:** The 1.95A figure is the panel-side current at the panel's ~40V operating voltage (40V × 1.95A ≈ 78W). The BCDC's MPPT steps that down to the battery charge voltage, so the battery-side contribution is higher: 78W ÷ ~13.4V ≈ **~5.8A to the AUX battery**.
 
-**BCDC Green Power Priority:** Solar input used first when available, alternator supplements to reach 50A total charging current. In full sun, solar contributes ~5.8A battery-side, reducing alternator load by the same amount.
+**BCDC Green Power Priority:** Solar input used first when available, alternator supplements to reach 50A total charging current.
 
 **Charging Contribution (battery-side):**
 
 - **Full sun:** ~5.8A to AUX battery (78W ÷ ~13.4V; reduces alternator load from 50A to ~44A)
 - **Partial sun:** Variable, proportional to available irradiance
 - **Overcast/Night:** 0A (BCDC uses alternator only)
-
-**Alternator Load Relief:** Minimal but measurable — reduces worst-case alternator load by ~5.8A during sunny daytime operation
 
 See [BCDC Alpha 50][bcdc] for complete charging system details.
 

--- a/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
+++ b/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
@@ -53,7 +53,7 @@ The radiator fan, iBooster, and TCU were relocated off the PMU onto START-direct
 The master feed carries the combined load (~68A continuous, ~108A brief peak); voltage drop and breaker sizing are set on that single cable.[^fwd-bus-vdrop] The iBooster's separate ignition **enable** (~5A) is sourced from the [Ignition Signal bus][ignition-signal], not this bus. Fan speed is set by a dedicated fan controller ({{ tbd(134) }}) with its own coolant sensor, independent of the PMU and J1939.
 
 !!! info "Shared forward feed — intentional tradeoff"
-    The three loads share one master feed + busbar (a passive cable, breaker, and bus bar — no active electronics), versus three independent runs from the battery. This is the same tradeoff the [AUX side][constant-bus] accepts, and is far more robust than their former shared dependency on the PMU module. Each load keeps its own breaker. See [Standards Exceptions][standards-exceptions].
+    This mirrors the same tradeoff the [AUX side][constant-bus] accepts, and removes the fan/iBooster/TCU's former shared dependency on the PMU module. See [Standards Exceptions][standards-exceptions].
 
 [^fwd-bus-vdrop]: Master feed 2 AWG @ ~108A brief peak (~68A continuous), ~8 ft, 60°C-derated (×1.2) ≈ 1.3% — sized on the combined load. Load feeds are short from the engine-bay bus, so per-load drop is negligible: fan 4 AWG @ 53A, iBooster 8 AWG @ 40A brief, TCU 12 AWG @ 15A. Final master-feed length and breaker selective-coordination pending {{ tbd(136) }} and {{ tbd(135) }}.
 

--- a/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
@@ -15,7 +15,7 @@ Automatic load management during ARB compressor operation to preserve AUX batter
 - **BCDC Charging (50A max):** Replenishes AUX battery from alternator
 - **Net AUX battery drain:** 90A - 50A = 40A during compressor operation
 
-The alternator is NOT overloaded during ARB operation. The 50A BCDC significantly reduces net discharge rate, making extended air-up practical. Load shedding provides additional margin and maintains optimal voltage.
+The alternator is NOT overloaded during ARB operation — the 50A BCDC significantly reduces net AUX discharge rate.
 
 ## Problem Statement
 
@@ -219,10 +219,7 @@ ELSE:
 
 **Best Practices for ARB Use:**
 
-1. **Increase Engine RPM:** Run engine at 1500+ RPM during tire inflation
-   - Alternator output increases with RPM
-   - Better voltage regulation at higher speeds
-   - Faster tire inflation
+1. **Increase Engine RPM:** Run engine at 1500+ RPM during tire inflation — higher alternator output means faster inflation and steadier voltage.
 
 2. **Monitor Voltage:** Watch Dakota Digital voltage gauge during ARB use
    - Normal: 14.0-14.4V (load shedding working)

--- a/docs/jeep_lj/01-power-systems/08-load-analysis/01-scenarios.md
+++ b/docs/jeep_lj/01-power-systems/08-load-analysis/01-scenarios.md
@@ -42,7 +42,7 @@ Both batteries under significant load simultaneously:
 - START: 198A / 270A = **73% alternator utilization**
 - AUX: 44A - 50A BCDC = **+6A net charge**
 
-**Verdict:** With corrected XL Sport specs (2.2A/pod), full night offroad lighting is now fully covered by BCDC. Battery maintains charge even in worst realistic case.
+**Verdict:** Full night offroad lighting is fully covered by BCDC — battery maintains charge even in the worst realistic case.
 
 ---
 
@@ -155,7 +155,7 @@ ARB compressor running with engine idling:
 | Extended Camp | —          | —       | -27A    | 76 min       | Limited   |
 | Airing Up     | 115A       | 43%     | -59A    | 10 min       | Excellent |
 
-**Key Insight:** With corrected XL Sport specs (2.2A/pod), the dual battery architecture now provides net positive charging even during full night offroad lighting. The 50A BCDC fully covers all lighting loads with margin to spare.
+**Key Insight:** The dual battery architecture provides net positive charging even during full night offroad lighting — the 50A BCDC fully covers all lighting loads with margin to spare.
 
 ## Related Documentation
 

--- a/docs/jeep_lj/01-power-systems/08-load-analysis/03-aux-battery.md
+++ b/docs/jeep_lj/01-power-systems/08-load-analysis/03-aux-battery.md
@@ -125,7 +125,7 @@ All circuits powered by AUX battery (charged by BCDC at 50A max):
 
 **Net Battery Effect:** +5A (battery charging!)
 
-**Assessment:** Excellent - with corrected XL Sport specs (2.2A/pod), full night offroad lighting is now fully covered by BCDC charging. Battery maintains charge even with all lights on.
+**Assessment:** Excellent - full night offroad lighting is fully covered by BCDC charging. Battery maintains charge even with all lights on.
 
 ---
 

--- a/docs/jeep_lj/06-audio-systems/04-subwoofer.md
+++ b/docs/jeep_lj/06-audio-systems/04-subwoofer.md
@@ -57,7 +57,7 @@ Amp Ch 1+2 (+/−) bridged → Sub A (+/−)
 Amp Ch 3+4 (+/−) bridged → Sub B (+/−)
 ```
 
-Total amp output 400W into the pair (200W per sub) — exact RMS match, no headroom waste from series resistance, independent gain trim per side if the L/R quarter-panel locations end up acoustically asymmetric.
+Total amp output 400W into the pair (200W per sub), with independent gain trim per side if the L/R quarter-panel locations end up acoustically asymmetric.
 
 ## Infinite Baffle Requirements
 
@@ -66,13 +66,7 @@ Total amp output 400W into the pair (200W per sub) — exact RMS match, no headr
 - **Ideal location:** Rear quarter panels above wheel wells, firing inward into cabin
 - **IB chamber:** Rear cargo area / behind quarter trim (effectively unlimited volume in an LJ)
 
-## Features
-
-- Transflective RGB LED lighting (via MLC-RW)
-- Gunmetal trim ring with titanium sport grille
-- Marine-grade construction
-- Mica-filled polypropylene cone
-- Synthetic rubber surround
+RGB LED lighting is transflective, driven via the MLC-RW (see wiring table below).
 
 ## Wiring
 


### PR DESCRIPTION
Nightly tidiness pass per `docs/jeep_lj/CLAUDE.md` (**BE SUCCINCT**). Six pages had the clearest, highest-confidence verbosity — restated design rationale, a duplicate scenario conclusion, and cosmetic marketing copy that serve none of the four reader personas (Mechanic/Installer, Owner/Designer, Parts Buyer, Troubleshooter). No numbers, part numbers, identifiers, or links were changed — prose and structure only.

| File | Lines before → after | What was cut | Which persona it failed |
| :--- | :-------------------- | :------------ | :----------------------- |
| `01-power-systems/04-pmu/05-pmu-arb-load-shedding.md` | 326 → 323 | Duplicate "load shedding provides additional margin" conclusion restated before the math was even shown; consolidated a 3-bullet RPM tip that repeated the same physics point twice | Owner (redundant conclusion), Troubleshooter (buried the useful part under filler) |
| `01-power-systems/02-starter-battery-distribution/index.md` | 103 → 103 | Admonition callout re-stated the "single feed vs three runs, each load keeps its own breaker" rationale already given in the paragraph above it; also dropped the unquantified "far more robust" adjective in favor of the concrete fact it stood in for | Owner (same rationale twice within 15 lines) |
| `01-power-systems/08-load-analysis/01-scenarios.md` | 170 → 170 | Two scenario verdicts repeated the "with corrected XL Sport specs (2.2A/pod)" changelog-style preamble instead of just stating the conclusion | Owner (stale correction framing repeated 4x across 2 files) |
| `01-power-systems/08-load-analysis/03-aux-battery.md` | 269 → 269 | Same "corrected XL Sport specs" preamble trimmed from one scenario assessment; the one instance with the actual magnitude of the correction (2.2A/pod vs 6A) was kept as the authoritative copy | Owner (same, cross-file duplication) |
| `01-power-systems/01-power-generation/04-solar.md` | 165 → 163 | A whole bullet ("Alternator Load Relief: ... ~5.8A") that restated the figure and claim already given one bullet above it | Owner/Troubleshooter (exact restatement) |
| `06-audio-systems/04-subwoofer.md` | 116 → 110 | "Features" bullets that were pure cosmetic/marketing copy (trim ring, grille, cone material, surround material) with no fact any persona needs; trimmed a third restatement of the "exact RMS match" bridged-wiring rationale | Parts Buyer/Mechanic (marketing noise), Owner (rationale repeated 3x in one page) |

## Verification

- `mkdocs build --strict` — passed, no broken links/anchors introduced.
- `markdownlint-cli2 "docs/jeep_lj/**/*.md"` — the same pre-existing `MD060` (table-column-style) issues present on `main` before this change remain (verified identical count/location against `main`, in `tbd-tracker.md` and pre-existing table formatting in the touched files); no new lint issues were introduced by this diff.

## Left for human judgment

- **`STANDARDS-EXCEPTIONS.md`** — the per-component "Do NOT flag as..." boilerplate and the ABYC/SAE standards-comparison framing repeat close to verbatim across ~6 sections. This file's stated purpose is to stop future reviews from re-flagging intentional decisions, so the repetition may be doing real work; left untouched rather than risk cutting something load-bearing.
- **`01-power-systems/07-wire-routing/02-firewall-ingress.md`** — the "Pin Budget Audit (Historical)" section (~75 lines) re-derives capacity numbers already given in the "Wire Count Summary" table above it, and even includes since-dropped circuits (Boomerang fob, gated start). Condensing it to a short "why we upsized" note would mean deleting table rows, which conflicts with this run's guardrail against removing table rows — left for a human to decide whether to archive/trim it.
- **`05-control-interfaces/03-command-touch-ct4.md`** — the turn-signal/lighting prose partially restates the wiring pinout table below it, but also carries a few details (junction-to-light gauge breakdown) not in the table. Lower confidence on what's safe to cut without losing signal.
- **`01-power-systems/04-pmu/04-pmu-programming.md`** — the battery voltage-threshold table reads close to generic automotive knowledge, but ties into the PMU's actual trigger logic just below it. Left alone; lowest-confidence candidate surveyed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LFZXANSSV5TfaVvDQUcpuG

---
_Generated by [Claude Code](https://claude.ai/code/session_01LFZXANSSV5TfaVvDQUcpuG)_