### PR TITLE
docs: nightly tidiness — trim verbosity (2026-09-04)

### DIFF
--- a/docs/jeep_lj/01-power-systems/01-power-generation/04-solar.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/04-solar.md
@@ -70,15 +70,13 @@ tags:
 
 **Panel-side vs battery-side current:** The 1.95A figure is the panel-side current at the panel's ~40V operating voltage (40V × 1.95A ≈ 78W). The BCDC's MPPT steps that down to the battery charge voltage, so the battery-side contribution is higher: 78W ÷ ~13.4V ≈ **~5.8A to the AUX battery**.
 
-**BCDC Green Power Priority:** Solar input used first when available, alternator supplements to reach 50A total charging current. In full sun, solar contributes ~5.8A battery-side, reducing alternator load by the same amount.
+**BCDC Green Power Priority:** Solar input used first when available, alternator supplements to reach 50A total charging current.
 
 **Charging Contribution (battery-side):**
 
-- **Full sun:** ~5.8A to AUX battery (78W ÷ ~13.4V; reduces alternator load from 50A to ~44A)
+- **Full sun:** ~5.8A to AUX battery (reduces alternator load from 50A to ~44A)
 - **Partial sun:** Variable, proportional to available irradiance
 - **Overcast/Night:** 0A (BCDC uses alternator only)
-
-**Alternator Load Relief:** Minimal but measurable — reduces worst-case alternator load by ~5.8A during sunny daytime operation
 
 See [BCDC Alpha 50][bcdc] for complete charging system details.
 

--- a/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
@@ -219,10 +219,7 @@ ELSE:
 
 **Best Practices for ARB Use:**
 
-1. **Increase Engine RPM:** Run engine at 1500+ RPM during tire inflation
-   - Alternator output increases with RPM
-   - Better voltage regulation at higher speeds
-   - Faster tire inflation
+1. **Increase Engine RPM:** Run engine at 1500+ RPM during tire inflation — alternator output increases with RPM
 
 2. **Monitor Voltage:** Watch Dakota Digital voltage gauge during ARB use
    - Normal: 14.0-14.4V (load shedding working)
@@ -231,7 +228,6 @@ ELSE:
 
 3. **Hot Weather:** Avoid prolonged ARB use at idle when ambient temp >95°F
    - Radiator fan + ARB + heat soak = high total load
-   - Let engine cool between inflation cycles
 
 4. **Avoid Simultaneous High Loads:**
    - ❌ ARB + winch (both 90A+ loads)

--- a/docs/jeep_lj/05-control-interfaces/02-switchpros-sp1200.md
+++ b/docs/jeep_lj/05-control-interfaces/02-switchpros-sp1200.md
@@ -166,15 +166,9 @@ ARB air tank pressure switch automatically activates compressor to maintain tank
 ARB Pressure Switch (180901) → TRIGGER-3 (Pin 17, PINK)
 ```
 
-**Configuration:**
-
-Program TRIGGER-3 to activate compressor when tank pressure drops below 135 PSI:
-
 **SwitchPros Logic:**
 
 - **TRIGGER-3 OR Button 11 → OUTPUT-11 (compressor)**
-- When tank pressure < 135 PSI: TRIGGER-3 closes → OUTPUT-11 activates → compressor runs
-- When tank pressure = 150 PSI: TRIGGER-3 opens → OUTPUT-11 deactivates → compressor stops
 - Manual override: Button 11 can force compressor on regardless of tank pressure
 
 **Signal Source:**

--- a/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
+++ b/docs/jeep_lj/05-control-interfaces/03-command-touch-ct4.md
@@ -57,23 +57,13 @@ tags:
 ### Headlight Control
 
 - **Headlights (SW3 - PULL):** Baja Designs LP6 headlights (low beam)
-  - **Pull lever** → Activates headlights (low beam)
-  - Power: PMU Out 13 (CONSTANT) → CT4 internal switching → SW3 output
-  - CT4 SW3 output → LP6 Pin 1 (low beam, both lights in parallel)
-  - CT4 handles switching internally (10A output capacity, 3.6A actual load)
-  - Disabled when ignition off (via ignition signal from ignition switch RUN)
-  - Latching on/off control (pull once to turn on, pull again to turn off)
+  - **Pull lever** → Activates headlights (low beam); disabled when ignition off
   - Wire gauge: 14 AWG from CT4 SW3 output to LP6 headlights
   - When active: Also triggers DRL cutoff relay to disable DRL circuit (SW3 output tapped to relay coil)
 
 - **High Beams (SW4 - PUSH):** Switches to high beams
-  - **Push lever** (while headlights on) → Activates high beams
-  - Power: PMU Out 13 (CONSTANT) → CT4 internal switching → SW4 output
-  - CT4 SW4 output → LP6 Pin 4 (high beam, both lights in parallel)
-  - CT4 handles switching internally (10A output capacity, 5.6A actual load)
-  - Disabled when ignition off (via ignition signal from ignition switch RUN)
+  - **Push lever** (while headlights on) → Activates high beams; disabled when ignition off
   - CT4 provides mutual exclusivity (high beam disables low beam automatically)
-  - Momentary or latching toggle (programmable)
   - Wire gauge: 14 AWG from CT4 SW4 output to LP6 headlights
 
 ### DRL/Parking Lights

--- a/docs/jeep_lj/08-exterior-systems/02-air-compressor.md
+++ b/docs/jeep_lj/08-exterior-systems/02-air-compressor.md
@@ -57,10 +57,7 @@ ARB Twin Compressor system with air tank and automatic pressure management for l
 
 ## Control System
 
-- **Control:** SwitchPros OUTPUT-11 (15A output, Button 11)
-  - OUTPUT-11 provides switched 12V control signal to compressor
-  - Compressor has internal relay/control that handles high-current motor switching
-  - 14 AWG wire from OUTPUT-11 to compressor control terminal
+- **Control:** SwitchPros OUTPUT-11 (15A output, Button 11) — compressor has internal relay/control that handles high-current motor switching, so the control wire only carries a 12V switching signal
 - **Ground:** 6 AWG black wire from compressor to AUX battery negative (direct connection for 90A return current)
 
 ## Wiring
@@ -148,8 +145,6 @@ ARB Twin Compressor system with air tank and automatic pressure management for l
 
 - **TRIGGER-3 Input:** Pressure switch signal (tank < 135 PSI activates trigger)
 - **OUTPUT-11 Logic:** Button 11 OR TRIGGER-3 → OUTPUT-11 (compressor)
-- **Manual Override:** Press Button 11 anytime to force compressor on (e.g., for tire inflation)
-- **Automatic Mode:** TRIGGER-3 maintains tank pressure 135-150 PSI without user intervention
 
 **Operational Modes:**
 

--- a/docs/jeep_lj/10-drivetrain/01-transmission.md
+++ b/docs/jeep_lj/10-drivetrain/01-transmission.md
@@ -152,10 +152,6 @@ The Turbolamik communicates with the Cummins R2.8 ECM via J1939 CAN for:
 | Connection    | Factory 8HP70 connector   |
 | Mounting      | Center console            |
 
-**Manual Mode (+/-):** Allows manual gear selection for rock crawling, engine braking on descents, and technical terrain.
-
-**Wiring:** Electronic shifter connects directly to transmission controller. No shift cables required.
-
 ### Drive Mode Switch
 
 | Specification | Value                              |


### PR DESCRIPTION
Nightly tidiness pass per `docs/jeep_lj/CLAUDE.md` (BE SUCCINCT). Cut prose that only restated an adjacent table, or gave generic operational advice not specific to this build. No specs, part numbers, wire gauges, or links were changed — verified against `git diff` before committing.

Verification: `python3 -m mkdocs build --strict` succeeds (exit 0, no new warnings — the one pre-existing broken-anchor notice on `03-command-touch-ct4.md` predates this change). `npx markdownlint-cli2 "docs/jeep_lj/**/*.md"` reports zero errors in any of the 6 edited files (the repo has pre-existing `MD060` table-style errors elsewhere, untouched by this PR).

| File | Lines before → after | What was cut | Persona it failed |
| :--- | :-------------------- | :------------ | :------------------ |
| `08-exterior-systems/02-air-compressor.md` | 192 → 187 | "Control System" sub-bullets restating wire gauge/destination already in the Wiring table; "Manual Override"/"Automatic Mode" bullets restating the Operational Modes table two sections down | Mechanic/Installer (table restated in prose) |
| `01-power-systems/01-power-generation/04-solar.md` | 166 → 162 | The ~5.8A battery-side solar contribution was stated 4 times in one section (derivation paragraph, Green Power Priority paragraph, Charging Contribution bullet, Alternator Load Relief paragraph); collapsed to one derivation + one bullet-list mention | Owner/Designer (same figure re-explained repeatedly in one file) |
| `05-control-interfaces/03-command-touch-ct4.md` | 229 → 219 | Per-switch bullets narrating "PMU Out 13 → CT4 → SW3/SW4 → LP6 Pin X" and output capacity/load, already in the Wiring Pinout table; latching/momentary behavior already in Programming Configuration | Mechanic/Installer (table restated in prose) |
| `01-power-systems/04-pmu/05-pmu-arb-load-shedding.md` | 327 → 324 | Generic sub-bullets under "Operational Procedures" ("Better voltage regulation at higher speeds", "Faster tire inflation", "Let engine cool between inflation cycles") — not build-specific | Mechanic/Installer (obvious/generic advice) |
| `05-control-interfaces/02-switchpros-sp1200.md` | 229 → 223 | TRIGGER-3 pressure-switch logic was stated 3 times (opening paragraph, "Configuration" line, "SwitchPros Logic" bullets); cut the redundant middle restatement | Owner/Designer (same logic re-explained repeatedly) |
| `10-drivetrain/01-transmission.md` | 222 → 218 | "Manual Mode" and "Wiring" one-liners restating the adjacent shifter spec table (Positions, Type rows) | Mechanic/Installer (table restated in prose) |

## Left for human judgment

- **`01-power-systems/STANDARDS-EXCEPTIONS.md`** — Extremely repetitive by design (each component section repeats "Review Guidance"/"Do NOT flag" boilerplate), but it's structured specifically to prevent AI/human reviewers from re-flagging intentional design decisions. Left untouched rather than risk removing an anti-flagging guardrail.
- **`01-power-systems/07-wire-routing/02-firewall-ingress.md`** — The "Pin Budget Audit (Historical)" section (~76 lines) is explicitly self-labeled historical/superseded ("*Final architecture documented above*") and largely duplicates the rationale already captured in the concise "Upsize" admonition earlier in the file. Compressing it would be a large, judgment-heavy cut (multiple tables) rather than a surgical trim, and the Owner may want the full audit trail kept for reference — flagging rather than cutting.
- **`10-drivetrain/01-transmission.md:173`** — "Exact pinout depends on controller selection (Compushift vs US Shift)" appears to be stale text left over from before the Turbolamik TCU 2.0 was selected (the page's product-info block already names Turbolamik as the controller). Not a style issue — a possible factual leftover worth a human look, not touched here.
- **`01-power-systems/08-load-analysis/03-aux-battery.md`** — Each scenario's "Assessment:" line partially restates the table above it, but this is the scenario-analysis format `CLAUDE.md` explicitly asks for (Owner-facing interpretation, not pure restatement); only borderline in a couple of scenarios, so left as-is rather than risk trimming legitimate analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EhD3FCdGg2okriA1Uh3eV9

---
_Generated by [Claude Code](https://claude.ai/code/session_01EhD3FCdGg2okriA1Uh3eV9)_