### PR TITLE
docs: nightly tidiness — trim verbosity (2026-09-12)

### DIFF
--- a/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
+++ b/docs/jeep_lj/01-power-systems/02-starter-battery-distribution/index.md
@@ -53,7 +53,7 @@ The radiator fan, iBooster, and TCU were relocated off the PMU onto START-direct
 The master feed carries the combined load (~68A continuous, ~108A brief peak); voltage drop and breaker sizing are set on that single cable.[^fwd-bus-vdrop] The iBooster's separate ignition **enable** (~5A) is sourced from the [Ignition Signal bus][ignition-signal], not this bus. Fan speed is set by a dedicated fan controller ({{ tbd(134) }}) with its own coolant sensor, independent of the PMU and J1939.
 
 !!! info "Shared forward feed — intentional tradeoff"
-    The three loads share one master feed + busbar (a passive cable, breaker, and bus bar — no active electronics), versus three independent runs from the battery. This is the same tradeoff the [AUX side][constant-bus] accepts, and is far more robust than their former shared dependency on the PMU module. Each load keeps its own breaker. See [Standards Exceptions][standards-exceptions].
+    The three loads share one master feed + busbar (a passive cable, breaker, and bus bar — no active electronics), versus three independent runs from the battery. This is the same tradeoff the [AUX side][constant-bus] accepts, replacing their former shared dependency on the PMU module with passive components only. Each load keeps its own breaker. See [Standards Exceptions][standards-exceptions].
 
 [^fwd-bus-vdrop]: Master feed 2 AWG @ ~108A brief peak (~68A continuous), ~8 ft, 60°C-derated (×1.2) ≈ 1.3% — sized on the combined load. Load feeds are short from the engine-bay bus, so per-load drop is negligible: fan 4 AWG @ 53A, iBooster 8 AWG @ 40A brief, TCU 12 AWG @ 15A. Final master-feed length and breaker selective-coordination pending {{ tbd(136) }} and {{ tbd(135) }}.
 

--- a/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
+++ b/docs/jeep_lj/01-power-systems/04-pmu/05-pmu-arb-load-shedding.md
@@ -15,7 +15,7 @@ Automatic load management during ARB compressor operation to preserve AUX batter
 - **BCDC Charging (50A max):** Replenishes AUX battery from alternator
 - **Net AUX battery drain:** 90A - 50A = 40A during compressor operation
 
-The alternator is NOT overloaded during ARB operation. The 50A BCDC significantly reduces net discharge rate, making extended air-up practical. Load shedding provides additional margin and maintains optimal voltage.
+The alternator is NOT overloaded during ARB operation. The 50A BCDC significantly reduces net discharge rate, making extended air-up practical.
 
 ## Problem Statement
 
@@ -33,13 +33,7 @@ Usable capacity (80% DOD):  108Ah
 Time to 20% SOC:           ~144 minutes continuous (2.4 hours)
 ```
 
-The Dakota Lithium 135Ah combined with 50A BCDC makes extended air-up a non-issue. Load shedding provides additional margin and maintains optimal voltage for electronics.
-
-**Impact Without Load Shedding:**
-
-- Minor: AUX battery still has comfortable margin at 50A BCDC
-- START battery loads reduce BCDC charging efficiency slightly
-- Load shedding maximizes available margin for extended sessions
+The Dakota Lithium 135Ah combined with 50A BCDC makes extended air-up a non-issue. Shedding still helps: it frees the BCDC to charge at full rate even when START battery voltage sags (see "Primary benefit" below).
 
 ## Solution Overview
 

--- a/docs/jeep_lj/01-power-systems/08-load-analysis/index.md
+++ b/docs/jeep_lj/01-power-systems/08-load-analysis/index.md
@@ -46,17 +46,7 @@ PMU max: 253A + SwitchPros max: 127A + ARB: 90A + Winch: 400A = 870A
 Alternator: 270A = CRITICAL UNDERSIZING ❌
 ```
 
-**Example - CORRECT:**
-
-```text
-START Battery Scenario (Offroad):
-PMU typical: 115A + Radiator fan: 53A + BCDC: 50A = 218A
-Alternator: 270A = 52A margin
-
-AUX Battery Scenario (Night Offroad):
-SwitchPros: 70A, BCDC charging: 50A
-Net drain: 20A, Time to 50% SOC: 102 minutes
-```
+The correct approach pairs each load with the battery that actually supplies it — see the worked scenarios in [START Battery Load Analysis][start-load] and [AUX Battery Load Analysis][aux-load].
 
 ### Load Categories
 

--- a/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
+++ b/docs/jeep_lj/01-power-systems/STANDARDS-EXCEPTIONS.md
@@ -123,16 +123,7 @@ This document tracks intentional deviations from general electrical standards wh
 
 ### Winch Review Guidance
 
-**This is NOT an oversight or safety issue.**
-
-It is intentional adherence to:
-
-1. Manufacturer specifications (WARN)
-2. Automotive standards (SAE J1128)
-3. Industry standard practice (factory winch installations)
-4. Engineering analysis (load, wire sizing, fault scenarios)
-
-**Do NOT flag as requiring correction in future reviews.**
+**This is NOT an oversight or safety issue** — it is intentional adherence to the WARN manufacturer spec, SAE J1128, and the fault analysis above. **Do NOT flag as requiring correction.**
 
 **Documentation References:**
 
@@ -226,32 +217,11 @@ It is intentional adherence to:
 - Manual battery disconnect available
 - **Status:** Acceptable per automotive practice, enhancement recommended
 
-### Starter Standards Comparison
-
-**Automotive (SAE J1128):**
-
-- Cable sizing acceptable for brief peak loads ✓
-- No CB required for starter circuits in factory vehicles ✓
-- Timer relay or slow-blow CB optional enhancement ✓
-
-**Marine (ABYC E-11):**
-
-- Would require circuit breaker or fuse
-- **This is NOT a marine application** - automotive standards apply
-
 ### Starter Review Guidance
 
-**Current design (no CB) is acceptable per automotive standards.**
+Cable sizing (no external CB) is acceptable per SAE J1128 automotive practice, not the marine ABYC E-11 rule. **Do NOT flag as a critical safety issue.**
 
-**Enhancement (timer relay) is recommended but not critical:**
-
-- Adds protection for stuck solenoid scenario
-- Low cost, simple implementation
-- Common in heavy-duty truck applications
-
-**Do NOT flag as critical safety issue** - cable sizing provides adequate protection for normal operation per SAE J1128.
-
-**Consider implementing timer relay as build enhancement** - provides additional fault protection beyond baseline automotive practice.
+A timer relay for the stuck-solenoid scenario (Option 1 above) remains a recommended, non-critical enhancement.
 
 **Documentation References:**
 
@@ -358,11 +328,7 @@ Grid heater brief, high-current load characteristics make circuit breaker unnece
 
 ### Alternator Review Guidance
 
-**This is standard automotive practice.**
-
-Alternators NEVER use circuit breakers on output circuits in factory or aftermarket applications.
-
-**Do NOT flag as missing protection.**
+**This is standard automotive practice** — no OEM or aftermarket alternator uses an output circuit breaker. **Do NOT flag as missing protection.**
 
 **Documentation References:**
 


### PR DESCRIPTION
Nightly tidiness pass per `docs/jeep_lj/CLAUDE.md`'s "BE SUCCINCT" rule. Prose and structure only — no specs, numbers, part numbers, TBDs, checkboxes, table rows, or links were touched.

| File | Lines before → after | What was cut | Persona it failed |
| :--- | :--- | :--- | :--- |
| `01-power-systems/STANDARDS-EXCEPTIONS.md` | 593 → ~560 | The Winch, Starter, and Alternator "Review Guidance" sub-sections each re-stated the same "this is intentional, don't flag it" conclusion 3-4 different ways (a "Standards Comparison" list, a numbered restatement, then a "Do NOT flag" line). Condensed each to one or two sentences, keeping the "Do NOT flag" instruction and the citation to the manufacturer spec / SAE J1128 / analysis above. | Owner/Designer — same conclusion legalistically repeated with no new information each time |
| `01-power-systems/08-load-analysis/index.md` | 126 → ~114 | Replaced a "CORRECT" worked example (specific START/AUX scenario numbers) with a cross-link to the two detailed scenario pages. That embedded example had drifted from the authoritative numbers in `02-start-battery.md`/`03-aux-battery.md` (see below) — removing the copy removes the inconsistency along with the duplication. | Owner/Designer — same example restated, and the copy had gone stale relative to the source pages |
| `01-power-systems/04-pmu/05-pmu-arb-load-shedding.md` | 327 → ~319 | Cut a filler sentence ("Load shedding provides additional margin and maintains optimal voltage") that appeared twice verbatim/near-verbatim, and an "Impact Without Load Shedding" bullet list that vaguely pre-stated a point the file already makes precisely later ("Primary benefit" section). | Owner/Designer — restatement with no new numbers, pre-empting a later, more specific explanation |
| `01-power-systems/02-starter-battery-distribution/index.md` | 235 → 235 | Dropped the marketing adjective "far more robust than" in favor of stating the actual tradeoff (passive components replacing the shared PMU dependency). | Mechanic/Installer & Owner/Designer — adjective carries no technical information |

## Left for human judgment

- **Data discrepancy, not a tidiness issue:** `08-load-analysis/index.md`'s "Summary Results" AUX battery table (Night Highway 38A/+12A, Night Offroad 70A/-20A/102min, Air Up Extended 34min, Winch Recovery 265A/-215A) does **not** match the current authoritative numbers in `03-aux-battery.md`'s own Summary table (Night Highway 35A/+15A, Night Offroad 45A/+5A, Air Up Extended 108min, Winch Recovery 255A/-205A) — the AUX page appears to have been updated (per its own note about "corrected XL Sport specs") without the index.md copy being refreshed. I did not touch any table rows or numbers per the hard guardrails, but this is worth a look since it's presenting two different numbers for the same scenarios in two places readers might land on.
- The `01-power-systems/index.md` "Power Generation & Storage" summary and `01-power-generation/index.md`'s own "System Overview" paragraph cover very similar ground (battery models, alternator, BCDC) in different phrasing. This reads more like an intentional landing-page-then-detail pattern than pure duplication, so I left it alone rather than guess.
- `STANDARDS-EXCEPTIONS.md` still has some repetition beyond what I touched (e.g. the Winch section's "Factory Vehicle Precedent" and "Fault Scenarios Covered" sub-sections each restate the "no CB needed" conclusion once more, and the file-level "Summary of Intentional Design Decisions" + "Review Checklist" sections restate every component's decision a third time). I judged those as carrying genuine distinct content (specific failure modes, specific vehicle precedents) rather than pure filler, and the checklist is checkbox-formatted so I left it untouched per the guardrail against deleting checkbox items — a human may want to condense further.

## Verification

- `python3 -m mkdocs build --strict` — passes with only 3 pre-existing warnings (broken `blob/main` links in `02-constant-bus.md`/`05-dashboard-controls.md`, missing anchor in `03-command-touch-ct4.md`) that are present on `main` too, unrelated to this diff.
- `npx markdownlint-cli2 "docs/jeep_lj/**/*.md"` — issue count on the 4 touched files is unchanged before/after this diff (23 issues, all pre-existing `MD060`/`MD024` table-style and duplicate-heading debt elsewhere in those files, none introduced by these edits).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VYiQxJ3MxANyTrGVbK2Paj

---
_Generated by [Claude Code](https://claude.ai/code/session_01VYiQxJ3MxANyTrGVbK2Paj)_