### PR TITLE
docs: nightly tidiness — trim verbosity (2026-09-10)

### DIFF
--- a/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
+++ b/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
@@ -39,7 +39,7 @@ All circuit breakers mounted within 7" of battery (ABYC/NEC compliant). See [Cir
 
 ## START+ Forward Distribution Bus {#start-forward-bus}
 
-The radiator fan, iBooster, and TCU were relocated off the PMU onto START-direct power. All three sit forward (engine bay / transmission) while the START battery is in the rear wheel well, so — mirroring the [AUX forward-feed architecture][constant-bus] — a **single master-protected feed** runs forward to an engine-bay busbar that fans out to the three loads on short local feeds. This keeps the long rear-to-front run to one heavy cable instead of three, and places each load's breaker near its load.
+The radiator fan, iBooster, and TCU were relocated off the PMU onto START-direct power. All three sit forward (engine bay / transmission) while the START battery is in the rear wheel well, so a **single master-protected feed** runs forward to an engine-bay busbar that fans out to the three loads on short local feeds. See [Standards Exceptions][standards-exceptions] for why this bus bar is a deliberate departure from the "no bus bar between battery and loads" rule.
 
 **Busbar:** Blue Sea 2105 MaxiBus (250A), engine bay, insulated cover — recommended; confirm with {{ tbd(135) }}
 **Master feed:** 2 AWG, ~8 ft, 150A CB at battery post (<7")
@@ -53,7 +53,7 @@ The radiator fan, iBooster, and TCU were relocated off the PMU onto START-direct
 The master feed carries the combined load (~68A continuous, ~108A brief peak); voltage drop and breaker sizing are set on that single cable.[^fwd-bus-vdrop] The iBooster's separate ignition **enable** (~5A) is sourced from the [Ignition Signal bus][ignition-signal], not this bus. Fan speed is set by a dedicated fan controller ({{ tbd(134) }}) with its own coolant sensor, independent of the PMU and J1939.
 
 !!! info "Shared forward feed — intentional tradeoff"
-    The three loads share one master feed + busbar (a passive cable, breaker, and bus bar — no active electronics), versus three independent runs from the battery. This is the same tradeoff the [AUX side][constant-bus] accepts, and is far more robust than their former shared dependency on the PMU module. Each load keeps its own breaker. See [Standards Exceptions][standards-exceptions].
+    Same accepted tradeoff as the [AUX side][constant-bus]'s forward feed. See [Standards Exceptions][standards-exceptions] for the full rationale.
 
 [^fwd-bus-vdrop]: Master feed 2 AWG @ ~108A brief peak (~68A continuous), ~8 ft, 60°C-derated (×1.2) ≈ 1.3% — sized on the combined load. Load feeds are short from the engine-bay bus, so per-load drop is negligible: fan 4 AWG @ 53A, iBooster 8 AWG @ 40A brief, TCU 12 AWG @ 15A. Final master-feed length and breaker selective-coordination pending {{ tbd(136) }} and {{ tbd(135) }}.
 

--- a/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/index.md
+++ b/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/index.md
@@ -16,9 +16,7 @@ The AUX battery ([Dakota Lithium 135Ah LiFePO4][batteries]) in the passenger rea
 5. **Inline 100A CB** → 4 AWG short feed → [JL Audio MV800/8i Amp][audio] (mounted under rear seat)
 
 !!! info "Two-Stage Distribution Architecture"
-The AUX battery has **no local CONSTANT bus** — protected feeds run from inline CBs at the battery to two distribution points: the firewall CONSTANT bus (most loads) and SafetyHub (local). This places distribution near the loads, minimizes the cabin trunk to a single heavy cable, and keeps the rear wheel well compartment uncluttered.
-
-See [Firewall CONSTANT Bus][constant-bus] for downstream distribution, [SafetyHub][aux-safetyhub] for fused recovery circuits, and [Circuit Breakers][circuit-breakers] for full CB list.
+The AUX battery has **no local CONSTANT bus** — protected feeds run from inline CBs at the battery to two distribution points: the firewall CONSTANT bus (most loads) and SafetyHub (local). See [Firewall CONSTANT Bus][constant-bus] for the full rationale and downstream distribution, [SafetyHub][aux-safetyhub] for fused recovery circuits, and [Circuit Breakers][circuit-breakers] for full CB list.
 
 !!! info "Single Source of Truth"
 This page is the authoritative source for all AUX battery wire specs (gauge, distance, voltage drop). Component pages reference here. For battery specs see [Section 1.1][batteries]. For ground bus bars see [Section 1.5][grounding].

--- a/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
@@ -33,13 +33,7 @@ Usable capacity (80% DOD):  108Ah
 Time to 20% SOC:           ~144 minutes continuous (2.4 hours)
 ```
 
-The Dakota Lithium 135Ah combined with 50A BCDC makes extended air-up a non-issue. Load shedding provides additional margin and maintains optimal voltage for electronics.
-
-**Impact Without Load Shedding:**
-
-- Minor: AUX battery still has comfortable margin at 50A BCDC
-- START battery loads reduce BCDC charging efficiency slightly
-- Load shedding maximizes available margin for extended sessions
+**Impact Without Load Shedding:** Minor — START battery loads reduce BCDC charging efficiency slightly, but AUX battery still has comfortable margin at 50A BCDC.
 
 ## Solution Overview
 

--- a/docs/jeep_lj/01-power-systems/08-load-analysis/02-start-battery.md
+++ b/docs/jeep_lj/01-power-systems/08-load-analysis/02-start-battery.md
@@ -189,8 +189,6 @@ All circuits powered by START battery (alternator charging):
 
 **Worst Realistic Case:** 201A (offroad with hot engine) = **69A margin** (74% utilization). Folding in the now-itemized TCU (~15A continuous) raises this to ~216A (54A margin) — still within capacity.
 
-**Key Insight:** All realistic scenarios stay well within alternator capacity. The 270A alternator provides adequate margin for all operating conditions.
-
 ## Load Exclusions (Not Alternator Loads)
 
 The following high-current loads are **NOT** supplied by the alternator:

--- a/docs/jeep_lj/01-power-systems/08-load-analysis/03-aux-battery.md
+++ b/docs/jeep_lj/01-power-systems/08-load-analysis/03-aux-battery.md
@@ -249,7 +249,7 @@ All circuits powered by AUX battery (charged by BCDC at 50A max):
 | Winch Recovery    | 255A       | 50A  | -205A      | 50+ pulls       | Excellent |
 | Camp Mode         | 27A        | 0A   | -27A       | **4 hours**     | Good      |
 
-**Key Insight:** With corrected XL Sport specs (2.2A/pod vs 6A), full night offroad lighting (45A) is now fully covered by 50A BCDC charging. The Dakota Lithium 135Ah upgrade provides effectively unlimited runtime for all driving scenarios including full lighting. Camp mode provides 4+ hours without engine.
+**Key Insight:** The Dakota Lithium 135Ah upgrade provides effectively unlimited runtime for all driving scenarios including full lighting. Camp mode provides 4+ hours without engine.
 
 ## Related Documentation
 

--- a/docs/jeep_lj/05-control-interfaces/06-keyless-ignition.md
+++ b/docs/jeep_lj/05-control-interfaces/06-keyless-ignition.md
@@ -120,7 +120,7 @@ Earlier iterations of this design included a discrete engine-running lockout rel
 
 ## Diesel Runaway Note
 
-Normal engine shutdown (press brake + 2 sec button hold) drops PBS-I's PINK IGN output, cutting ECM power. However, ECM-only kill does not stop a runaway sustained by oil or hydrocarbon vapor. Independent mechanical protection is provided by the Mishimoto catch can (prevention) plus the AMOT 4261M air shutoff valve with dash-mounted manual cable (termination). See [Diesel Runaway Protection][runaway-protection].
+Normal engine shutdown (press brake + 2 sec button hold) drops PBS-I's PINK IGN output, cutting ECM power — but that alone can't stop a runaway sustained by oil or hydrocarbon vapor. See [Diesel Runaway Protection][runaway-protection] for the independent mechanical defense (catch can + AMOT air shutoff).
 
 ## Outstanding Items
 


### PR DESCRIPTION
Nightly tidiness pass per `docs/jeep_lj/CLAUDE.md` §1 (BE SUCCINCT). All edits are prose-only — no numbers, specs, gauges, part numbers, pin names, or reference-link targets changed. No TBD items, checkboxes, table rows, or frontmatter removed.

| File | Lines before → after | What was cut | Persona it failed |
| :--- | :--- | :--- | :--- |
| `01-power-systems/02-starter-battery-distribution/index.md` | 103 → 103 | Trimmed the START+ Forward Bus intro paragraph and the "Shared forward feed" info box — both restated the full rationale that already lives in `STANDARDS-EXCEPTIONS.md`'s "START+ Forward Distribution Bus" section; replaced with a one-line cross-link | Owner (same rationale duplicated across files) |
| `01-power-systems/03-aux-battery-distribution/index.md` | 66 → 64 | Cut the second sentence of the "Two-Stage Distribution Architecture" info box, which restated the fuller explanation already in `02-constant-bus.md`'s own "Two-Stage Distribution Architecture" box | Owner (same rationale duplicated across files) |
| `01-power-systems/04-pmu/05-pmu-arb-load-shedding.md` | 326 → 320 | The "extended air-up is a non-issue" conclusion was stated 3× in one file (Dual Battery Architecture section, after the Problem Statement code block, and again in the "Impact Without Load Shedding" bullets); collapsed to a single sentence, keeping only the one new fact (BCDC charging-efficiency caveat) | Owner/Troubleshooter (same conclusion repeated 3× in-file) |
| `01-power-systems/08-load-analysis/02-start-battery.md` | 243 → 241 | Cut a "Key Insight" line that purely restated the Summary table and the "Worst Realistic Case" line directly above it | Mechanic/Troubleshooter (prose restating an adjacent table) |
| `01-power-systems/08-load-analysis/03-aux-battery.md` | 269 → 269 | Cut the sentence in the closing "Key Insight" that restated Scenario 3's Assessment (same XL Sport/night-offroad-lighting conclusion, already in the Summary table above), keeping only the two facts not stated elsewhere | Mechanic/Troubleshooter (prose restating an adjacent table) |
| `05-control-interfaces/06-keyless-ignition.md` | 151 → 151 | Trimmed the "Diesel Runaway Note" section, which restated the full mechanical-defense rationale that's the entire subject of `02-engine-systems/11-runaway-protection.md`; reduced to one clause + cross-link | Owner (same rationale duplicated across files) |

**Verification:**
- `python3 -m mkdocs build --strict` — the only warnings are 3 pre-existing ones on `main` (unrelated files/links), confirmed identical before/after this branch's changes.
- `npx markdownlint-cli2 "docs/jeep_lj/**/*.md"` — pre-existing MD060 table-alignment failures exist repo-wide on `main` (1161 errors, mostly `tbd-tracker.md`, an auto-generated page); per-file error counts for all 6 edited files are byte-for-byte identical before and after this branch's edits, so no new lint errors were introduced.

## Left for human judgment

- `STANDARDS-EXCEPTIONS.md` has six near-identical "Review Guidance" closings (Winch, Starter, Grid Heater, Alternator, BCDC, SwitchPros/SafetyHub sections) that each restate their section's own Decision/rationale in prose, on top of the file's own "Summary of Intentional Design Decisions" and "Review Checklist" sections that already serve that purpose once. Left alone tonight — collapsing all six is a larger, multi-section edit that didn't fit this run's smaller/most-confident-wins scope.
- `01-power-systems/07-wire-routing/02-firewall-ingress.md` has a ~75-line "Pin Budget Audit (Historical)" section whose own header says it's superseded by the Pin Assignment/Wire Count Summary sections earlier in the same file. Left alone — cutting it is a bigger, single-file change than tonight's per-file budget, and I wasn't fully confident none of the historical numbers are still referenced elsewhere.
- The pre-existing repo-wide MD060 (table-column-style) lint failures and the 3 pre-existing strict-build warnings are unrelated to tonight's scope (prose-only trimming) and were left untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01HJt5oxYaRQ9JJ6pTcraWpd

---
_Generated by [Claude Code](https://claude.ai/code/session_01HJt5oxYaRQ9JJ6pTcraWpd)_