### PR TITLE
docs: nightly tidiness — trim verbosity (2026-09-05)

### DIFF
--- a/docs/jeep_lj/01-power-systems/01-power-generation/04-solar.md
+++ b/docs/jeep_lj/01-power-systems/01-power-generation/04-solar.md
@@ -70,15 +70,13 @@ tags:
 
 **Panel-side vs battery-side current:** The 1.95A figure is the panel-side current at the panel's ~40V operating voltage (40V × 1.95A ≈ 78W). The BCDC's MPPT steps that down to the battery charge voltage, so the battery-side contribution is higher: 78W ÷ ~13.4V ≈ **~5.8A to the AUX battery**.
 
-**BCDC Green Power Priority:** Solar input used first when available, alternator supplements to reach 50A total charging current. In full sun, solar contributes ~5.8A battery-side, reducing alternator load by the same amount.
+**BCDC Green Power Priority:** Solar input used first when available, alternator supplements to reach 50A total charging current.
 
 **Charging Contribution (battery-side):**
 
 - **Full sun:** ~5.8A to AUX battery (78W ÷ ~13.4V; reduces alternator load from 50A to ~44A)
 - **Partial sun:** Variable, proportional to available irradiance
 - **Overcast/Night:** 0A (BCDC uses alternator only)
-
-**Alternator Load Relief:** Minimal but measurable — reduces worst-case alternator load by ~5.8A during sunny daytime operation
 
 See [BCDC Alpha 50][bcdc] for complete charging system details.
 

--- a/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
+++ b/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
@@ -39,7 +39,7 @@ All circuit breakers mounted within 7" of battery (ABYC/NEC compliant). See [Cir
 
 ## START+ Forward Distribution Bus {#start-forward-bus}
 
-The radiator fan, iBooster, and TCU were relocated off the PMU onto START-direct power. All three sit forward (engine bay / transmission) while the START battery is in the rear wheel well, so — mirroring the [AUX forward-feed architecture][constant-bus] — a **single master-protected feed** runs forward to an engine-bay busbar that fans out to the three loads on short local feeds. This keeps the long rear-to-front run to one heavy cable instead of three, and places each load's breaker near its load.
+The radiator fan, iBooster, and TCU were relocated off the PMU onto START-direct power via a **single master-protected feed** that runs forward to an engine-bay busbar and fans out to the three loads on short local feeds. See [Standards Exceptions][standards-exceptions] for why this departs from the direct-battery-connection default.
 
 **Busbar:** Blue Sea 2105 MaxiBus (250A), engine bay, insulated cover — recommended; confirm with {{ tbd(135) }}
 **Master feed:** 2 AWG, ~8 ft, 150A CB at battery post (<7")
@@ -53,7 +53,7 @@ The radiator fan, iBooster, and TCU were relocated off the PMU onto START-direct
 The master feed carries the combined load (~68A continuous, ~108A brief peak); voltage drop and breaker sizing are set on that single cable.[^fwd-bus-vdrop] The iBooster's separate ignition **enable** (~5A) is sourced from the [Ignition Signal bus][ignition-signal], not this bus. Fan speed is set by a dedicated fan controller ({{ tbd(134) }}) with its own coolant sensor, independent of the PMU and J1939.
 
 !!! info "Shared forward feed — intentional tradeoff"
-    The three loads share one master feed + busbar (a passive cable, breaker, and bus bar — no active electronics), versus three independent runs from the battery. This is the same tradeoff the [AUX side][constant-bus] accepts, and is far more robust than their former shared dependency on the PMU module. Each load keeps its own breaker. See [Standards Exceptions][standards-exceptions].
+    The three loads share one master feed + busbar instead of three independent battery runs — the same tradeoff the [AUX side][constant-bus] accepts. Each load keeps its own breaker. See [Standards Exceptions][standards-exceptions] for the full rationale.
 
 [^fwd-bus-vdrop]: Master feed 2 AWG @ ~108A brief peak (~68A continuous), ~8 ft, 60°C-derated (×1.2) ≈ 1.3% — sized on the combined load. Load feeds are short from the engine-bay bus, so per-load drop is negligible: fan 4 AWG @ 53A, iBooster 8 AWG @ 40A brief, TCU 12 AWG @ 15A. Final master-feed length and breaker selective-coordination pending {{ tbd(136) }} and {{ tbd(135) }}.
 

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/02-dashboard-cluster.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/02-dashboard-cluster.md
@@ -70,7 +70,7 @@ Drop-in replacement for factory TJ gauge cluster. Combines analog gauges with di
 See [HDX Control Module wiring table][hdx-control] for complete signal routing.
 
 !!! warning "Speedometer Required for Legal Operation"
-Speedometer is legally required for on-road vehicle operation. GPS-50-2 module provides speed data - ensure GPS antenna has clear sky view for reliable operation.
+Speedometer is legally required for on-road vehicle operation. See [GPS-50-2][bim-gps] for antenna placement requirements.
 
 ## Outstanding Items
 

--- a/docs/jeep_lj/06-audio-systems/03-speakers.md
+++ b/docs/jeep_lj/06-audio-systems/03-speakers.md
@@ -48,9 +48,7 @@ Marine-grade coaxial speakers with integrated RGB LED lighting for front dash an
 - Integrated 0.8" pure silk dome tweeter (no separate install)
 - Multi-order 2-way passive crossover (built-in)
 - Automatic solid-state tweeter protection
-- Transflective RGB LED lighting
 - Mica-filled polypropylene woofer
-- Gunmetal trim ring with titanium sport grille
 
 ---
 
@@ -88,11 +86,9 @@ Marine-grade coaxial speakers with integrated RGB LED lighting for front dash an
 
 ### Rear Speaker Features
 
-- Built-in RGB LED lights
 - 3/4" silk dome tweeters
 - Mica-filled polypropylene woofers
 - Enclosed weather-resistant design
-- Roll bar clamp mounting
 
 ## Wiring
 

--- a/docs/jeep_lj/06-audio-systems/04-subwoofer.md
+++ b/docs/jeep_lj/06-audio-systems/04-subwoofer.md
@@ -68,8 +68,6 @@ Total amp output 400W into the pair (200W per sub) — exact RMS match, no headr
 
 ## Features
 
-- Transflective RGB LED lighting (via MLC-RW)
-- Gunmetal trim ring with titanium sport grille
 - Marine-grade construction
 - Mica-filled polypropylene cone
 - Synthetic rubber surround

--- a/docs/jeep_lj/index.md
+++ b/docs/jeep_lj/index.md
@@ -96,7 +96,7 @@ The factory TIPM is replaced with discrete, serviceable modules:
 
 - **[PMU24][pmu]:** Programmable 24-channel power management unit
 - **[BODY PDU][body-pdu]:** Body relay/fuse panel for cabin accessories
-- **[SafetyHub][safetyhub]:** 12-channel advanced safety controller
+- **[SafetyHub][safetyhub]:** 12-channel safety controller
 - **[Ron Francis WS-51C][wipers]:** Wiper control module
 
 ### Brake & Ignition


### PR DESCRIPTION
Nightly tidiness pass per `docs/jeep_lj/CLAUDE.md`'s **BE SUCCINCT** rule. No specs, values, part numbers, or identifiers were changed — prose and structure only.

| File | Lines before → after | What was cut | Which persona it failed |
| :--- | :--- | :--- | :--- |
| `01-power-systems/01-power-generation/04-solar.md` | 165 → 163 | The ~5.8A battery-side solar contribution was derived once, then restated in two more sentences ("BCDC Green Power Priority" clause, "Alternator Load Relief" line) that just repeated the number already in the bullet table above. | Troubleshooter/Owner — same fact stated 4x on one page |
| `01-power-systems/02-starter-battery-distribution/index.md` | 103 → 103 | The START+ Forward Distribution Bus paragraph and its admonition re-explained the full engineering rationale (why relocated, why single feed, why it mirrors AUX) that's already the dedicated "Engineering Rationale" section in `STANDARDS-EXCEPTIONS.md`; also dropped the unsupported comparative "far more robust than their former...dependency." Replaced with a short factual summary + cross-link. | Owner — same design decision explained twice across files |
| `02-engine-systems/09-gauge-cluster/02-dashboard-cluster.md` | 98 → 98 | The GPS antenna sky-view warning duplicated the more detailed version on the GPS module's own page (`04-bim-gps.md`, which owns antenna placement per that section's CLAUDE.md). Replaced with a cross-link. | Owner/Troubleshooter — same warning in two files |
| `06-audio-systems/03-speakers.md` | 124 → 120 | "Features" bullets restating catalog marketing copy already encoded in the model number (`-S-GmTi-i`: Sport grille, Gunmetal/Titanium) or redundant with the wiring table (RGB LED). | Parts Buyer — marketing copy, not buying/wiring info |
| `06-audio-systems/04-subwoofer.md` | 116 → 114 | Same catalog marketing bullets (RGB LED, trim ring/grille description) redundant with the page intro and the Wiring table. | Parts Buyer — marketing copy |
| `index.md` | 164 → 164 | Dropped the unsupported adjective "advanced" from the SafetyHub description. | All personas — marketing adjective, no informational content |

**Verification:**
- `python3 -m mkdocs build --strict` — passes (no broken links/anchors).
- `npx markdownlint-cli2 "docs/jeep_lj/**/*.md"` — pre-existing `MD060`/table-alignment failures exist repo-wide on `main` already (confirmed via `git stash` diff: identical error set before/after this change, only line numbers shifted). This PR introduces zero new lint errors.

## Left for human judgment

- **`01-power-systems/STANDARDS-EXCEPTIONS.md`** — each of the 7 exception sections (Winch, Starter, Grid Heater, Alternator, BCDC, START+ Forward Bus, SwitchPros/SafetyHub) ends with a "Review Guidance" block that restates a directive already covered in the "Engineering Analysis" bullets above it (e.g. Alternator's "Alternators NEVER use circuit breakers... in factory or aftermarket applications" repeats its own "Factory Practice" bullet, and is arguably an overbroad claim). This reads as intentional design — each section is meant to stand alone for a reviewer who jumps straight to one component — so I left it untouched rather than guess at intent across a 592-line governance/reviewer-instruction file.
- **`08-exterior-systems/02-air-compressor.md`** line 95 — the tank material spec includes an unsourced "~50% lighter than steel" comparator. Left alone per the hard guardrail against changing any number/value, since it's ambiguous whether that figure counts as a "value" the rule protects.

Repo-wide `MD060` table-column-style failures are pre-existing on `main` and out of scope for this pass (would require reformatting most tables in the docs tree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GqXXpFA8uBB9rKFcVkZRL9

---
_Generated by [Claude Code](https://claude.ai/code/session_01GqXXpFA8uBB9rKFcVkZRL9)_