### PR TITLE
docs: nightly tidiness — trim verbosity (2026-09-11)

### DIFF
--- a/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/04-safetyhub.md
+++ b/docs/jeep_lj/01-power-systems/03-aux-battery-distribution/04-safetyhub.md
@@ -57,11 +57,7 @@ Wire and CB sized for full 150A SafetyHub capacity (current load 90A). Provides 
 
 **Slot Utilization:** 2 of 7 used (2 MIDI, 5 available — ATC-1 freed after winch trigger reallocated to BODY PDU CB43)
 
-**Total Load:** 90A maximum (ARB only — winch control reallocated to BODY PDU CB43)
-
-**Utilization:** 90A / 150A = 60%
-
-**Future Capacity:** 60A additional capacity available (150A max - 90A current = 60A headroom)
+**Total Load:** 90A / 150A = 60% (ARB only — winch control reallocated to BODY PDU CB43)
 
 !!! info "Winch Main Power"
 Winch motor power (409A peak) connects directly to AUX battery positive terminal with no external circuit breaker per WARN manufacturer specifications. See [STANDARDS-EXCEPTIONS.md][standards-exceptions] and [Recovery Systems][recovery-systems] for complete protection strategy.

--- a/docs/jeep_lj/02-engine-systems/05-horn.md
+++ b/docs/jeep_lj/02-engine-systems/05-horn.md
@@ -52,18 +52,6 @@ START battery CONSTANT → PMU → Out 18 → PIAA Horns (5.4A) → Chassis Grou
                       Horn Button → In 1 (trigger)  [column path undefined — {{ tbd(152) }}]
 ```
 
-**Power Flow:**
-
-1. START battery+ → 250A inline CB → PMU
-2. Horn button (steering wheel) → PMU In 1 (trigger signal)
-3. PMU Out 18 activated when In 1 closes
-4. PMU Out 18 → PIAA horns (5.4A) → chassis ground (engine bay)
-
-**Notes:**
-
-- PMU Out 18 switches directly (no external relay needed)
-- Works with ignition off (CONSTANT power for safety)
-
 ## Outstanding Items
 
 {{ tbds() }}

--- a/docs/jeep_lj/02-engine-systems/07-grid-heater.md
+++ b/docs/jeep_lj/02-engine-systems/07-grid-heater.md
@@ -41,25 +41,6 @@ tags:
 | Duty cycle        | 3–5 s during cold start (ECM-controlled)           |
 | Protection        | Integrated fusible link                            |
 
-## System Architecture
-
-1. **ECM Control (Direct):**
-   - ECM triggers grid heater relay directly via pins 46/21 (~0.5-1A)
-   - ECM manages timing, temperature thresholds, and duty cycle
-   - No PMU involvement - ECM knows engine temperature better than external controller
-
-2. **Grid Heater Relay (Cummins 5467024):**
-   - Coil Power: ECM pins 46/21 (~1A) - direct connection
-   - Main Power: Direct from START battery+ via fusible link (bypasses all bus bars and PMU)
-   - Main Ground: START battery- or NEGATIVE bus
-   - Output: 80A to grid heater element (design value - verify via resistance measurement during installation)
-   - Protection: Integrated fusible link
-
-3. **Grid Heater Element:**
-   - Location: Intake manifold
-   - Power: 80A from relay (design value)
-   - Duty Cycle: 3-5 seconds during cold start (ECM controlled)
-
 ## Wiring Summary
 
 **Two-Stage Design:** ECM pins 46/21 (1A) → relay coil → relay switches high current (40-80A) directly from battery to element.

--- a/docs/jeep_lj/02-engine-systems/08-fuel-system.md
+++ b/docs/jeep_lj/02-engine-systems/08-fuel-system.md
@@ -45,12 +45,6 @@ Return line → Fuel Tank
 
 The factory Jeep LJ in-tank electric fuel pump is **not used** in this configuration.
 
-## Installation Summary
-
-1. **Inlet:** Route fuel line from tank pickup → fuel filter/separator inlet
-2. **Filter to Pump:** Route from filter outlet → gear-driven pump inlet (back of block)
-3. **Return:** Route from engine return fitting → tank return
-
 ## Priming
 
 Use the manual hand pump on the fuel filter/water separator to prime the system before initial startup or after filter changes.

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/02-dashboard-cluster.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/02-dashboard-cluster.md
@@ -70,7 +70,7 @@ Drop-in replacement for factory TJ gauge cluster. Combines analog gauges with di
 See [HDX Control Module wiring table][hdx-control] for complete signal routing.
 
 !!! warning "Speedometer Required for Legal Operation"
-Speedometer is legally required for on-road vehicle operation. GPS-50-2 module provides speed data - ensure GPS antenna has clear sky view for reliable operation.
+    Speedometer is legally required for on-road operation. See [GPS-50-2][bim-gps] for antenna sky-view requirements.
 
 ## Outstanding Items
 

--- a/docs/jeep_lj/02-engine-systems/09-gauge-cluster/03-bim-j1939.md
+++ b/docs/jeep_lj/02-engine-systems/09-gauge-cluster/03-bim-j1939.md
@@ -73,9 +73,6 @@ Interfaces Cummins R2.8 ECM J1939 CAN bus data with HDX instrument system. Provi
 - Boost/MAP
 - Air/fuel ratio
 
-!!! info "ECM Data Availability"
-Specific J1939 parameters vary by ECM configuration and vehicle application. Cummins R2.8 ECM should provide tachometer, coolant temp, oil pressure, and check engine light at minimum. Additional parameters depend on ECM programming and connected sensors.
-
 ## Wiring
 
 | Connection   | Source                            | Destination    | Wire Gauge  | Notes                            |


### PR DESCRIPTION
Nightly tidiness pass per `docs/jeep_lj/CLAUDE.md` (BE SUCCINCT). Cut prose that only restated an adjacent table/diagram, and one case of the same design rationale duplicated across two pages. No numbers, identifiers, TBD items, table rows, or reference-link definitions were touched.

| File | Lines before → after | What was cut | Persona it failed |
| :--- | :--- | :--- | :--- |
| `02-engine-systems/07-grid-heater.md` | 115 → 96 | "System Architecture" numbered list that restated the Specifications table, the Wiring Summary diagram, and the top-matter power source — no new facts | Mechanic (already has table + diagram) |
| `02-engine-systems/05-horn.md` | 82 → 70 | "Power Flow" numbered list + "Notes" bullets, both re-describing the ASCII wiring diagram and "PMU Configuration" bullets just above them | Mechanic/Troubleshooter (diagram + config bullets already cover it) |
| `02-engine-systems/08-fuel-system.md` | 66 → 60 | "Installation Summary" numbered list that re-walked the "Fuel Flow Path" diagram step for step | Mechanic (diagram already shows the path) |
| `02-engine-systems/09-gauge-cluster/03-bim-j1939.md` | 136 → 133 | An "ECM Data Availability" info box restating the "Standard Parameters" / "Cummins R2.8 Specific" bullet lists directly above it (also fixed malformed admonition indentation while removing it) | Mechanic/Owner (bullets above already state this) |
| `02-engine-systems/09-gauge-cluster/02-dashboard-cluster.md` | 98 → 98 | Trimmed a warning admonition that re-explained GPS antenna sky-view requirements already covered in `04-bim-gps.md`; now cross-links to that page instead (kept the legal-requirement note) | Owner (same rationale was duplicated across two files) |
| `01-power-systems/03-aux-battery-distribution/04-safetyhub.md` | 90 → 86 | Collapsed four one-line stats (Slot Utilization / Total Load / Utilization / Future Capacity) that all just did arithmetic on the same 90A/150A figure, one of which also duplicated the "60A headroom" fact already stated in the admonition above | Mechanic/Owner (same number stated 3× different ways) |

## Left for human judgment

- **`02-engine-systems/09-gauge-cluster/02-dashboard-cluster.md` vs `01-hdx-control.md`:** the dashboard-cluster "Lamps & Indicators" table lists a "Transfer Case Switch → 4WD/4LO indicators" row, but `01-hdx-control.md`'s wiring table explicitly says the 4x4/EX input is **not used** ("NV241 Command-Trac is cable-shifted with no electrical position switch; 4WD/4LO indicator omitted"). This looks like a real factual inconsistency, not a verbosity issue — left untouched since fixing it is outside this pass's scope (prose/structure only, no spec judgment calls).
- **`05-control-interfaces/05-dashboard-controls.md`:** the winch dash-switch section states "dash push switch + handheld remote work simultaneously in parallel" twice (once under "How It Works", again under "Wiring" as "Parallel Remote"). Minor and low-confidence enough on wording/placement that I left it for a human pass rather than risk cutting the wrong copy.
- Did not touch any of the brake-booster, starter, HVAC, keyless-ignition, or offroad-lighting pages — read through several of them and found them already dense with sourced, non-redundant rationale (each sentence carries a footnote or a distinct fact); cutting further risked losing real content rather than trimming filler.

## Verification

- `python3 -m mkdocs build --strict`: fails with the same 3 pre-existing warnings present on `main` before this change (two broken `blob/main` links in files this PR doesn't touch, one missing anchor in `command-touch-ct4.md`) — confirmed identical before/after via `git stash`.
- `npx markdownlint-cli2 "docs/jeep_lj/**/*.md"`: repo-wide this already reports 1000+ pre-existing issues (mostly `MD060` table-pipe-alignment) with no CI job enforcing it; restricted to the 6 files this PR touches, the issue count is identical (44 issues in 4 files) before and after — this PR introduces zero new lint issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0135WNfQM5RFDWZCo4eVzszd

---
_Generated by [Claude Code](https://claude.ai/code/session_0135WNfQM5RFDWZCo4eVzszd)_